### PR TITLE
chore: add JSON stringify spacing parameter to make prettier JSON files

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1540,7 +1540,7 @@ function SubmitSelection(selection, framesPerTask) {
             sanitizedOutputFolder
         );
         var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents));
+        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents, null, 4));
     }
 
     /**
@@ -1558,7 +1558,7 @@ function SubmitSelection(selection, framesPerTask) {
             framesPerTask
         );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(parametersOutDir, JSON.stringify(parametersContents));
+        writeFile(parametersOutDir, JSON.stringify(parametersContent, null, 4));
     }
 
     /**
@@ -2444,7 +2444,7 @@ if (isSecurityPrefSet()) {
     errorText2.text = [
         "In order for the Deadline Cloud submitter to execute, you need to update your script permissions to allow script networking and file access. To do this, follow the instructions below",
         "  1)  For Windows User: Select Edit > Preferences > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
-        "        For macOS User: Select After Effects > Settings > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
+        "       For macOS User: Select After Effects > Settings > Scripting & Expressions > select Allow Scripts To Write Files And Access Network",
         '  2)  Check "Allow Scripts to Write Files and Access Network"',
         '  3)  (Optional) To disable warnings every time you submit a job with the submitter, you can deselect "Warn User When Executing Files"',
         "  4)  Close this window and try again.",

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1547,18 +1547,24 @@ function SubmitSelection(selection, framesPerTask) {
      * Generates parameter_values json file
      **/
     function generateParameterValues(bundlePath, outputFolder, outputFileName, isImageSeq) {
-        var parametersContents = parameterValues(
-            renderQueueIndex,
-            app.project.file.fsName,
-            outputFolder,
-            outputFileName,
-            isImageSeq,
-            startFrame,
-            endFrame,
-            framesPerTask
-        );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(parametersOutDir, JSON.stringify(parametersContent, null, 4));
+        writeFile(
+            parametersOutDir,
+            JSON.stringify(
+                parameterValues(
+                    renderQueueIndex,
+                    app.project.file.fsName,
+                    outputFolder,
+                    outputFileName,
+                    isImageSeq,
+                    startFrame,
+                    endFrame,
+                    framesPerTask
+                ),
+                null,
+                4,
+            )
+        );
     }
 
     /**

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -99,7 +99,7 @@ function SubmitSelection(selection, framesPerTask) {
             sanitizedOutputFolder
         );
         var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents));
+        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents, null, 4));
     }
 
     /**
@@ -117,7 +117,7 @@ function SubmitSelection(selection, framesPerTask) {
             framesPerTask
         );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(parametersOutDir, JSON.stringify(parametersContents));
+        writeFile(parametersOutDir, JSON.stringify(parametersContent, null, 4));
     }
 
     /**

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -106,18 +106,24 @@ function SubmitSelection(selection, framesPerTask) {
      * Generates parameter_values json file
      **/
     function generateParameterValues(bundlePath, outputFolder, outputFileName, isImageSeq) {
-        var parametersContents = parameterValues(
-            renderQueueIndex,
-            app.project.file.fsName,
-            outputFolder,
-            outputFileName,
-            isImageSeq,
-            startFrame,
-            endFrame,
-            framesPerTask
-        );
         var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(parametersOutDir, JSON.stringify(parametersContent, null, 4));
+        writeFile(
+            parametersOutDir,
+            JSON.stringify(
+                parameterValues(
+                    renderQueueIndex,
+                    app.project.file.fsName,
+                    outputFolder,
+                    outputFileName,
+                    isImageSeq,
+                    startFrame,
+                    endFrame,
+                    framesPerTask
+                ),
+                null,
+                4,
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In previous PR [here](https://github.com/aws-deadline/deadline-cloud-for-after-effects/pull/116), I forgot to add some parameters to JSON.stringify. Results in uglier JSON files.

### What was the solution? (How)
Added them

### What is the impact of this change?
Cleaner JSON files

### How was this change tested?
Not tested

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
