### PR TITLE
ci: fix all OS input references in publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
   PreRelease:
-    needs: UnitTests
+    needs: VerifyCommit
     runs-on: ubuntu-latest
     environment: release
     outputs:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -37,19 +37,6 @@ jobs:
             echo "Verified author email ($AUTHOR) is as expected ($EXPECTED_AUTHOR)"
           fi
 
-  UnitTests:
-    needs: VerifyCommit
-    name: UnitTests
-    strategy:
-      matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-    uses: ./.github/workflows/reusable_python_build.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      commit: ${{ github.ref }}
-
   PreRelease:
     needs: UnitTests
     runs-on: ubuntu-latest

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -145,7 +145,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['windows-latest', 'macos-latest']
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -94,7 +94,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['windows-latest', 'macos-latest']
     with:
       project_name: ${{ github.event.repository.name }}
       ref:  ${{needs.PreRelease.outputs.tag}}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -92,18 +92,19 @@ jobs:
     needs: PreRelease
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
-    if: ${{ inputs.installer_oses }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     with:
       project_name: ${{ github.event.repository.name }}
       ref:  ${{needs.PreRelease.outputs.tag}}
       ref_type: tags
-      oses: ${{ inputs.installer_oses }}
+      oses: ${{ matrix.os }}
       environment: release
 
   IsCondaReady:
     needs: BuildInstallers
     if: needs.BuildInstallers.result == 'success' || needs.BuildInstallers.result == 'skipped'
-    runs-on: ubuntu-latest
     environment: release
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
     steps:
@@ -139,12 +140,12 @@ jobs:
     needs: [Release, PreRelease]
     runs-on: ubuntu-latest
     environment: release
-    if: (needs.Release.result == 'success' && needs.PreRelease.result == 'success') && ${{ inputs.installer_oses }}
+    if: needs.Release.result == 'success' && needs.PreRelease.result == 'success'
     permissions:
       id-token: write
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.installer_oses) }}
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Many reference to input os were still there

### What was the solution? (How)
Remove them and hardcode the OSes

### What is the impact of this change?
Unblocks release

### How was this change tested?
It can't be without deploying it

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
