### PR TITLE
fix: added Python validation check on job submission

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2412,13 +2412,15 @@ function buildUI(thisObj) {
 
     var submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
-        const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
-        var maxCpuUsagePercentage = undefined;
-        if (mfrCheckBox.value) {
-            maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+        if (getPythonExecutable()) {
+            const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
+            var maxCpuUsagePercentage = undefined;
+            if (mfrCheckBox.value) {
+                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+            }
+            SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage);
+            list.selection = null;
         }
-        SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage);
-        list.selection = null;
     }
     submitButton.alignment = 'right';
     submitButton.enabled = false;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1641,8 +1641,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
-        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
+        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -241,8 +241,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\"";
-        output = system.callSystem('osascript -e \'do shell script "' + submitScriptContents + '"\'');
+        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
+        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }
     if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
         adcAlert(

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -174,13 +174,15 @@ function buildUI(thisObj) {
 
     var submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
-        const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
-        var maxCpuUsagePercentage = undefined;
-        if (mfrCheckBox.value) {
-            maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+        if (getPythonExecutable()) {
+            const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
+            var maxCpuUsagePercentage = undefined;
+            if (mfrCheckBox.value) {
+                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+            }
+            SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage);
+            list.selection = null;
         }
-        SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage);
-        list.selection = null;
     }
     submitButton.alignment = 'right';
     submitButton.enabled = false;


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/153

### What was the problem/requirement? (What/Why)
Customers were reporting that they were not getting proper error messaging when Python was not installed or added to PATH

### What was the solution? (How)
Added additional python validation check on job submission so that job submission cannot proceed and fails early until it is validated that Python is installed and added to the customer's PATH env variable. This prevents having to add duplicate python validation in other places and centralizes it in one area.

### What is the impact of this change?
Better error handling and messaging for customers

### How was this change tested?
Updated the scripts in AE, uninstalled Python, then attempted to submit a job, and verified the popup appeared. Then I reinstalled Python and added it to my PATH and attempted job submission, which passed!

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
