### PR TITLE
fix: added UTF-8 file encoding support on all files written to or read from

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -4,6 +4,24 @@
 
 var scriptFolder = Folder.current.fsName;
 
+function readFile(filePath) {
+    var f = new File(filePath);
+    f.encoding = "UTF-8";
+    f.open("r");
+    var fileContents = f.read();
+    f.close();
+    return fileContents;
+}
+
+function writeFile(filePath, fileContents) {
+    var f = new File(filePath);
+    f.encoding = "UTF-8";
+    f.open("w");
+    f.write(fileContents);
+    f.close();
+    return;
+}
+
 function timeToFrames(time, fps) {
     //temporarily change display format so we can convert seconds to frames
     //We could perform the math ourselves, but using After Effects's internal methods ensure that we don't lose precision due to floating point errors
@@ -118,6 +136,8 @@ function systemCallWithErrorAlerts(cmd) {
 function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
+
+
 
 function __generateUtil() {
 
@@ -1404,16 +1424,6 @@ function generateFontReferences(fontPaths) {
     return formattedFontsPaths;
 }
 
-/*
- * Write a JSON file to the file path
- */
-function writeJSONFile(jsonData, filePath) {
-
-    var file = File(filePath);
-    file.open('w');
-    file.write(JSON.stringify(jsonData, null, 4));
-    file.close();
-}
 
 function isVideoOutput(extension) {
     const VideoOutputExtensions = ["avi", "mp4", "mov"];
@@ -1532,7 +1542,7 @@ function SubmitSelection(selection, framesPerTask) {
             sanitizedOutputFolder
         );
         var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeJSONFile(jobAttachmentsContents, assetReferencesOutDir);
+        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents));
     }
 
     /**
@@ -1550,7 +1560,7 @@ function SubmitSelection(selection, framesPerTask) {
             framesPerTask
         );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeJSONFile(parametersContents, parametersOutDir);
+        writeFile(parametersOutDir, JSON.stringify(parametersContents));
     }
 
     /**
@@ -1558,13 +1568,11 @@ function SubmitSelection(selection, framesPerTask) {
      **/
     function generateTemplate(bundlePath, isImageSeq) {
         // Open the template depending on the output type
-        var template = new File(bundlePath + "/video_template.json");
+        var path = bundlePath + "/video_template.json";
         if (isImageSeq) {
-            template = new File(bundlePath + "/image_template.json");
+            path = bundlePath + "/image_template.json";
         }
-        template.open("r");
-        var templateContents = template.read();
-        template.close();
+        var templateContents = readFile(path);
         // Parse the template string to a JSON object
         var templateObject = JSON.parse(templateContents);
         templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
@@ -1588,11 +1596,7 @@ function SubmitSelection(selection, framesPerTask) {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsVersion;
             }
         }
-
-        var newTemplate = new File(bundlePath + "/template.json");
-        newTemplate.open("w");
-        newTemplate.write(JSON.stringify(templateObject, null, 4));
-        newTemplate.close();
+        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4))
         logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
     }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -137,8 +137,6 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
-
-
 function __generateUtil() {
 
     var scriptFileUtilName = "Util.jsx";

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1594,7 +1594,7 @@ function SubmitSelection(selection, framesPerTask) {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsVersion;
             }
         }
-        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4))
+        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4));
         logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
     }
 

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -497,16 +497,6 @@ function generateFontReferences(fontPaths) {
     return formattedFontsPaths;
 }
 
-/*
- * Write a JSON file to the file path
- */
-function writeJSONFile(jsonData, filePath) {
-
-    var file = File(filePath);
-    file.open('w');
-    file.write(JSON.stringify(jsonData, null, 4));
-    file.close();
-}
 
 function isVideoOutput(extension) {
     const VideoOutputExtensions = ["avi", "mp4", "mov"];

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -99,7 +99,7 @@ function SubmitSelection(selection, framesPerTask) {
             sanitizedOutputFolder
         );
         var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeJSONFile(jobAttachmentsContents, assetReferencesOutDir);
+        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents));
     }
 
     /**
@@ -117,7 +117,7 @@ function SubmitSelection(selection, framesPerTask) {
             framesPerTask
         );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeJSONFile(parametersContents, parametersOutDir);
+        writeFile(parametersOutDir, JSON.stringify(parametersContents));
     }
 
     /**
@@ -125,13 +125,11 @@ function SubmitSelection(selection, framesPerTask) {
      **/
     function generateTemplate(bundlePath, isImageSeq) {
         // Open the template depending on the output type
-        var template = new File(bundlePath + "/video_template.json");
+        var path = bundlePath + "/video_template.json";
         if (isImageSeq) {
-            template = new File(bundlePath + "/image_template.json");
+            path = bundlePath + "/image_template.json";
         }
-        template.open("r");
-        var templateContents = template.read();
-        template.close();
+        var templateContents = readFile(path);
         // Parse the template string to a JSON object
         var templateObject = JSON.parse(templateContents);
         templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
@@ -155,11 +153,7 @@ function SubmitSelection(selection, framesPerTask) {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsVersion;
             }
         }
-
-        var newTemplate = new File(bundlePath + "/template.json");
-        newTemplate.open("w");
-        newTemplate.write(JSON.stringify(templateObject, null, 4));
-        newTemplate.close();
+        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4))
         logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
     }
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -153,7 +153,7 @@ function SubmitSelection(selection, framesPerTask) {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsVersion;
             }
         }
-        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4))
+        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4));
         logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1,5 +1,23 @@
 var scriptFolder = Folder.current.fsName;
 
+function readFile(filePath) {
+    var f = new File(filePath);
+    f.encoding = "UTF-8";
+    f.open("r");
+    var fileContents = f.read();
+    f.close();
+    return fileContents;
+}
+
+function writeFile(filePath, fileContents) {
+    var f = new File(filePath);
+    f.encoding = "UTF-8";
+    f.open("w");
+    f.write(fileContents);
+    f.close();
+    return;
+}
+
 function timeToFrames(time, fps) {
     //temporarily change display format so we can convert seconds to frames
     //We could perform the math ourselves, but using After Effects's internal methods ensure that we don't lose precision due to floating point errors
@@ -114,6 +132,8 @@ function systemCallWithErrorAlerts(cmd) {
 function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
+
+
 
 function __generateUtil() {
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -133,8 +133,6 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
-
-
 function __generateUtil() {
 
     var scriptFileUtilName = "Util.jsx";


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Files with special characters were not being processed correctly. See #113 for more info.

### What was the solution? (How)
Ensure that every file being read from and/or written to that is submitted or used for job bundle are set to UTF-8 encoding. Resolves #113 

### What is the impact of this change?
Characters like ñ are now supported and won't break the AE job submission.

### How was this change tested?
MacOS AE25 and Windows AE25 job submission, verified that the job template does pop up with the correct job attachment paths and the resulting job bundle JSON files do not have the missing character emoji.
<img width="666" alt="Screenshot 2025-01-31 at 3 22 35 PM" src="https://github.com/user-attachments/assets/a2402d9b-eaf7-43f1-ba4e-f35527af8411" />
<img width="579" alt="Screenshot 2025-01-31 at 3 22 14 PM" src="https://github.com/user-attachments/assets/0ee11296-d1b0-41ee-893c-70c6a01ad226" />


### Was this change documented?

No need

- Did you update all relevant docstrings for functions that you modified?
No need

- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?

No need

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
