### PR TITLE
chore: add py as a python executable option to cover Windows Python installation

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1101,7 +1101,7 @@ function getFontsFromFile() {
  * @return String with executable name corresponding to Python 3, or an empty string if not found
  **/
 function getPythonExecutable() {
-    var pythonExecutables = ["python3", "python"];
+    var pythonExecutables = ["python3", "python", "py"];
 
     for (var i = 0; i < pythonExecutables.length; i++) {
         // Search for python executable

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -189,7 +189,7 @@ function getFontsFromFile() {
  * @return String with executable name corresponding to Python 3, or an empty string if not found
  **/
 function getPythonExecutable() {
-    var pythonExecutables = ["python3", "python"];
+    var pythonExecutables = ["python3", "python", "py"];
 
     for (var i = 0; i < pythonExecutables.length; i++) {
         // Search for python executable


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When Python is installed on Windows, the name of the executable can also be `py`, and its possible they won't have python or python3, but just py.

### What was the solution? (How)
Add Py to the list of executables to check for.

### What is the impact of this change?
Better handling for edge case customers

### How was this change tested?
Not tested since it's a minor one-liner change.

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
