### PR TITLE
feat: Include custom Adobe Font files in the submitter job

### DIFF
--- a/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
+++ b/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
@@ -1,0 +1,119 @@
+import os
+import shutil
+import ctypes
+from ctypes import wintypes
+
+try:
+    import winreg
+except ImportError:
+    import _winreg as winreg
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)
+
+FONTS_REG_PATH = r"Software\Microsoft\Windows NT\CurrentVersion\Fonts"
+
+HWND_BROADCAST = 0xFFFF
+SMTO_ABORTIFHUNG = 0x0002
+WM_FONTCHANGE = 0x001D
+GFRI_DESCRIPTION = 1
+GFRI_ISTRUETYPE = 3
+
+INSTALL_SCOPE_USER = "USER"
+INSTALL_SCOPE_SYSTEM = "SYSTEM"
+
+FONT_LOCATION_SYSTEM = os.path.join(os.environ.get("SystemRoot"), "Fonts")
+FONT_LOCATION_USER = os.path.join(os.environ.get("LocalAppData"), "Microsoft", "Windows", "Fonts")
+
+
+def install_font(src_path, scope=INSTALL_SCOPE_USER):
+    try:
+        # copy the font to the Windows Fonts folder
+        if scope == INSTALL_SCOPE_SYSTEM:
+            dst_path = os.path.join(FONT_LOCATION_SYSTEM, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_LOCAL_MACHINE
+        else:
+            dst_path = os.path.join(FONT_LOCATION_USER, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_CURRENT_USER
+
+        shutil.copy(src_path, dst_path)
+        # load the font in the current session
+        if not gdi32.AddFontResourceW(dst_path):
+            os.remove(dst_path)
+            raise WindowsError('AddFontResource failed to load "%s"' % src_path)
+        # notify running programs
+        user32.SendMessageTimeoutW(
+            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
+        )
+        # store the fontname/filename in the registry
+        filename = os.path.basename(dst_path)
+        fontname = os.path.splitext(filename)[0]
+        # try to get the font's real name
+        cb = wintypes.DWORD()
+        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
+            buf = (ctypes.c_wchar * cb.value)()
+            if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
+                fontname = buf.value
+        is_truetype = wintypes.BOOL()
+        cb.value = ctypes.sizeof(is_truetype)
+        gdi32.GetFontResourceInfoW(
+            filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE
+        )
+        if is_truetype:
+            fontname += " (TrueType)"
+        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)
+    except Exception:
+        import traceback
+
+        return False, traceback.format_exc()
+    return True, ""
+
+
+def uninstall_font(src_path, scope=INSTALL_SCOPE_USER):
+    try:
+        # copy the font to the Windows Fonts folder
+        if scope == INSTALL_SCOPE_SYSTEM:
+            dst_path = os.path.join(FONT_LOCATION_SYSTEM, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_LOCAL_MACHINE
+        else:
+            dst_path = os.path.join(FONT_LOCATION_USER, os.path.basename(src_path))
+            registry_scope = winreg.HKEY_CURRENT_USER
+
+        # remove the fontname/filename from the registry
+        filename = os.path.basename(dst_path)
+        fontname = os.path.splitext(filename)[0]
+        # try to get the font's real name
+        cb = wintypes.DWORD()
+        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
+            buf = (ctypes.c_wchar * cb.value)()
+            if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
+                fontname = buf.value
+        is_truetype = wintypes.BOOL()
+        cb.value = ctypes.sizeof(is_truetype)
+        gdi32.GetFontResourceInfoW(
+            filename, ctypes.byref(cb), ctypes.byref(is_truetype), GFRI_ISTRUETYPE
+        )
+        if is_truetype:
+            fontname += " (TrueType)"
+
+        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, fontname)
+
+        # unload the font in the current session
+        if not gdi32.RemoveFontResourceW(dst_path):
+            os.remove(dst_path)
+            raise WindowsError('RemoveFontResourceW failed to load "%s"' % src_path)
+
+        if os.path.exists(dst_path):
+            os.remove(dst_path)
+
+        # notify running programs
+        user32.SendMessageTimeoutW(
+            HWND_BROADCAST, WM_FONTCHANGE, 0, 0, SMTO_ABORTIFHUNG, 1000, None
+        )
+    except Exception:
+        import traceback
+
+        return False, traceback.format_exc()
+    return True, ""

--- a/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
+++ b/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
@@ -2,11 +2,14 @@ import os
 import shutil
 import ctypes
 from ctypes import wintypes
+import logging
 
 try:
     import winreg
 except ImportError:
     import _winreg as winreg
+
+_logger = logging.getLogger(__name__)
 
 user32 = ctypes.WinDLL("user32", use_last_error=True)
 gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)

--- a/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
+++ b/src/deadline/ae_adaptor/AEAdaptor/font_installer.py
@@ -25,6 +25,10 @@ INSTALL_SCOPE_SYSTEM = "SYSTEM"
 FONT_LOCATION_SYSTEM = os.path.join(os.environ.get("SystemRoot"), "Fonts")
 FONT_LOCATION_USER = os.path.join(os.environ.get("LocalAppData"), "Microsoft", "Windows", "Fonts")
 
