### PR TITLE
chore: fix hatch linting

### DIFF
--- a/src/deadline/ae_adaptor/AEClient/ae_client.py
+++ b/src/deadline/ae_adaptor/AEClient/ae_client.py
@@ -50,7 +50,7 @@ class AEClient(ClientInterface):
         cmd_args = [ae_exe, "-noui", "-s", startup_script_inline]
         print(f"Starting AfterFX: {cmd_args}")
         # Set stdout and stderr to the system stdout and stderr to prevent shell getting blocked
-        sys.__stdout__.flush()
+        sys.stdout.flush()
 
         regexhandler = RegexHandler(list())
         self._ipc_client = LoggingSubprocess(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The linting failed in the GitHub Action.
### What was the solution? (How)
Fixed it by changing sys.__stdout__ to sys.stdout.
### What is the impact of this change?
Fix the Github action for dependency bot.
### How was this change tested?
```
hatch run linting
deadline-cloud-for-after-effects % hatch run lint
cmd [1] | ruff check .
All checks passed!
cmd [2] | black --check --diff .
All done! ✨ 🍰 ✨
12 files would be left unchanged.
cmd [3] | mypy src
Success: no issues found in 9 source files
```
### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```
`hatch run test` but it only has 1 unrelated test
 
### Was this change documented?
n/a
### Is this a breaking change?
n/a

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
