### PR TITLE
chore(deps): update deadline-cloud and openjd-adaptor-runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
-  "deadline == 0.40.*",
-  "openjd-adaptor-runtime == 0.5.*"
+  "deadline == 0.45.*",
+  "openjd-adaptor-runtime == 0.6.*"
 ]
 
 [project.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
update deadline-cloud and openjd-adaptor-runtime deps

### What was the solution? (How)
update deadline-cloud to 0.45.* and openjd-adaptor-runtime to 0.6.*
### What is the impact of this change?

### How was this change tested?
`hatch run test`

### Was this change documented?
no

### Is this a breaking change?
no
