### PR TITLE
feat: Include ipc.jsx file in PyPi Wheel

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade hatch
+      - name: Run JSX Bundle for clientipc
+        run: |
+          python jsxbundler.py --source src/aeipc/ipc.jsx --destination src/deadline/ae_adaptor/clientipc/ipc.jsx
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ include = ["src/deadline/*", "hatch_custom_hook.py"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/deadline"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/deadline/ae_adaptor/clientipc" = "src/deadline/ae_adaptor/clientipc"
+
 # --- MYPY ---
 
 [tool.mypy]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When installing the deadline cloud for after effects adaptor from PyPi, there was no included `ipc.jsx` file.
This caused renders to not work.

### What was the solution? (How)
The repository included instructions on building the ipc.jsx file. This PR includes the ipc.jsx in the `hatch build` command and updates the github `release_publish.yml` action to jsxbundle the clientipc before running hatch build.
### What is the impact of this change?
The PyPi wheel files will now include the ipc.jsx file
### How was this change tested?
Tested locally
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A
```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
N/A
### Is this a breaking change?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