+# Check if the Fonts folder exists, create it if it doesn't
+if not os.path.exists(FONT_LOCATION_USER):
+    _logger.info("Creating User Fonts folder: %s" % FONT_LOCATION_USER)
+    os.makedirs(FONT_LOCATION_USER)
 
 def install_font(src_path, scope=INSTALL_SCOPE_USER):
     try:

--- a/src/deadline/ae_submitter/data/InitData.jsx
+++ b/src/deadline/ae_submitter/data/InitData.jsx
@@ -87,7 +87,79 @@ function __generateInitData()
                 }
             }
         }
+        var fontReferences = generateFontReferences();
+        logger.debug("Get Fonts: " + key, scriptFileInitDataName);
+        for (var i = 0; i < fontReferences.length; i++) {
+            detectedItemsList.push(fontReferences[i]);
+        }
         dcProperties.jobAttachments.autoDetectedInputFiles.set(detectedItemsList);
+    }
+
+    function _generateFontReferences() {
+        var fontLocations = [];
+        var usedList = app.project.usedFonts;
+        for (var i = 0; i < usedList.length; i++) {
+            var font = usedList[i].font;
+            var fontFamilyName = font.familyName;
+            var familyStyle = font.styleName;
+            var fontName = fontFamilyName + " " + familyStyle + ".otf";
+            fontLocations.push([fontName, fontLocation]);
+        }
+        return fontLocations
+    }
+
+    function _oldGenerateFontReferences() {
+        var fontLocations = [];
+        var items = app.project.items;
+        for (var i = items.length; i >= 1; i--) {
+            var myItem = app.project.item(i);
+            if (myItem instanceof CompItem) {
+                for (var j = myItem.layers.length; j >= 1; j--) {
+                    var myLayer = myItem.layers[j];
+                    if (myLayer instanceof TextLayer){
+                        var textDocument = myLayer.text.sourceText.value;
+                        var fontLocation = textDocument.fontLocation;
+                        var fontFamilyName = textDocument.fontFamily;
+                        var familyStyle = textDocument.fontStyle;
+                        var fontName = fontFamilyName + " " + familyStyle + ".otf";
+                        fontLocations.push([fontName, fontLocation]);
+                    }
+                }
+            }
+        }
+        return fontLocations
+    }
+
+    function generateFontReferences() {
+        var rawFontPaths = [];
+        if (parseInt(app.version[0] + app.version[1]) >= 24) {
+            rawFontPaths = _generateFontReferences();
+        } else {
+            rawFontPaths = _oldGenerateFontReferences();
+        }
+        var _tempFilePath = dcUtil.normPath(Folder.temp.fsName + "/" + "tempFonts");
+        var formattedFontPaths = [];
+        var tempFontPath = new Folder(_tempFilePath);
+        if (!tempFontPath.exists) {
+            tempFontPath.create();
+        }
+
+
+        for (var i = 0; i < rawFontPaths.length; i++) {
+            var fontName = rawFontPaths[i][0];
+            var fontLocation = rawFontPaths[i][1];
+            if (fontLocation.indexOf("C:\\Windows\\Fonts") !== -1) {
+                // We are filtering out fonts installed in C:\Windows\Fonts potentially here.
+                //   I would make the argument that if a font is installed to the system (not an Adobe Font), that
+                //   it should be managed on a system level not through the submitter.
+                continue
+            }
+            var fontFile = File(fontLocation);
+            var _filePath = dcUtil.normPath(_tempFilePath + "/" + fontName);
+            fontFile.copy(_filePath);
+            formattedFontPaths.push(_filePath);
+        }
+        return formattedFontPaths;
     }
 
     function initAutoDetectOutputDirectories()

--- a/src/deadline/ae_submitter/data/InitData.jsx
+++ b/src/deadline/ae_submitter/data/InitData.jsx
@@ -103,6 +103,7 @@ function __generateInitData()
             var fontFamilyName = font.familyName;
             var familyStyle = font.styleName;
             var fontName = fontFamilyName + " " + familyStyle + ".otf";
+            var fontLocation = font.location;
             fontLocations.push([fontName, fontLocation]);
         }
         return fontLocations


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When a user uses Adobe Fonts, those custom fonts get installed in their appdata directory and are not included in the job.
The resulting render does not have the correct fonts.
### What was the solution? (How)
We query the scene and collect all of the custom adobe fonts. These fonts are uploaded as job attachments and the adaptor will install the fonts for the currently running user during the launch of After Effects.
When After Effects is closed, the fonts are uninstalled.
### What is the impact of this change?
After Effects renders that use custom Adobe Fonts render correctly
### How was this change tested?
I have tested it running a modified version of the standard AfterEffects submitter template with a local session-runner.
These files can be found here: https://gist.github.com/Ahuge/ab8da83c16e5ceadb8683bbde4d9155a
The main change in the template was goofing around with my VirtualEnv as a JobEnvironment

I will deploy this to my own Deadline farm and confirm things there as well.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Not yet

### Is this a breaking change?
I suppose?
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
