### PR TITLE
chore(dev): add missing test deps

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -5,10 +5,9 @@ on:
     inputs:
       os:
         required: true
-        default: Linux
+        default: Windows
         type: choice
         options:
-        - Linux
         - Windows
         - MacOS
       ref_type:

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,7 +1,6 @@
 [envs.codebuild.scripts]
 build = "hatch build"
 
-
 [envs.codebuild.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 
@@ -12,6 +11,11 @@ detached = true
 deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"
+
+[envs.default]
+pre-install-commands = [
+  "pip install -r requirements-testing.txt"
+]
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Pytest wasn't being installed:

```
Running command & "pipeline\test_installer.ps1"
Creating environment: default
Installing project in development mode
Checking dependencies
'pytest' is not recognized as an internal or external command,
operable program or batch file.
```

### What was the solution? (How)

Ensure that when we create the env, we install the test dependencies

### What is the impact of this change?

working tests!

### How was this change tested?

running the tests! I pruned my hatch environments, built the AE installer, and ran the tests as sudo:

```
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw2] [  7%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 15%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw2] [ 30%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw0] [ 38%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 46%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw1] [ 53%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw1] [ 61%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw8] [ 69%] PASSED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw3] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw7] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw9] [100%] PASSED test/installer/test_installer.py::TestSystemInstall::test_uninstall 

========================================================= slowest 5 durations ==========================================================
7.02s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions
6.78s setup    test/installer/test_installer.py::TestUserInstall::test_install
6.67s setup    test/installer/test_installer.py::TestSystemInstall::test_uninstall
6.29s setup    test/installer/test_installer.py::TestSystemInstall::test_install
6.16s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
===================================================== 7 passed, 6 skipped in 9.96s =====================================================

```

### Was this change documented?

N/A

### Is this a breaking change?
Fixing :)

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
