### PR TITLE
ci: set os values for installer builder in release workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -92,14 +92,11 @@ jobs:
     needs: PreRelease
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
-    strategy:
-      matrix:
-        os: "['Linux', 'Windows', 'MacOS']"
     with:
       project_name: ${{ github.event.repository.name }}
       ref:  ${{needs.PreRelease.outputs.tag}}
       ref_type: tags
-      oses: ${{ matrix.os }}
+      oses: "['Linux', 'Windows', 'MacOS']"
       environment: release
 
   IsCondaReady:
@@ -146,7 +143,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        os: ${{ fromJson("['Linux', 'Windows', 'MacOS']") }}
+        os: ["Linux", "Windows", "MacOS"]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
os names are not being passed to the jobs correctly in the release workflow

### What was the solution? (How)
Pass in oses as as a string to the BuildInstaller and set the Matrix to a list of oses in the installer release job

### What is the impact of this change?
Allows building and release of installers in the release workflow

### How was this change tested?
Will be tested in release

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
