### PR TITLE
docs: update the warning if customers don't allow scripts writable

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2432,18 +2432,19 @@ if (isSecurityPrefSet()) {
     });
     errorText.graphics.foregroundColor = errorText.graphics.newPen(
         errorText.graphics.PenType.SOLID_COLOR,
-        [1.0, 0.2, 0.2],
+        [1.0, 1.0, 0.0],
         1
     );
-    errorText.text = "ERROR: Insufficient Script Permissions";
+    errorText.text = "Update Script Permissions";
     var errorText2 = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText2.text = [
-        "Please allow script networking and file access:",
-        '  1)  Go to "Edit > Preferences > Scripting & Expressions"',
+        "In order for the Deadline Cloud submitter to execute, you need to update your script permissions to allow script networking and file access. To do this, follow the instructions below",
+        "  1)  For Windows User: Select Edit > Preferences > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
+        "        For macOS User: Select After Effects > Settings > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
         '  2)  Check "Allow Scripts to Write Files and Access Network"',
-        '  3)  (Optional) Deselect "Warn User When Executing Files"',
+        '  3)  (Optional) To disable warnings every time you submit a job with the submitter, you can deselect "Warn User When Executing Files"',
         "  4)  Close this window and try again.",
     ].join("\n");
     errorText2.alignment = ["fill", "fill"];

--- a/src/OpenAESubmitter.jsx
+++ b/src/OpenAESubmitter.jsx
@@ -36,18 +36,19 @@ if (isSecurityPrefSet()) {
     });
     errorText.graphics.foregroundColor = errorText.graphics.newPen(
         errorText.graphics.PenType.SOLID_COLOR,
-        [1.0, 0.2, 0.2],
+        [1.0, 1.0, 0.0],
         1
     );
-    errorText.text = "ERROR: Insufficient Script Permissions";
+    errorText.text = "Update Script Permissions";
     var errorText2 = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText2.text = [
-        "Please allow script networking and file access:",
-        '  1)  Go to "Edit > Preferences > Scripting & Expressions"',
+        "In order for the Deadline Cloud submitter to execute, you need to update your script permissions to allow script networking and file access. To do this, follow the instructions below",
+        "  1)  For Windows User: Select Edit > Preferences > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
+        "       For macOS User: Select After Effects > Settings > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
         '  2)  Check "Allow Scripts to Write Files and Access Network"',
-        '  3)  (Optional) Deselect "Warn User When Executing Files"',
+        '  3)  (Optional) To disable warnings every time you submit a job with the submitter, you can deselect "Warn User When Executing Files"',
         "  4)  Close this window and try again.",
     ].join("\n");
     errorText2.alignment = ["fill", "fill"];


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our artist gave a feedback about the color of the warning and its mesasge when customers don't have allow scripts and network access checked.

### What was the solution? (How)

1. Rephrased the paragraph.
2. Changed red to yellow to make it. 

In the artist's word,
> Red usually means something has failed, but because this is a known issue with a relatively easy fix, maybe we make it yellow which would indicate a warning, or blue to indicate that there is information available to the user.

### What is the impact of this change?
better customer experience.

### How was this change tested?
Old version
![image](https://github.com/user-attachments/assets/719736ac-55d6-4569-bd41-f6dfc21e5da1)

New version
![image](https://github.com/user-attachments/assets/e8d3a149-edba-481d-b280-a85832d1d9f6)

### Was this change documented?


### Is this a breaking change?
N/A
---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
