### PR TITLE
chore: correct menu name in README submitter instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 ### To use the submitter:
 
 1. Add a composition to your render queue and set up your render settings, output module, and output path.
-1. Open the Deadline Cloud Submitter Panel by clicking **Windows > DeadlineCloudSubmitter.jsx**.
+1. Open the Deadline Cloud Submitter Panel by clicking **Window > DeadlineCloudSubmitter.jsx**.
 1. Select your composition from the list and click **Submit**. You can hit the **Refresh** button to refresh the list.
 1. (Optional: for image sequences output types) you can specify the number of frames per task so that the job created by the After Effects submitter will create the tasks based on the number and then Deadline Cloud will assign the tasks to available workers to delegate the load.
 1. If you see a warning popup window with "You are about to run the script contained in file", you can suppress the warning by following the instruction in the popup or the instructions above to disable warnings when submitting jobs.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When testing the After Effects submitter, I was confused by a reference to a "Windows" menu in the README which was intended to be "Window".

![image](https://github.com/user-attachments/assets/9cb87969-a304-45b8-a8c5-44ceec31b255)

### What was the solution? (How)
Updated the README.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
