### PR TITLE
feat: add xml file for submitter installer

### DIFF
--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -14,8 +14,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -27,8 +26,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -41,8 +39,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>
@@ -55,8 +52,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>
@@ -92,12 +88,10 @@
                 <setInstallerVariable>
                     <name>after_effects_script_ui_directory_2024</name>
                     <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support
-                        Files\Scripts\ScriptUI Panels</value>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
                     <ruleList>
                         <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support
-                                Files\Scripts\ScriptUI Panels</path>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
                         </fileExists>
                     </ruleList>
                 </setInstallerVariable>
@@ -110,24 +104,20 @@
                 <setInstallerVariable>
                     <name>after_effects_script_ui_directory_2025</name>
                     <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support
-                        Files\Scripts\ScriptUI Panels</value>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
                     <ruleList>
                         <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support
-                                Files\Scripts\ScriptUI Panels</path>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
                         </fileExists>
                     </ruleList>
                 </setInstallerVariable>
             </actionList>
             <conditionRuleList>
                 <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support
-                        Files\Scripts\ScriptUI Panels</path>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
                 </fileExists>
                 <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support
-                        Files\Scripts\ScriptUI Panels</path>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
                 </fileExists>
             </conditionRuleList>
             <ruleList>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -9,13 +9,24 @@
         <folder>
             <description>After Effects Plug-in</description>
             <destination>${after_effects_script_ui_directory}</destination>
-            <name>aftereffectpluginsassets</name>
+            <name>aftereffectsplugin</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
                     <origin>
