### PR TITLE
Changed the adaptor to search the entire project for matching composition names instead of just the root folder

### DIFF
--- a/src/aeipc/ipc.jsx
+++ b/src/aeipc/ipc.jsx
@@ -166,47 +166,48 @@ function _ipcModule() {
         if (project) {
             
             // Get the number of compositions in the project
-            var numComps = project.rootFolder.numItems;
+            var numComps = project.numItems;
             var hasComp = false;
             var comp = null;
 
-            // Loop through each item in the project root folder
-            for (var i = 1; i <= numComps; i++) 
+            var hasRQI = false;
+            for (var j = 1; j <= app.project.renderQueue.numItems; j++)
             {
-            
-                // Get the current item
-                var currentItem = project.rootFolder.item(i);
-                
-                // Check if the item is a composition
-                if (currentItem instanceof CompItem) 
+                if(compName == app.project.renderQueue.item(j).comp.name)
                 {
-                    if(currentItem.name.indexOf(compName) !== -1)
+                    hasRQI = true;
+                    conn.writeln("OK");
+                    break;
+                }
+            } 
+            if (!hasRQI)
+            {
+                // Loop through each item in the project to try to find the correct composition
+                for (var i = 1; i <= numComps; i++) 
+                {
+                
+                    // Get the current item
+                    var currentItem = project.item(i);
+                    
+                    // Check if the item is a composition
+                    if (currentItem instanceof CompItem) 
                     {
-                        hasComp = true;
-                        comp = currentItem;
+                        if(currentItem.name.indexOf(compName) !== -1)
+                        {
+                            hasComp = true;
+                            comp = currentItem;
+                            break;
+                        }
                     }
                 }
-            }
-            if (hasComp)
-            {
-                var hasRQI = false;
-                for (var j = 1; j <= app.project.renderQueue.numItems; j++)
-                {
-                    if(compName == app.project.renderQueue.item(j).comp.name)
-                    {
-                        hasRQI = true;
-                        conn.writeln("OK");
-                    }
-                } 
-                if (!hasRQI)
-                {
+                if (!hasComp) {
                     app.project.renderQueue.items.add(comp);
                     conn.writeln("Created RQI");
                 }
-            
-            }
-            else {
-                conn.writeln("Error: Comp doesn't exist in project");
+                else {
+                    conn.writeln("Error: Comp doesn't exist in project");
+                    doShutdown = true;
+                }
             }
         }
     }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Projects that had compositions in folders were not rendering.

### What was the solution? (How)
The adaptor was only looping through the root folder when searching for compositions. This PR makes it look through the entire project.

### What is the impact of this change?
You will now be able to render compositions regardless of if they are organized in a folder or not.

### How was this change tested?
I tested with project files that used folders.

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.
No, I don't know what this is.

### Was this change documented?
No, it does not need to be documented because it just addresses a bug.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
