### PR TITLE
ci: fix syntax error in release bump

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
 
   Bump:
-    needs: Unit Tests
+    needs: UnitTests
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Syntax error in the bump workflow

### What was the solution? (How)
Change `needs: Unit Tests` to `needs: UntiTests`

### What is the impact of this change?
Fix version  bump workflow

### How was this change tested?
```
hatch run lint
hatch run test
```

### Was this change documented?
No

### Is this a breaking change?
No