### PR TITLE
fix logic around setting render parameters

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,5 +5,5 @@ mypy == 1.*
 pytest == 8.*
 pytest-cov == 5.*
 pytest-xdist == 3.*
-ruff == 0.4.*
+ruff == 0.5.*
 twine == 5.*

--- a/src/aeipc/ipc.jsx
+++ b/src/aeipc/ipc.jsx
@@ -274,14 +274,15 @@ function _ipcModule() {
         {
             if(compName == app.project.renderQueue.item(j).comp.name)
             {
-                var RQI_to_copy = app.project.renderQueue.item(j);
-                RQI_to_copy.render = false;
+                RQI = app.project.renderQueue.item(j);
+                RQI.render = true;
             }
             else {
                 app.project.renderQueue.item(j).render = false;
             }
         }
-        var RQI = RQI_to_copy.duplicate();
+        // var RQI = RQI_to_copy.duplicate();
+        // var RQI = RQI_to_copy;
         // var renderQueueItem = app.project.renderQueue.item(1).outputModule(1).getSettings(); // Assuming you want information for the first render queue item
         // alert(renderQueueItem["Format"]);
         output_file_settings = {
@@ -294,12 +295,17 @@ function _ipcModule() {
         RQI.outputModule(1).setSettings(output_file_settings);
 
         // Set start frame and end frame
-        var frameRate = comp.frameRate;
-        var start = frame / frameRate;
-        var end = (frame + 1) / frameRate; 
-        var duration = end - start
+        // var frameRate = comp.frameRate;
+        // var start = frame / frameRate;
+        // var end = (frame + 1) / frameRate; 
+        // var duration = end - start
 
-        setWorkArea(RQI.comp, start, duration, conn);
+        //Have to set the start and duration according to the last entry in this forum post: https://community.adobe.com/t5/after-effects-discussions/workareastart-and-workareaduration-behaviour-in-extendscript/m-p/13093413
+        var start = currentFormatToTime("0:00:" + frame, comp.frameRate);
+        var duration = currentFormatToTime("0:00:01", comp.frameRate, true);//assumes a duration of one frame 
+
+        RQI.timeSpanStart = start
+        RQI.timeSpanDuration = duration
         app.project.renderQueue.render();
         RQI.remove();
     

--- a/src/aeipc/ipc.jsx
+++ b/src/aeipc/ipc.jsx
@@ -192,7 +192,7 @@ function _ipcModule() {
                     // Check if the item is a composition
                     if (currentItem instanceof CompItem) 
                     {
-                        if(currentItem.name.indexOf(compName) !== -1)
+                        if(currentItem.name == compName)
                         {
                             hasComp = true;
                             comp = currentItem;
@@ -200,47 +200,16 @@ function _ipcModule() {
                         }
                     }
                 }
-                if (!hasComp) {
+                if (hasComp) {
                     app.project.renderQueue.items.add(comp);
                     conn.writeln("Created RQI");
                 }
                 else {
-                    doShutdown = true;
                     conn.writeln("Error: Comp doesn't exist in project");
+                    app.project.close(CloseOptions.DO_NOT_SAVE_CHANGES);
+                    doShutdown = true;
                 }
             }
-        }
-    }
-
-    var EPSILON = 0.00001
-    // Maximum number of attempts to set the workAreaStart
-    var _WORK_AREA_START_MAX_TRIES = 1000;
-
-    function setWorkArea(compObject, start, duration, conn) {
-        // For some reason, setting the workAreaStart needs to be run multiple times for it to work properly.
-        // We'll try it for a set limit of tries before raising an error.
-        // See: https://community.adobe.com/t5/after-effects-discussions/workareastart-and-workareaduration-behaviour-in-extendscript/m-p/13093413
-        var halfFrameDuration = 1 / compObject.frameRate * 0.5;
-        start = start + EPSILON; // Add float padding to ensure it rounds to the correct frame.
-        duration = duration + EPSILON;
-        for (x = 0; x <= _WORK_AREA_START_MAX_TRIES; x++) {
-            compObject.workAreaStart = start;
-            compObject.workAreaDuration = duration;
-            if (start - halfFrameDuration < compObject.workAreaStart &&
-                compObject.workAreaStart < start + halfFrameDuration &&
-                duration - halfFrameDuration < compObject.workAreaDuration &&
-                compObject.workAreaDuration < duration + halfFrameDuration
-            ) {
-                // Values are correct, stop looping.
-                return
-            }
-        }
-        // Check within epsilon range to account for rounding errors
-        if (!(start - halfFrameDuration < compObject.workAreaStart && compObject.workAreaStart < start + halfFrameDuration)) {
-            conn.writeln("Error: Could not set workAreaStart to " + start)
-        }
-        if (!(duration - halfFrameDuration < compObject.workAreaDuration && compObject.workAreaDuration < duration + halfFrameDuration)) {
-            conn.writeln("Error: Could not set workAreaDuration to " + duration)
         }
     }
 
@@ -271,13 +240,10 @@ function _ipcModule() {
             }
         }
         if(!compFound){
-            doShutdown = true;
             _log.error("Error: Unable to find composition in render queue");
+            app.project.close(CloseOptions.DO_NOT_SAVE_CHANGES);
+            doShutdown = true;
         }
-        // var RQI = RQI_to_copy.duplicate();
-        // var RQI = RQI_to_copy;
-        // var renderQueueItem = app.project.renderQueue.item(1).outputModule(1).getSettings(); // Assuming you want information for the first render queue item
-        // alert(renderQueueItem["Format"]);
         output_file_settings = {
             "Output File Info": {
                 "Base Path": outputDirData,
@@ -286,16 +252,19 @@ function _ipcModule() {
             }
         }
         RQI.outputModule(1).setSettings(output_file_settings);
-
-        // Set start frame and end frame
-        // var frameRate = comp.frameRate;
-        // var start = frame / frameRate;
-        // var end = (frame + 1) / frameRate; 
-        // var duration = end - start
-
-        //Have to set the start and duration according to the last entry in this forum post: https://community.adobe.com/t5/after-effects-discussions/workareastart-and-workareaduration-behaviour-in-extendscript/m-p/13093413
-        var start = currentFormatToTime("0:00:" + frame, comp.frameRate);
-        var duration = currentFormatToTime("0:00:01", comp.frameRate, true);//assumes a duration of one frame 
+        
+        var start;
+        var duration;//assumes a duration of one frame 
+        if(app.project.framesCountType == FramesCountType.FC_START_1){
+            frame++;
+        }
+        if(app.project.framesUseFeetFrames){
+            start = currentFormatToTime("0000+" + frame, comp.frameRate);
+            duration = currentFormatToTime("0000+01", comp.frameRate, true);//assumes a duration of one frame 
+        } else {
+            start = currentFormatToTime("0:00:" + frame, comp.frameRate);
+            duration = currentFormatToTime("0:00:01", comp.frameRate, true);//assumes a duration of one frame 
+        }
 
         RQI.timeSpanStart = start
         RQI.timeSpanDuration = duration
@@ -303,9 +272,6 @@ function _ipcModule() {
         RQI.remove();
     
         conn.writeln("AEClient: Finished Rendering Frame " + frame);
-
-        // app.project.close(CloseOptions.DO_NOT_SAVE_CHANGES);
-        // doShutdown = true;
     }
 
     return {


### PR DESCRIPTION
### What was the problem/requirement?
The adaptor was rendering the entire composition every task.

### What was the solution?
The old code was editing the composition, but not the output module of the render queue item already in the render queue. This PR uses timeSpanStart and timeSpanDuration to properly set the render queue item's frame range.

### What is the impact of this change?
You can actually distribute render across multiple nodes by having different workers work on different frames.

### How was this change tested?
By running render jobs on an EC2 CMF worker in my AWS account.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

I don't know where the tests are.

### Was this change documented?
The change brings the code in line with how the adaptor is documented to work.

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