-                        components/deadline-cloud-for-after-effects/dist/*</origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
                 </distributionDirectory>
+            </distributionFileList>
+        </folder>
+        <folder>
+            <description>After Effects Plug-in Script</description>
+            <destination>${after_effects_script_ui_directory}</destination>
+            <name>aftereffectspluginscript</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionFile>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                </distributionFile>
             </distributionFileList>
         </folder>
     </folderList>
@@ -59,16 +70,14 @@
     <parameterList>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for After Effects
-                - Register the plug-in with After Effects by moving the script to the After Effects
-                ScriptUI folder
+- Register the plug-in with After Effects by moving the script to the After Effects ScriptUI folder
             </value>
         </stringParameter>
         <directoryParameter>
             <name>after_effects_script_ui_directory</name>
             <description>After Effects Scripts Directory</description>
             <explanation>Path to scripts directory in the After Effects resources directory. For
-                easiest
-                installation, After Effects should be installed before installing Deadline Cloud for
+                easiest installation, After Effects should be installed before installing Deadline Cloud for
                 After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
                 After Effects 2024\Support Files\Scripts\ScriptUI Panels". </explanation>
             <allowEmptyValue>0</allowEmptyValue>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -7,20 +7,20 @@
     <show>1</show>
     <folderList>
         <folder>
-            <description>After Effects Plug-in assets</description>
-            <destination>${after_effects_scripts_ui_directory}</destination>
+            <description>After Effects Plug-in</description>
+            <destination>${after_effects_script_ui_directory}</destination>
             <name>aftereffectpluginsassets</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
                     <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets/*</origin>
+                        components/deadline-cloud-for-after-effects/dist/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
-        <folder>
+        <!-- <folder>
             <description>After Effects Plug-in Script</description>
-            <destination>${after_effects_scripts_ui_directory}</destination>
+            <destination>${after_effects_script_ui_directory}</destination>
             <name>aftereffectspluginscript</name>
             <platforms>all</platforms>
             <distributionFileList>
@@ -29,7 +29,7 @@
                         components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
-        </folder>
+        </folder> -->
     </folderList>
     <initializationActionList>
         <if>
@@ -68,7 +68,7 @@
             </value>
         </stringParameter>
         <directoryParameter>
-            <name>after_effects_scripts_directory</name>
+            <name>after_effects_script_ui_directory</name>
             <description>After Effects Scripts Directory</description>
             <explanation>Path to scripts directory in the After Effects resources directory. For
                 easiest
@@ -77,8 +77,8 @@
                 After Effects 2024\Support Files\Scripts\ScriptUI Panels". </explanation>
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
-            <cliOptionName>after-effects-scripts-directory</cliOptionName>
-            <cliOptionText>Path to scripts directory in the After Effects resources directory.</cliOptionText>
+            <cliOptionName>after-effects-script-directory</cliOptionName>
+            <cliOptionText>Path to ScriptUI directory in the After Effects application directory.</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
             <mustExist>1</mustExist>
         </directoryParameter>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -1,0 +1,93 @@
+<component>
+    <name>deadline_cloud_for_after_effects</name>
+    <description>Deadline Cloud for After Effects 2024/2025</description>
+    <detailedDescription>After Effects plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
+    <canBeEdited>1</canBeEdited>
+    <selected>0</selected>
+    <show>1</show>
+    <folderList>
+        <folder>
+            <description>After Effects Plug-in assets</description>
+            <destination>${after_effects_scripts_ui_directory}</destination>
+            <name>aftereffectpluginsassets</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionDirectory allowWildcards="1">
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets/*</origin>
+                </distributionDirectory>
+            </distributionFileList>
+        </folder>
+        <folder>
+            <description>After Effects Plug-in Script</description>
+            <destination>${after_effects_scripts_ui_directory}</destination>
+            <name>aftereffectspluginscript</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionFile>
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                </distributionFile>
+            </distributionFileList>
+        </folder>
+    </folderList>
+    <initializationActionList>
+        <if>
+            <conditionRuleList>
+                <compareText>
+                    <logic>does_not_contain</logic>
+                    <text>${platform_name}</text>
+                    <value>linux</value>
+                </compareText>
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="all_components"
+                    value="${all_components} deadline_cloud_for_after_effects" />
+            </actionList>
+            <elseActionList>
+                <setInstallerVariable name="component(deadline_cloud_for_after_effects).show"
+                    value="0" />
+            </elseActionList>
+        </if>
+        <setInstallerVariable name="after_effects_installdir"
+            value="${installdir}\Submitters\After Effects" />
+        <if>
+            <conditionRuleList>
+                <platformTest type="windows" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="after_effects_deps_platform" value="windows" />
+            </actionList>
+        </if>
+    </initializationActionList>
+    <parameterList>
+        <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
+            <value>Deadline Cloud for After Effects
+                - Register the plug-in with After Effects by moving the script to the After Effects
+                ScriptUI folder
+            </value>
+        </stringParameter>
+        <directoryParameter>
+            <name>after_effects_scripts_directory</name>
+            <description>After Effects Scripts Directory</description>
+            <explanation>Path to scripts directory in the After Effects resources directory. For
+                easiest
+                installation, After Effects should be installed before installing Deadline Cloud for
+                After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
+                After Effects 2024\Support Files\Scripts\ScriptUI Panels". </explanation>
+            <allowEmptyValue>0</allowEmptyValue>
+            <ask>yes</ask>
+            <cliOptionName>after-effects-scripts-directory</cliOptionName>
+            <cliOptionText>Path to scripts directory in the After Effects resources directory.</cliOptionText>
+            <mustBeWritable>yes</mustBeWritable>
+            <mustExist>1</mustExist>
+        </directoryParameter>
+    </parameterList>
+    <shouldPackRuleList>
+        <compareText>
+            <logic>does_not_contain</logic>
+            <text>${platform_name}</text>
+            <value>linux</value>
+        </compareText>
+    </shouldPackRuleList>
+</component>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -147,10 +147,9 @@
     </initializationActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
-            <value>Deadline Cloud for After Effects
-- Register the plug-in with After Effects by moving the script to the After Effects
-ScriptUI folder.
-            </value>
+            <value>Deadline Cloud for After Effects 2024-2025
+- Compatible with Adobe After Effects 2024-2025
+- Register the plug-in with After Effects by moving the script to the After Effects ScriptUI Panel directory.</value>
         </stringParameter>
 
         <!-- Directory parameter for After Effects 2024 -->

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -25,7 +25,8 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>
@@ -48,15 +49,51 @@
                     value="0" />
             </elseActionList>
         </if>
-        <setInstallerVariable name="after_effects_installdir"
-            value="${installdir}\Submitters\After Effects" />
         <if>
-            <conditionRuleList>
-                <platformTest type="windows" />
-            </conditionRuleList>
+            <conditionRuleEvaluationLogic>or</conditionRuleEvaluationLogic>
             <actionList>
-                <setInstallerVariable name="after_effects_deps_platform" value="windows" />
+                <componentSelection>
+                    <deselect></deselect>
+                    <select>AfterEffects2024</select>
+                </componentSelection>
+                <setInstallerVariable>
+                    <name>after_effects_script_ui_directory</name>
+                    <ruleEvaluationLogic>or</ruleEvaluationLogic>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
+                    <ruleList>
+                        <fileExists>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                        </fileExists>
+                    </ruleList>
+                </setInstallerVariable>
+                <componentSelection>
+                    <deselect></deselect>
+                    <select>AfterEffects2025</select>
+                </componentSelection>
+                <setInstallerVariable>
+                    <name>after_effects_script_ui_directory</name>
+                    <ruleEvaluationLogic>or</ruleEvaluationLogic>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
+                    <ruleList>
+                        <fileExists>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                        </fileExists>
+                    </ruleList>
+                </setInstallerVariable>
             </actionList>
+            <conditionRuleList>
+                <fileExists>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                </fileExists>
+                <fileExists>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                </fileExists>
+            </conditionRuleList>
+            <ruleList>
+                <platformTest>
+                    <type>windows</type>
+                </platformTest>
+            </ruleList>
         </if>
         <if>
             <conditionRuleList>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -79,6 +79,19 @@
 
         <if>
             <conditionRuleEvaluationLogic>or</conditionRuleEvaluationLogic>
+            <conditionRuleList>
+                <fileExists>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                </fileExists>
+                <fileExists>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                </fileExists>
+            </conditionRuleList>
+            <ruleList>
+                <platformTest>
+                    <type>windows</type>
+                </platformTest>
+            </ruleList>
             <actionList>
                 <!-- After Effects 2024 selection and script directory -->
                 <componentSelection>
@@ -112,19 +125,6 @@
                     </ruleList>
                 </setInstallerVariable>
             </actionList>
-            <conditionRuleList>
-                <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
-                </fileExists>
-                <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
-                </fileExists>
-            </conditionRuleList>
-            <ruleList>
-                <platformTest>
-                    <type>windows</type>
-                </platformTest>
-            </ruleList>
         </if>
 
         <if>
@@ -145,12 +145,11 @@
             </actionList>
         </if>
     </initializationActionList>
-
     <parameterList>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for After Effects
-                - Register the plug-in with After Effects by moving the script to the After Effects
-                ScriptUI folder.
+- Register the plug-in with After Effects by moving the script to the After Effects
+ScriptUI folder.
             </value>
         </stringParameter>
 
@@ -159,8 +158,8 @@
             <name>after_effects_script_ui_directory_2024</name>
             <description>After Effects 2024 Scripts Directory</description>
             <explanation>Path to the scripts directory in After Effects 2024 resources. Default
-                directory: "C:\Program Files\Adobe\Adobe After Effects 2024\Support
-                Files\Scripts\ScriptUI Panels".</explanation>
+directory: "C:\Program Files\Adobe\Adobe After Effects 2024\Support
+Files\Scripts\ScriptUI Panels".</explanation>
             <allowEmptyValue>1</allowEmptyValue>
             <ask>yes</ask>
         </directoryParameter>
@@ -170,8 +169,8 @@
             <name>after_effects_script_ui_directory_2025</name>
             <description>After Effects 2025 Scripts Directory</description>
             <explanation>Path to the scripts directory in After Effects 2025 resources. Default
-                directory: "C:\Program Files\Adobe\Adobe After Effects 2025\Support
-                Files\Scripts\ScriptUI Panels".</explanation>
+directory: "C:\Program Files\Adobe\Adobe After Effects 2025\Support
+Files\Scripts\ScriptUI Panels".</explanation>
             <allowEmptyValue>1</allowEmptyValue>
             <ask>yes</ask>
         </directoryParameter>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -112,9 +112,9 @@
             <name>after_effects_script_ui_directory</name>
             <description>After Effects Scripts Directory</description>
             <explanation>Path to scripts directory in the After Effects resources directory. For
-                easiest installation, After Effects should be installed before installing Deadline Cloud for
-                After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
-                After Effects 2025\Support Files\Scripts\ScriptUI Panels".</explanation>
+easiest installation, After Effects should be installed before installing Deadline Cloud for
+After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
+After Effects 2025\Support Files\Scripts\ScriptUI Panels".</explanation>
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
             <cliOptionName>after-effects-script-directory</cliOptionName>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -1,64 +1,76 @@
-<component>
+<componentGroup>
     <name>deadline_cloud_for_after_effects</name>
     <description>Deadline Cloud for After Effects 2024-2025</description>
     <detailedDescription>After Effects plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
     <show>1</show>
-    <folderList>
-        <!-- After Effects 2024 folder -->
-        <folder>
-            <description>After Effects 2024 Plug-in Folder</description>
-            <destination>${after_effects_script_ui_directory_2024}</destination>
-            <name>aftereffects2024pluginfolder</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
-                </distributionDirectory>
-            </distributionFileList>
-        </folder>
-        <!-- After Effects 2025 folder -->
-        <folder>
-            <description>After Effects 2025 Plug-in Folder</description>
-            <destination>${after_effects_script_ui_directory_2025}</destination>
-            <name>aftereffects2025pluginfolder</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
-                </distributionDirectory>
-            </distributionFileList>
-        </folder>
-
-        <!-- After Effects 2024 Script file -->
-        <folder>
-            <description>After Effects 2024 Script</description>
-            <destination>${after_effects_script_ui_directory_2024}</destination>
-            <name>aftereffects2024pluginscript</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionFile>
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
-                </distributionFile>
-            </distributionFileList>
-        </folder>
-
-        <!-- After Effects 2025 Script file -->
-        <folder>
-            <description>After Effects 2025 Script</description>
-            <destination>${after_effects_script_ui_directory_2025}</destination>
-            <name>aftereffects2025pluginscript</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionFile>
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
-                </distributionFile>
-            </distributionFileList>
-        </folder>
-    </folderList>
-
+    <componentList>
+        <component>
+            <name>ae_2024</name>
+            <description>After Effects 2024</description>
+            <selected>0</selected>
+             <parameterList>
+                <!-- Directory parameter for After Effects 2024 -->
+                <directoryParameter>
+                    <name>after_effects_script_ui_directory_2024</name>
+                    <description>After Effects 2024 Scripts Directory</description>
+                    <explanation>Path to the scripts directory in After Effects 2024 resources. Default
+directory: "C:\Program Files\Adobe\Adobe After Effects 2024\Support
+Files\Scripts\ScriptUI Panels".</explanation>
+                    <allowEmptyValue>1</allowEmptyValue>
+                    <ask>yes</ask>
+                </directoryParameter>
+            </parameterList>
+            <folderList>
+                <!-- After Effects 2024 folder -->
+                <folder>
+                    <description>After Effects 2024 Plug-in Folder</description>
+                    <destination>${after_effects_script_ui_directory_2024}</destination>
+                    <name>aftereffects2024pluginfolder</name>
+                    <platforms>all</platforms>
+                    <distributionFileList>
+                        <distributionDirectory allowWildcards="1">
+                            <origin>components/deadline-cloud-for-after-effects/dist/*</origin>
+                        </distributionDirectory>
+                    </distributionFileList>
+                </folder>
+            </folderList>
+        </component>
+        <component>
+            <name>ae_2025</name>
+            <description>After Effects 2025</description>
+            <selected>0</selected>
+            <parameterList>
+                <!-- Directory parameter for After Effects 2025 -->
+                <directoryParameter>
+                    <name>after_effects_script_ui_directory_2025</name>
+                    <description>After Effects 2025 Scripts Directory</description>
+                    <explanation>Path to the scripts directory in After Effects 2025 resources. Default
+directory: "C:\Program Files\Adobe\Adobe After Effects 2025\Support
+Files\Scripts\ScriptUI Panels".</explanation>
+                    <allowEmptyValue>1</allowEmptyValue>
+                    <ask>yes</ask>
+                </directoryParameter>
+            </parameterList>
+            <folderList>
+                <!-- After Effects 2025 folder -->
+                <folder>
+                    <description>After Effects 2025 Plug-in Folder</description>
+                    <destination>${after_effects_script_ui_directory_2025}</destination>
+                    <name>aftereffects2025pluginfolder</name>
+                    <platforms>all</platforms>
+                    <distributionFileList>
+                        <distributionDirectory allowWildcards="1">
+                            <origin>components/deadline-cloud-for-after-effects/dist/*</origin>
+                        </distributionDirectory>
+                    </distributionFileList>
+                </folder>
+            </folderList>
+        </component>
+    </componentList>
     <initializationActionList>
+        <!-- After Effects 2024 selection and script directory -->
         <if>
             <conditionRuleList>
                 <compareText>
@@ -72,61 +84,23 @@
                     value="${all_components} deadline_cloud_for_after_effects" />
             </actionList>
             <elseActionList>
-                <setInstallerVariable name="component(deadline_cloud_for_after_effects).show"
-                    value="0" />
+                <setInstallerVariable name="component(deadline_cloud_for_after_effects).show" value="0" />
             </elseActionList>
         </if>
-
         <if>
-            <conditionRuleEvaluationLogic>or</conditionRuleEvaluationLogic>
             <conditionRuleList>
-                <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
-                </fileExists>
                 <fileExists>
                     <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
                 </fileExists>
             </conditionRuleList>
-            <ruleList>
-                <platformTest>
-                    <type>windows</type>
-                </platformTest>
-            </ruleList>
             <actionList>
-                <!-- After Effects 2024 selection and script directory -->
                 <componentSelection>
                     <deselect></deselect>
                     <select>AfterEffects2024</select>
                 </componentSelection>
-                <setInstallerVariable>
-                    <name>after_effects_script_ui_directory_2024</name>
-                    <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
-                    <ruleList>
-                        <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
-                        </fileExists>
-                    </ruleList>
-                </setInstallerVariable>
-
-                <!-- After Effects 2025 selection and script directory -->
-                <componentSelection>
-                    <deselect></deselect>
-                    <select>AfterEffects2025</select>
-                </componentSelection>
-                <setInstallerVariable>
-                    <name>after_effects_script_ui_directory_2025</name>
-                    <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
-                    <ruleList>
-                        <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
-                        </fileExists>
-                    </ruleList>
-                </setInstallerVariable>
+                <setInstallerVariable name="after_effects_script_ui_directory_2024" value = "C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels"/>
             </actionList>
         </if>
-
         <if>
             <conditionRuleList>
                 <fileExists negate="1" path="${after_effects_script_ui_directory_2024}" />
@@ -135,7 +109,25 @@
                 <setInstallerVariable name="after_effects_script_ui_directory_2024" value="" />
             </actionList>
         </if>
-
+        <!-- After Effects 2025 selection and script directory -->
+        <if>
+            <conditionRuleEvaluationLogic>and</conditionRuleEvaluationLogic>
+            <conditionRuleList>
+                <fileExists>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                </fileExists>
+                <platformTest>
+                    <type>windows</type>
+                </platformTest>
+            </conditionRuleList>
+            <actionList>
+                <componentSelection>
+                    <deselect></deselect>
+                    <select>AfterEffects2025</select>
+                </componentSelection>
+                <setInstallerVariable name="after_effects_script_ui_directory_2025" value = "C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels"/>
+            </actionList>
+        </if>
         <if>
             <conditionRuleList>
                 <fileExists negate="1" path="${after_effects_script_ui_directory_2025}" />
@@ -151,30 +143,7 @@
 - Compatible with Adobe After Effects 2024-2025
 - Register the plug-in with After Effects by moving the script to the After Effects ScriptUI Panel directory.</value>
         </stringParameter>
-
-        <!-- Directory parameter for After Effects 2024 -->
-        <directoryParameter>
-            <name>after_effects_script_ui_directory_2024</name>
-            <description>After Effects 2024 Scripts Directory</description>
-            <explanation>Path to the scripts directory in After Effects 2024 resources. Default
-directory: "C:\Program Files\Adobe\Adobe After Effects 2024\Support
-Files\Scripts\ScriptUI Panels".</explanation>
-            <allowEmptyValue>1</allowEmptyValue>
-            <ask>yes</ask>
-        </directoryParameter>
-
-        <!-- Directory parameter for After Effects 2025 -->
-        <directoryParameter>
-            <name>after_effects_script_ui_directory_2025</name>
-            <description>After Effects 2025 Scripts Directory</description>
-            <explanation>Path to the scripts directory in After Effects 2025 resources. Default
-directory: "C:\Program Files\Adobe\Adobe After Effects 2025\Support
-Files\Scripts\ScriptUI Panels".</explanation>
-            <allowEmptyValue>1</allowEmptyValue>
-            <ask>yes</ask>
-        </directoryParameter>
     </parameterList>
-
     <shouldPackRuleList>
         <compareText>
             <logic>does_not_contain</logic>
@@ -182,4 +151,4 @@ Files\Scripts\ScriptUI Panels".</explanation>
             <value>linux</value>
         </compareText>
     </shouldPackRuleList>
-</component>
+</componentGroup>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -141,7 +141,7 @@ Files\Scripts\ScriptUI Panels".</explanation>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for After Effects 2024-2025
 - Compatible with Adobe After Effects 2024-2025
-- Register the plug-in with After Effects by moving the script to the After Effects ScriptUI Panel directory.</value>
+- Registers the plug-in with After Effects by moving the script to the After Effects ScriptUI Panel directory.</value>
         </stringParameter>
     </parameterList>
     <shouldPackRuleList>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -1,6 +1,6 @@
 <component>
     <name>deadline_cloud_for_after_effects</name>
-    <description>Deadline Cloud for After Effects 2024/2025</description>
+    <description>Deadline Cloud for After Effects 2024-2025</description>
     <detailedDescription>After Effects plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -116,7 +116,7 @@
             <explanation>Path to scripts directory in the After Effects resources directory. For
                 easiest installation, After Effects should be installed before installing Deadline Cloud for
                 After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
-                After Effects 2024\Support Files\Scripts\ScriptUI Panels". </explanation>
+                After Effects 2025\Support Files\Scripts\ScriptUI Panels".</explanation>
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
             <cliOptionName>after-effects-script-directory</cliOptionName>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -13,8 +13,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -25,8 +24,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -18,18 +18,6 @@
                 </distributionDirectory>
             </distributionFileList>
         </folder>
-        <!-- <folder>
-            <description>After Effects Plug-in Script</description>
-            <destination>${after_effects_script_ui_directory}</destination>
-            <name>aftereffectspluginscript</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionFile>
-                    <origin>
-                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
-                </distributionFile>
-            </distributionFileList>
-        </folder> -->
     </folderList>
     <initializationActionList>
         <if>
@@ -57,6 +45,14 @@
             </conditionRuleList>
             <actionList>
                 <setInstallerVariable name="after_effects_deps_platform" value="windows" />
+            </actionList>
+        </if>
+        <if>
+            <conditionRuleList>
+                <fileExists negate="1" path="${after_effects_script_ui_directory}" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="after_effects_script_ui_directory" value="" />
             </actionList>
         </if>
     </initializationActionList>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -6,29 +6,62 @@
     <selected>0</selected>
     <show>1</show>
     <folderList>
+        <!-- After Effects 2024 folder -->
         <folder>
-            <description>After Effects Plug-in</description>
-            <destination>${after_effects_script_ui_directory}</destination>
-            <name>aftereffectsplugin</name>
+            <description>After Effects 2024 Plug-in Folder</description>
+            <destination>${after_effects_script_ui_directory_2024}</destination>
+            <name>aftereffects2024pluginfolder</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
+        <!-- After Effects 2025 folder -->
         <folder>
-            <description>After Effects Plug-in Script</description>
-            <destination>${after_effects_script_ui_directory}</destination>
-            <name>aftereffectspluginscript</name>
+            <description>After Effects 2025 Plug-in Folder</description>
+            <destination>${after_effects_script_ui_directory_2025}</destination>
+            <name>aftereffects2025pluginfolder</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionDirectory allowWildcards="1">
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter_Assets</origin>
+                </distributionDirectory>
+            </distributionFileList>
+        </folder>
+
+        <!-- After Effects 2024 Script file -->
+        <folder>
+            <description>After Effects 2024 Script</description>
+            <destination>${after_effects_script_ui_directory_2024}</destination>
+            <name>aftereffects2024pluginscript</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionFile>
-                    <origin>components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
+                </distributionFile>
+            </distributionFileList>
+        </folder>
+
+        <!-- After Effects 2025 Script file -->
+        <folder>
+            <description>After Effects 2025 Script</description>
+            <destination>${after_effects_script_ui_directory_2025}</destination>
+            <name>aftereffects2025pluginscript</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionFile>
+                    <origin>
+                        components/deadline-cloud-for-after-effects/dist/DeadlineCloudSubmitter.jsx</origin>
                 </distributionFile>
             </distributionFileList>
         </folder>
     </folderList>
+
     <initializationActionList>
         <if>
             <conditionRuleList>
@@ -47,44 +80,54 @@
                     value="0" />
             </elseActionList>
         </if>
+
         <if>
             <conditionRuleEvaluationLogic>or</conditionRuleEvaluationLogic>
             <actionList>
+                <!-- After Effects 2024 selection and script directory -->
                 <componentSelection>
                     <deselect></deselect>
                     <select>AfterEffects2024</select>
                 </componentSelection>
                 <setInstallerVariable>
-                    <name>after_effects_script_ui_directory</name>
+                    <name>after_effects_script_ui_directory_2024</name>
                     <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support
+                        Files\Scripts\ScriptUI Panels</value>
                     <ruleList>
                         <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support
+                                Files\Scripts\ScriptUI Panels</path>
                         </fileExists>
                     </ruleList>
                 </setInstallerVariable>
+
+                <!-- After Effects 2025 selection and script directory -->
                 <componentSelection>
                     <deselect></deselect>
                     <select>AfterEffects2025</select>
                 </componentSelection>
                 <setInstallerVariable>
-                    <name>after_effects_script_ui_directory</name>
+                    <name>after_effects_script_ui_directory_2025</name>
                     <ruleEvaluationLogic>or</ruleEvaluationLogic>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support
+                        Files\Scripts\ScriptUI Panels</value>
                     <ruleList>
                         <fileExists>
-                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                            <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support
+                                Files\Scripts\ScriptUI Panels</path>
                         </fileExists>
                     </ruleList>
                 </setInstallerVariable>
             </actionList>
             <conditionRuleList>
                 <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support
+                        Files\Scripts\ScriptUI Panels</path>
                 </fileExists>
                 <fileExists>
-                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support
+                        Files\Scripts\ScriptUI Panels</path>
                 </fileExists>
             </conditionRuleList>
             <ruleList>
@@ -93,36 +136,57 @@
                 </platformTest>
             </ruleList>
         </if>
+
         <if>
             <conditionRuleList>
-                <fileExists negate="1" path="${after_effects_script_ui_directory}" />
+                <fileExists negate="1" path="${after_effects_script_ui_directory_2024}" />
             </conditionRuleList>
             <actionList>
-                <setInstallerVariable name="after_effects_script_ui_directory" value="" />
+                <setInstallerVariable name="after_effects_script_ui_directory_2024" value="" />
+            </actionList>
+        </if>
+
+        <if>
+            <conditionRuleList>
+                <fileExists negate="1" path="${after_effects_script_ui_directory_2025}" />
+            </conditionRuleList>
+            <actionList>
+                <setInstallerVariable name="after_effects_script_ui_directory_2025" value="" />
             </actionList>
         </if>
     </initializationActionList>
+
     <parameterList>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
             <value>Deadline Cloud for After Effects
-- Register the plug-in with After Effects by moving the script to the After Effects ScriptUI folder
+                - Register the plug-in with After Effects by moving the script to the After Effects
+                ScriptUI folder.
             </value>
         </stringParameter>
+
+        <!-- Directory parameter for After Effects 2024 -->
         <directoryParameter>
-            <name>after_effects_script_ui_directory</name>
-            <description>After Effects Scripts Directory</description>
-            <explanation>Path to scripts directory in the After Effects resources directory. For
-easiest installation, After Effects should be installed before installing Deadline Cloud for
-After Effects. The default ScriptUI directory looks like "C:\Program Files\Adobe\Adobe
-After Effects 2025\Support Files\Scripts\ScriptUI Panels".</explanation>
-            <allowEmptyValue>0</allowEmptyValue>
+            <name>after_effects_script_ui_directory_2024</name>
+            <description>After Effects 2024 Scripts Directory</description>
+            <explanation>Path to the scripts directory in After Effects 2024 resources. Default
+                directory: "C:\Program Files\Adobe\Adobe After Effects 2024\Support
+                Files\Scripts\ScriptUI Panels".</explanation>
+            <allowEmptyValue>1</allowEmptyValue>
             <ask>yes</ask>
-            <cliOptionName>after-effects-script-directory</cliOptionName>
-            <cliOptionText>Path to ScriptUI directory in the After Effects application directory.</cliOptionText>
-            <mustBeWritable>yes</mustBeWritable>
-            <mustExist>1</mustExist>
+        </directoryParameter>
+
+        <!-- Directory parameter for After Effects 2025 -->
+        <directoryParameter>
+            <name>after_effects_script_ui_directory_2025</name>
+            <description>After Effects 2025 Scripts Directory</description>
+            <explanation>Path to the scripts directory in After Effects 2025 resources. Default
+                directory: "C:\Program Files\Adobe\Adobe After Effects 2025\Support
+                Files\Scripts\ScriptUI Panels".</explanation>
+            <allowEmptyValue>1</allowEmptyValue>
+            <ask>yes</ask>
         </directoryParameter>
     </parameterList>
+
     <shouldPackRuleList>
         <compareText>
             <logic>does_not_contain</logic>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to add AE to installer.

### What was the solution? (How)
Added install_builder xml.
1. The installer will ask customers if they want to install the script to 2024 or 2025.
1. Then if the default ScriptUI Panels folder exist, we auto fill the directory path in the installer.
1. If not, leave the directoryParameter empty for customer to input.
1. We added a warning notification when customers is using user profile

### What is the impact of this change?
We will be able to add AE to the installer.

### How was this change tested?
dev build successfully.



### Was this change documented?

https://github.com/user-attachments/assets/21a56809-7e03-4943-9990-1d115c851b7b



N/A

### Is this a breaking change?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
