### PR TITLE
feat!: Update AfterEffects environment variable naming

### DIFF
--- a/src/deadline/ae_adaptor/AEClient/ae_client.py
+++ b/src/deadline/ae_adaptor/AEClient/ae_client.py
@@ -44,7 +44,7 @@ class AEClient(ClientInterface):
             client_path_abs = client_path_abs.replace("\\", "\\\\")
         startup_script_inline = f"var x = new File('{client_path_abs}') ; x.open(); eval(x.read()); app.exitAfterLaunchAndEval = false;"
 
-        ae_exe = os.environ.get("AFTEREFFECTS_ADAPTOR_AEFX_EXECUTABLE", "afterfx")
+        ae_exe = os.environ.get("AFTERFX_EXECUTABLE", "afterfx")
 
         # flag -noui for no ui doesn't close properly when running in monitor
         cmd_args = [ae_exe, "-noui", "-s", startup_script_inline]


### PR DESCRIPTION
This now matches the other new DCC naming scheme

### What was the problem/requirement? (What/Why)
The assumption that the executable afterfx.exe exists on the PATH doesn't always make sense, often it is easier to specify the version of AfterEffects to use by explicit path and using an environment variable is an easy way to do this for customers.

### What was the solution? (How)
We have defined a new environment variable `AFTERFX_EXECUTABLE` which follows the naming from 
[`deadline-cloud-for-cinema-4d`](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/src/deadline/cinema4d_adaptor/Cinema4DAdaptor/adaptor.py#L298) of `<EXE_NAME>_EXECUTABLE`

### What is the impact of this change?
Breaking change as we changed the name of the existing environment variable.

### How was this change tested?

### Did you run the "Job Bundle Output Tests"? If not, why not? If so, paste the test results here.

```
Required: paste the contents of job_bundle_output_tests/test-job-bundle-results.txt here
```

### Was this change documented?
Yes, FAQ.md and DEVELOPMENT.md
### Is this a breaking change?
Yes
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
