### PR TITLE
feat: Allow specifying environment variable to override AfterEffects executable path

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,3 +81,8 @@ Example `launch.json` configuration for attached debugger (for AE 2023):
     ]
 }
 ```
+
+
+_______
+
+NOTE: The aftereffects-openjd binary expects that the AfterEffects executable is named `afterfx` and is set on the PATH. If this is not the case, you can set the `AFTEREFFECTS_ADAPTOR_AEFX_EXECUTABLE` environment variable to the path to the After Effects executable.

--- a/src/deadline/ae_adaptor/AEClient/ae_client.py
+++ b/src/deadline/ae_adaptor/AEClient/ae_client.py
@@ -26,7 +26,6 @@ except (ImportError, ModuleNotFoundError):
 
 
 logger = logging.getLogger(__name__)
-ae_exe = "afterfx"
 
 
 class AEClient(ClientInterface):
@@ -42,6 +41,9 @@ class AEClient(ClientInterface):
             # Escape backslashes in client path
             client_path_abs = client_path_abs.replace("\\", "\\\\")
         startup_script_inline = f"var x = new File('{client_path_abs}') ; x.open(); eval(x.read()); app.exitAfterLaunchAndEval = false;"
+
+        ae_exe = os.environ.get("AFTEREFFECTS_ADAPTOR_AEFX_EXECUTABLE", "afterfx")
+
         # flag -noui for no ui doesn't close properly when running in monitor
         cmd_args = [ae_exe, "-s", startup_script_inline]
         print(f"Starting AfterFX: {cmd_args}")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are some scenarios where it is easier to set an environment variable to point to AfterEffects than it is to modify the path.
### What was the solution? (How)
This solution implements an environment variable `AFTEREFFECTS_ADAPTOR_AEFX_EXECUTABLE` that allows overriding the name of the executable to run
### What is the impact of this change?
Additional functionality without removing the existing functionality. Users can now override the `afterfx` executable path by setting the `AFTEREFFECTS_ADAPTOR_AEFX_EXECUTABLE` environment variable
### How was this change tested?
Locally
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
N/A
```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Documented in `DEVELOPMENT.md`
### Is this a breaking change?
No, it is a feature change
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
