### PR TITLE
fix: move ae_adaptor and ae_submitter into deadline namespace

### DIFF
--- a/jsxbundler.py
+++ b/jsxbundler.py
@@ -28,7 +28,7 @@ def cli_entry():
         default="dist/jsxbundle/DeadlineCloudSubmitter.jsx",
         help="""Destination file. Defaults to 
         "dist/jsxbundle/DeadlineCloudSubmitter.jsx". Alternatively you could 
-        use "C:\Program Files\Adobe\Adobe After Effects 2023\Support Files\Scripts\DeadlineCloudSubmitter.jsx" 
+        use "C:/Program Files/Adobe/Adobe After Effects 2023/Support Files/Scripts/DeadlineCloudSubmitter.jsx"
         or equivalent.""",
     )
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,10 @@ destinations = [
 ]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/deadline/ae_adaptor/*", "hatch_custom_hook.py"]
+include = ["src/deadline/*", "hatch_custom_hook.py"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/deadline/ae_adaptor"]
+packages = ["src/deadline"]
 
 # --- MYPY ---
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. When running `pip install deadline-cloud-for-after-effects`, it would install `ae_adaptor` into the site-packages, instead of in the deadline namespace package.
2. When running the jsxbundler.py on Windows, it would error would with a "\P invalid syntax" on the help text of argparse 

### What was the solution? (How)

1. include the deadline namespace for targets, this then also includes the ae_submitter in the pip install, even
2. just swap the slash in the help text

### What is the impact of this change?

Users can get further in this alpha intergration without experiencing roadblocks immediately.

### How was this change tested?

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

I then pip-installed the local build and confirmed that it put the submitter and adaptor within the deadline namespace.

### Was this change documented?

N/A

### Is this a breaking change?

Fixing change :')

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
