### PR TITLE
fix: revert switching Deadline CLI from Terminal window call to shell…

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1641,8 +1641,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
-        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
+        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -241,8 +241,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
-        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
+        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(


### PR DESCRIPTION
…cript call to avoid Terminal window popup on Mac (#159)"

This reverts commit 7e475201beee0150e1bfb90bb801b96cddfebd4f.

Fixes: _<insert link to GitHub issue here>_

### What was the problem/requirement? (What/Why)
Tried to stop Terminal popup from happening, however, this reintroduced the issue where artist can't interact with AE.

### What was the solution? (How)
Revert

### What is the impact of this change?

### How was this change tested?

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes/No

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

### Was this change documented?

_delete text starting here_

- Did you update all relevant docstrings for functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?

  _delete text ending here_

### Is this a breaking change?

_delete text starting here_
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
_delete text ending here_

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
