### PR TITLE
ci: remove linux installer build

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -96,7 +96,7 @@ jobs:
       project_name: ${{ github.event.repository.name }}
       ref:  ${{needs.PreRelease.outputs.tag}}
       ref_type: tags
-      oses: "['Linux', 'Windows', 'MacOS']"
+      oses: "['Windows', 'MacOS']"
       environment: release
 
   IsCondaReady:
@@ -143,7 +143,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        os: ["Linux", "Windows", "MacOS"]
+        os: ["Windows", "MacOS"]
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is no linux installer for AE

### What was the solution? (How)
Remove Linux installer build from release workflow

### How was this change tested?
Tested in release workflow

### Is this a breaking change?
No 

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
