### PR TITLE
docs: added troubleshooting documentation for disabling Python app execution aliases on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ user@7cf34df03377 ~ % where deadline
 1. Then follow the troubleshooting steps above for Python for your respective OS and verify that deadline is on your $PATH.
 1. If you have multiple Python installations and manage Deadline via Pip, verify that the Python on your $PATH is the Python that managed your Deadline installation. This can be done by running `python -m pip list` and `python3 -m pip list` to verify this.
 
+
+### After submission on Windows, a command prompt screen flashes open and close and submitter GUI doesn't pop open
+1. Go to the Windows Start menu and searching for "Manage app execution aliases". Then disable the `python3.exe` and `python.exe` aliases manually and retry submission.
+
 ### Font with an unsupported extension <extension> was found**
 See **Font attachment system** below.
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I noticed that when Python app execution aliases are enabled on Windows, the Deadline GUI submitter doesn't launch properly and the submission closes.

### What was the solution? (How)
Update our Troubleshooting docs to have those disabled before running jobs

### What is the impact of this change?
Better job submission troubleshooting experience.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
