### PR TITLE
fix: fix the panel ui when allow scripts to write files and access ne…

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2413,8 +2413,8 @@ if (isSecurityPrefSet()) {
 } else {
     //Print an error message and instructions for changing security preferences
     var submitterPanel =
-        thisObj instanceof Panel ?
-        thisObj :
+        this instanceof Panel ?
+        this :
         new Window(
             "palette",
             "Submit Queue to AWS Deadline Cloud",
@@ -2443,6 +2443,7 @@ if (isSecurityPrefSet()) {
         "Please allow script networking and file access:",
         '  1)  Go to "Edit > Preferences > Scripting & Expressions"',
         '  2)  Check "Allow Scripts to Write Files and Access Network"',
+        '  3)  (Optional) Deselect "Warn User When Executing Files"',
         "  3)  Close this window and try again.",
     ].join("\n");
     errorText2.alignment = ["fill", "fill"];

--- a/src/OpenAESubmitter.jsx
+++ b/src/OpenAESubmitter.jsx
@@ -17,8 +17,8 @@ if (isSecurityPrefSet()) {
 } else {
     //Print an error message and instructions for changing security preferences
     var submitterPanel =
-        thisObj instanceof Panel ?
-        thisObj :
+        this instanceof Panel ?
+        this :
         new Window(
             "palette",
             "Submit Queue to AWS Deadline Cloud",
@@ -47,6 +47,7 @@ if (isSecurityPrefSet()) {
         "Please allow script networking and file access:",
         '  1)  Go to "Edit > Preferences > Scripting & Expressions"',
         '  2)  Check "Allow Scripts to Write Files and Access Network"',
+        '  3)  (Optional) Deselect "Warn User When Executing Files"',
         "  3)  Close this window and try again.",
     ].join("\n");
     errorText2.alignment = ["fill", "fill"];


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
We noticed a bug during testing that when the allow scripts to write files and access the network was disabled, the script panel couldn't be loaded successfully.
### What was the solution? (How)
The problem is thisObj is not existing when building the UI, we should change it to this.

### What is the impact of this change?
Fix the problem.

### How was this change tested?
Yes, manual testing enabled access scripts to write files and disabled.
When it is disabled, it should look like below.
<img width="558" alt="image" src="https://github.com/user-attachments/assets/4b229a24-9a5c-4bcf-8325-10c0d3916773" />

### Was this change documented?
N/A

### Is this a breaking change?
N/A

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
