### PR TITLE
fix: provide a way for CMF customers with aerender exectuable env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ You can use After Effects conda recipe in
 [deadline-cloud-sample package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-25.0)
 as a reference when building the package.
 
+Jobs created by this submitter require aerender executable be available on the PATH of the user that will be running your jobs. Or you can set the AERENDER_EXECUTABLE to point to the aerender executable.
+
 ## Viewing the Job Bundle that will be submitted
 
 To submit a job, the submitter first generates a Job Bundle, and then uses functionality

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/aerender.ps1
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/aerender.ps1
@@ -34,8 +34,10 @@ if (-Not "$outputpath".Contains(",")) {
     $renderarg += "-output", "`"$outputpath`""
 }
 
+$aerender_exe = if ($env:AERENDER_EXECUTABLE) { $env:AERENDER_EXECUTABLE } else { "aerender.exe" }
+
 try {
-    aerender.exe $renderarg 2>&1 | ForEach-Object {
+    & $aerender_exe $renderarg 2>&1 | ForEach-Object {
         Check-Output -output "$_" -exitCode $LASTEXITCODE
     }
 } catch {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
According to https://github.com/aws-deadline/deadline-cloud-for-after-effects/pull/72, the customer is asking to provide a way to use EXECTUABLE env variable for aerender.

### What was the solution? (How)
Change the default aerender.exe to look for env variable first. For CMF customers, they can set this env variable by QEnv or directly in the worker environment. For SMF with Conda, the envariable need to be disable since Conda will set the aerender into PATH. 

### What is the impact of this change?
Provide more flexibility for custmoers to set `aerender` executable path.

### How was this change tested?
Submitted the job to SMF with custom conda channel and it rendered the result successfully.

### Was this change documented?
Yes

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
