### PR TITLE
fix: defined default height and width of submitter panel

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2330,8 +2330,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
-        newList.preferredSize.height = 400
-        newList.preferredSize.width = 500
+        newList.preferredSize.height = 400;
+        newList.preferredSize.width = 500;
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2330,6 +2330,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
+        newList.preferredSize.height = 400
+        newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -109,6 +109,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
+        newList.preferredSize.height = 400
+        newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -109,8 +109,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
-        newList.preferredSize.height = 400
-        newList.preferredSize.width = 500
+        newList.preferredSize.height = 400;
+        newList.preferredSize.width = 500;
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/145

### What was the problem/requirement? (What/Why)
There wasn't a default width and length for the deadline cloud dockable submitter

### What was the solution? (How)
Provided a default size

### What is the impact of this change?
The list box won't be so tiny that it looks empty or invisible

### How was this change tested?
Used it in Mac and Windows, looks fine

![Screenshot 2025-02-28 at 2 38 46 PM](https://github.com/user-attachments/assets/97e604e7-5e07-429d-93ac-3757d9a1734e)

### Is this a breaking change?

No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
