### PR TITLE
fix: switch Deadline CLI from Terminal window call to shell script call to avoid Terminal window popup on Mac

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1641,8 +1641,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
-        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
+        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -241,8 +241,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
-        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
+        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When submitting AE jobs, a separate Terminal window opens to call the Deadline GUI-submitter CLI in a separate process so that artists can still interact with AE while looking at the submitter window.

### What was the solution? (How)
Switch from calling the Terminal application to running shell script directly

### What is the impact of this change?
Mac AE submitter experience is better

### How was this change tested?
Submitted jobs, the AE submitter opens and the Terminal window is not showing up

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
