### PR TITLE
ci: add changelog template

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -1,0 +1,25 @@
+{% for version, release in context.history.released.items() %}
+## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+
+    {% if "breaking" in release["elements"] %}
+### BREAKING CHANGES
+        {% for commit in release["elements"]["breaking"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+    {% if "feature" in release["elements"] %}
+### Features
+        {% for commit in release["elements"]["feature"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+    {% if "fix" in release["elements"] %}
+### Bug Fixes
+        {% for commit in release["elements"]["fix"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+{% endfor %}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Changelog template is missing

### What was the solution? (How)
Add the template

### What is the impact of this change?
Fix changelog for CI

### How was this change tested?
`hatch run release:bump --patch`

### Was this change documented?
No

### Is this a breaking change?
No
