### PR TITLE
test: update temp dir and enable components

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ addopts = [
   "--cov-report=xml:build/coverage/coverage.xml",
   "--cov-report=term-missing",
   "--numprocesses=auto",
-  "--basetemp=tmp",
 ]
 testpaths = ["test"]
 looponfailroots = ["src", "test"]

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -57,8 +57,12 @@ def installer_path():
 
 def _run_installer(installer_path, install_scope, installation_path) -> Path:
     # use a path that does not exist
+    ae2024: Path = installation_path / "ae2024"
+    ae2024.mkdir(parents=True)
+    ae2025: Path = installation_path / "ae2025"
+    ae2025.mkdir(parents=True)
     installation_path = installation_path / "dne"
-    installation_path.mkdir(parents=True, exist_ok=True)
+    installation_path.mkdir(parents=True)
 
     args = [
         installer_path,
@@ -69,7 +73,11 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--prefix",
         installation_path,
         "--enable-components",
-        "deadline_cloud_for_after_effects",
+        "deadline_cloud_for_after_effects,ae_2024,ae_2025",
+        "--after_effects_script_ui_directory_2024",
+        ae2024,
+        "--after_effects_script_ui_directory_2025",
+        ae2025
     ]
     if platform.system() == "Darwin":
         args = ["sudo", "-n", *args]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Windows installer permission tests were failing in codebuild

### What was the solution? (How)

Turns out, the folder the project installs to was set to the CWD/tmp. Codebuild seems to add more permissions than we're checking for due to that. It does mean the tests need to be a bit more focused, but putting them in localappdata temp has them passing.

I also enabled the rest of the components to actually install them.

### What is the impact of this change?

Fully tested installers

### How was this change tested?

running the tests in codebuild and locally.

### Was this change documented?

N/A

### Is this a breaking change?

N/A

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
