### PR TITLE
feat: add support for After Effects submitter user install on Mac & Windows

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,14 +131,15 @@ hatch run test
 ```
 Note: if you added new files and see the copyright headers test failing, run linting
 
-To test installer, you need admin permission to run the tests correctly.
+To test the installer, there are user-level and system-level installer tests.
 
-On Mac, run:
+On Mac, run one of these commands to run a set of installer tests:
 ```bash
-sudo hatch run test-installer
+hatch run test-installer # Just user-level installer tests
+sudo hatch run test-installer # Run user-level and system-level installer tests
 ```
 
-On Windows, open your Powershell terminal with "Run As Admin" and run:
+On Windows, either run the following command in a regular Powershell window for user-level installer tests or in a "Run As Admin" Powershell window for system-level installer tests
 ```bash
 hatch run test-installer
 ```

--- a/README.md
+++ b/README.md
@@ -66,25 +66,25 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 
 1. Next step is to install the After Effects submitter. We recommend choosing the submitter installer approach to receive both Deadline CLI and your selected integrated submitters. However, if you want to update your submitter with the latest code pushed to this repository, choose the manual installation approach, but ensure you have Deadline CLI already installed via pip or submitter installer beforehand (see instructions above under Prerequisites for info on this).
 
-*NOTE: if the After Effects submitter is not installed as a system install, the submitter will not be a dockable but will be a standalone submitter window.*
+*NOTE: If you install the After Effects submitter as a user install, the submitter will be a standalone submitter window rather than a dockable panel.*
 
    - **Submitter Installer Approach**
       - First, download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
-      - Next, if you are running a System Install, right-click the installer and choose `Run as Admin`. Otherwise, run the installer regularly for a User Install.
-      - Follow the prompts and select which submitters you would like to install. Here are the following OS-specific submitters paths depending on your install approach:
-         - Windows default path for AE System Install: `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`.
-         - Mac default path for AE System Install: `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
-         - Windows default path for AE User Install: `C:\Users\<user>\DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
-         - Mac default path for AE User Install: `/Users/<user>/DeadlineCloudSubmitter/Submitters/AfterEffects/AE<version>`
-      - If chosing a User Install, save the path where you stored the JSX submitter script.
+      - Next, if you are running a System Install on Windows, right-click the installer and choose `Run as Admin`. Otherwise, run the installer regularly for a User Install.
+      - Follow the prompts and select which submitters you would like to install. Here are the following OS-specific default submitters paths depending on your install approach:
+         - **Windows with System Installation**: `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
+         - **Windows with User Installation**: `C:\Users\<user>\DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
+         - **macOS with System Installation**: `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
+         - **macOS with User Installation**: `/Users/<user>/DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
+      - If choosing a User Install and you provide a custom install path, be sure to save that path for later reference.
 
    - **Manual Installation Approach**
       - Scroll to the top of this repository's Github page, and click on the green Code button. In the drop-down, select `Download ZIP`.
       - Unzip the .zip file and navigate to the `dist` folder in the downloaded repository. The submitter files are `DeadlineCloudSubmitter.jsx` and the `DeadlineCloudSubmitter_Assets` folder.
       - For System Install that requires Admin permission, you need to move the submitter files to the ScriptUI Panels folder of After Effects. This will require Admin permission.
-         - Windows: Move them to `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
-         - Mac: Move to `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
-      - For a User install that doesn't need Admin permission, you can leave the submitter files there or to a folder of your choice. If you've used the submitter installer before, you can put it under the DeadlineCloudSubmitter folder in the paths defined in the Submitter Installer Approach section. Save the path where you stored the JSX submitter script.
+         - **Windows**: Move them to `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
+         - **macOS**: Move them to `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
+      - For a User install that doesn't need Admin permission, copy the submitter files to a folder of your choice. If you've used the submitter installer before, you can put it under the DeadlineCloudSubmitter folder in the paths defined in the Submitter Installer Approach section for user installation. Save the path where you stored the JSX submitter script for easy access later.
 
 1. After installing the Deadline CLI manually or via submitter installer, ensure you log into your user profile by running `deadline auth login` in the Terminal/Powershell or logging in via the Deadline Cloud Monitor.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 - Install Python 3.9+ and verify either `python --version` or `python3 --version` or `py --version` works in your Command Prompt or Powershell window.
 - Install Adobe After Effects 24 or 25.
 - Set up your Deadline Cloud monitor, farm, fleet, and queue details, following the documentation from [here for setup](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/monitor-onboarding.html) and its subsections.
-- **If you're on Mac**, you will need to install Deadline CLI manually by running the following commands in Terminal:
+- If you're doing a manual install without using the submitter installer, you will need to install Deadline CLI by running the following commands in Terminal/Powershell:
    ```
    pip install deadline
    pip install "deadline[gui]"
@@ -65,21 +65,28 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
    - macOS: `Select After Effects > Settings > Scripting & Expressions > deselect Warn User When Executing Files`
 
 1. Next step is to install the After Effects submitter. We recommend choosing the submitter installer approach to receive both Deadline CLI and your selected integrated submitters. However, if you want to update your submitter with the latest code pushed to this repository, choose the manual installation approach, but ensure you have Deadline CLI already installed via pip or submitter installer beforehand (see instructions above under Prerequisites for info on this).
-   - Windows:
-      - **Submitter Installer Approach**:
-         - First, download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
-         - Next, right-click the installer and choose `Run as Admin` to make sure the submitter can be installed.
-         - Follow the prompts and select which submitters you would like to install. Note: the default path for the AE submitter is `Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`. After completing installation, you will have the AE submitter and Deadline Cloud CLI installed.
-      - **Manual Installation Approach**:
-         - Scroll to the top of this repository's Github page, and click on the green Code button. In the drop-down, select `Download ZIP`.
-         - Unzip the .zip file and navigate to the `dist` folder in the downloaded repository.
-         - Copy `DeadlineCloudSubmitter.jsx` and the `DeadlineCloudSubmitter_Assets` folder from the `dist` folder to ScriptUI Panels folder under `Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels` within your After Effects installation.
-   - MacOS:
-      - **Manual Installation Approach**:
-         - Scroll to the top of this repository's Github page, and click on the green Code button. In the drop-down, select `Download ZIP`.
-         - Unzip the .zip file and navigate to the `dist` folder in the downloaded repository.
-         - Copy `DeadlineCloudSubmitter.jsx` and the `DeadlineCloudSubmitter_Assets` folder from the `dist` folder to ScriptUI Panels folder under `Applications/Adobe After Effects <version>/Scripts/Script UI Panels` within your After Effects installation.
-      - **Submitter Installer Approach**: No support yet, will update with instructions once we add support for it!
+
+*NOTE: if the After Effects submitter is not installed as a system install, the submitter will not be a dockable but will be a standalone submitter window.*
+
+   - **Submitter Installer Approach**
+      - First, download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
+      - Next, if you are running a System Install, right-click the installer and choose `Run as Admin`. Otherwise, run the installer regularly for a User Install.
+      - Follow the prompts and select which submitters you would like to install. Here are the following OS-specific submitters paths depending on your install approach:
+         - Windows default path for AE System Install: `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`.
+         - Mac default path for AE System Install: `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
+         - Windows default path for AE User Install: `C:\Users\<user>\DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
+         - Mac default path for AE User Install: `/Users/<user>/DeadlineCloudSubmitter/Submitters/AfterEffects/AE<version>`
+      - If chosing a User Install, save the path where you stored the JSX submitter script.
+
+   - **Manual Installation Approach**
+      - Scroll to the top of this repository's Github page, and click on the green Code button. In the drop-down, select `Download ZIP`.
+      - Unzip the .zip file and navigate to the `dist` folder in the downloaded repository. The submitter files are `DeadlineCloudSubmitter.jsx` and the `DeadlineCloudSubmitter_Assets` folder.
+      - For System Install that requires Admin permission, you need to move the submitter files to the ScriptUI Panels folder of After Effects. This will require Admin permission.
+         - Windows: Move them to `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
+         - Mac: Move to `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
+      - For a User install that doesn't need Admin permission, you can leave the submitter files there or to a folder of your choice. If you've used the submitter installer before, you can put it under the DeadlineCloudSubmitter folder in the paths defined in the Submitter Installer Approach section. Save the path where you stored the JSX submitter script.
+
+1. After installing the Deadline CLI manually or via submitter installer, ensure you log into your user profile by running `deadline auth login` in the Terminal/Powershell or logging in via the Deadline Cloud Monitor.
 
 1. Next, to install the necessary dependencies used by the AE submitter, run the following in your local Terminal or Command Prompt.
    ```
@@ -90,10 +97,12 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 ### To use the submitter:
 
 1. Add a composition to your render queue and set up your render settings, output module, and output path.
-1. Open the Deadline Cloud Submitter Panel by clicking **Window > DeadlineCloudSubmitter.jsx**.
-1. Select your composition from the list and click **Submit**. You can hit the **Refresh** button to refresh the list.
-1. (Optional: for image sequences output types) you can specify the number of frames per task so that the job created by the After Effects submitter will create the tasks based on the number and then Deadline Cloud will assign the tasks to available workers to delegate the load.
-1. You can also specify multi-frame rendering with your job submission. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html) for more
+1. To open the Deadline Cloud Submitter Panel, there is a different approach depending on whether it's a User Install or a System Install.
+   - **System Install**: Open submitter by clicking **Window > DeadlineCloudSubmitter.jsx**.
+   - **User Install**: Open submitter by clicking **File > Scripts > Run Script File** and navigate to where the `DeadlineCloudSubmitter.jsx` file is located and select it to run the submitter. If the submitter is closed, reopen it easily by clicking **File > Scripts > Recent Script Files** and pick the `DeadlineCloudSubmitter.jsx` file that was previously run.
+1. Select your composition you want to render click `Submit` to submit a render job. Here are some settings you can set:
+   1. (Optional) For image sequences output types you can specify the number of frames per task so that the job created by the After Effects submitter will create the tasks based on the number and then Deadline Cloud will assign the tasks to available workers to delegate the load.
+   1. You can also specify multi-frame rendering with your job submission. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
 1. If you see a warning popup window with "You are about to run the script contained in file", you can suppress the warning by following the instruction in the popup or the instructions above to disable warnings when submitting jobs.
 1. Install any python libraries if prompted and press the Login button in the bottom left if you are not logged in.
 1. Set the farm and queue you are submitting to with the Settings button, and click **Submit**.
@@ -112,7 +121,7 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 1. We must also ensure you're adding the Python that was used to install Deadline CLI. Run `python -m pip list` and/or `python3 -m pip list` to verify this and add to $PATH$ whichever python applies.
 1. Finally, add the `bin` folder containing Python CLI to your path by editing `~/.zshrc` (and `~/.bashrc` if applicable) and updating the $PATH. For example, if your Python and Deadline CLI are under `/Library/Frameworks/Python.framework/Versions/3.13/bin`, add the following code to your `~/.zshrc` file at the end of the file so it gets final priority when the $PATH is evaluated.
 ```code
-export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.13/bin`
+export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.13/bin
 ```
 1. Save and exit, then run `source ~/.zshrc`
 
@@ -129,7 +138,7 @@ user@7cf34df03377 ~ % where deadline
 1. Open Command Prompt.
 1. Run `where python`, `where python3`, `where py`, and `where deadline`. The Deadline check will tell you which Python executable you should be adding to your $PATH.
 1. Press Windows + S and search for "Edit the system environment variables". Note this will require admin access. Click "Environment Variables...". Depending on whether Deadline CLI was a user installation or system installation, open the corresponding $PATH variable.
-1. Ensure that the binary folders containing deadline and your python CLI have been added to your PATH. Deadline will either be located in the DeadlineCloudSubmitter folder when installed from the submitter installer or under a python folder if managed by pip. If you're managing Deadline CLI with pip, run `python -m pip list` and/or `python3 -m pip list` to ensure you add the Python containing Deadine CLI to your path.
+1. Ensure that the binary folders containing deadline and your python CLI have been added to your PATH. Deadline will either be located in the DeadlineCloudSubmitter folder when installed from the submitter installer or under a python folder if managed by pip. If you're managing Deadline CLI with pip, run `python -m pip list` and/or `python3 -m pip list` to ensure you add the Python containing Deadline CLI to your path.
 
 ### Error: Deadline Not Found
 1. First, open your Terminal or Command Prompt and run `deadline --version` to verify installation.
@@ -161,7 +170,7 @@ To install fonts for non-Adobe apps in Creative Cloud:
 
 ## Setting up After Effects with your Deadline Cloud Farm
 
-After Effects 24.6 and 25.1 conda packages are now available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
+After Effects 24.6.4 and 25.1 conda packages are now available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
 [the instruction](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html).
 You can also use After Effects conda recipe in
 [deadline-cloud-sample package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-25.0)

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -68,31 +68,50 @@
         </component>
     </componentList>
     <initializationActionList>
-        <!-- Define default ScriptUI file paths variables based on OS type -->
-        <setInstallerVariable>
-            <name>default_ae_script_ui_path_25</name>
-            <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
-        </setInstallerVariable>
-        <setInstallerVariable>
-            <name>default_ae_script_ui_path_24</name>
-            <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
-        </setInstallerVariable>
+        <!-- Define default ScriptUI file paths variables based on OS type and install type -->
         <if>
-            <ruleList>
-                <platformTest>
-                    <type>osx</type>
-                </platformTest>
-            </ruleList>
+            <conditionRuleList>
+                <compareText logic="equals" text="${installscope}" value="user"/>
+            </conditionRuleList>
             <actionList>
+                <!-- For user installation, set paths to regular installdir location -->
                 <setInstallerVariable>
                     <name>default_ae_script_ui_path_25</name>
-                    <value>/Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels</value>
+                    <value>${installdir}/AE2025</value>
                 </setInstallerVariable>
                 <setInstallerVariable>
                     <name>default_ae_script_ui_path_24</name>
-                    <value>/Applications/Adobe After Effects 2024/Scripts/ScriptUI Panels</value>
+                    <value>${installdir}/AE2024</value>
                 </setInstallerVariable>
             </actionList>
+            <elseActionList>
+                <!-- For system installation, use the elevated privileges location under default Applications path -->
+                <setInstallerVariable>
+                    <name>default_ae_script_ui_path_25</name>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
+                </setInstallerVariable>
+                <setInstallerVariable>
+                    <name>default_ae_script_ui_path_24</name>
+                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
+                </setInstallerVariable>
+                <if>
+                    <ruleList>
+                        <platformTest>
+                            <type>osx</type>
+                        </platformTest>
+                    </ruleList>
+                    <actionList>
+                        <setInstallerVariable>
+                            <name>default_ae_script_ui_path_25</name>
+                            <value>/Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels</value>
+                        </setInstallerVariable>
+                        <setInstallerVariable>
+                            <name>default_ae_script_ui_path_24</name>
+                            <value>/Applications/Adobe After Effects 2024/Scripts/ScriptUI Panels</value>
+                        </setInstallerVariable>
+                    </actionList>
+                </if>
+            </elseActionList>
         </if>
         <!-- Non-Linux OS validation -->
         <if>
@@ -111,35 +130,39 @@
                 <setInstallerVariable name="component(deadline_cloud_for_after_effects).show" value="0" />
             </elseActionList>
         </if>
-        <!-- After Effects 2024 script directory selection -->
+        <!-- After Effects 2024 and 2025 script directory selection -->
         <if>
             <conditionRuleList>
-                <fileExists>
-                    <path>${default_ae_script_ui_path_24}</path>
-                </fileExists>
+                <compareText logic="equals" text="${installscope}" value="system"/>
             </conditionRuleList>
             <actionList>
-                <componentSelection>
-                    <deselect></deselect>
-                    <select>AfterEffects2024</select>
-                </componentSelection>
+                <!-- For system installation, first check if folder exists, then move files there. Otherwise leave folder selection blank -->
+                <if>
+                    <conditionRuleList>
+                        <fileExists>
+                            <path>${default_ae_script_ui_path_24}</path>
+                        </fileExists>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="after_effects_script_ui_directory_2024" value="${default_ae_script_ui_path_24}"/>
+                    </actionList>
+                </if>
+                <if>
+                    <conditionRuleList>
+                        <fileExists>
+                            <path>${default_ae_script_ui_path_25}</path>
+                        </fileExists>
+                    </conditionRuleList>
+                    <actionList>
+                        <setInstallerVariable name="after_effects_script_ui_directory_2025" value="${default_ae_script_ui_path_25}"/>
+                    </actionList>
+                </if>
+            </actionList>
+            <elseActionList>
+                <!-- For user installation, set directory to default location because it will be created -->
                 <setInstallerVariable name="after_effects_script_ui_directory_2024" value="${default_ae_script_ui_path_24}"/>
-            </actionList>
-        </if>
-        <!-- After Effects 2025 script directory selection -->
-        <if>
-            <conditionRuleList>
-                <fileExists>
-                    <path>${default_ae_script_ui_path_25}</path>
-                </fileExists>
-            </conditionRuleList>
-            <actionList>
-                <componentSelection>
-                    <deselect></deselect>
-                    <select>AfterEffects2025</select>
-                </componentSelection>
                 <setInstallerVariable name="after_effects_script_ui_directory_2025" value="${default_ae_script_ui_path_25}"/>
-            </actionList>
+            </elseActionList>
         </if>
     </initializationActionList>
     <parameterList>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -2,7 +2,7 @@
 
 <componentGroup>
     <name>deadline_cloud_for_after_effects</name>
-    <description>Deadline Cloud for After Effects 2024-2025</description>
+    <description>Deadline Cloud for After Effects</description>
     <detailedDescription>After Effects plugin for submitting jobs to AWS Deadline Cloud.</detailedDescription>
     <canBeEdited>1</canBeEdited>
     <selected>0</selected>
@@ -17,13 +17,62 @@
                 <directoryParameter value="">
                     <name>after_effects_script_ui_directory_2024</name>
                     <description>After Effects 2024 Script UI Directory</description>
-                    <explanation>Path to the script UI directory in After Effects 2024 resources. Default directory: ${default_ae_script_ui_path_24}</explanation>
+                    <explanation>Path to the script UI directory in After Effects 2024 resources.</explanation>
                     <allowEmptyValue>1</allowEmptyValue>
                     <ask>yes</ask>
+                    <!-- Set default paths right before this parameter page is shown in order to set default path values based on user input -->
+                    <preShowPageActionList>
+                        <if>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <!-- For user installation, always set the default path -->
+                                <setInstallerVariable>
+                                    <name>after_effects_script_ui_directory_2024</name>
+                                    <value>${installdir}/AE2024</value>
+                                </setInstallerVariable>
+                            </actionList>
+                            <elseActionList>
+                                <!-- For system installation, set the default path based on OS -->
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx"/>
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable>
+                                            <name>default_ae_script_ui_path_24</name>
+                                            <value>/Applications/Adobe After Effects 2024/Scripts/ScriptUI Panels</value>
+                                        </setInstallerVariable>
+                                    </actionList>
+                                    <elseActionList>
+                                        <setInstallerVariable>
+                                            <name>default_ae_script_ui_path_24</name>
+                                            <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
+                                        </setInstallerVariable>
+                                    </elseActionList>
+                                </if>
+                                <!-- Check if the directory exists for system installs before setting install path as default -->
+                                <if>
+                                    <conditionRuleList>
+                                        <fileExists>
+                                            <path>${default_ae_script_ui_path_24}</path>
+                                        </fileExists>
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable>
+                                            <name>after_effects_script_ui_directory_2024</name>
+                                            <value>${default_ae_script_ui_path_24}</value>
+                                        </setInstallerVariable>
+                                    </actionList>
+                                </if>
+                            </elseActionList>
+                        </if>
+                    </preShowPageActionList>
                 </directoryParameter>
             </parameterList>
             <folderList>
-                <!-- After Effects 2024 folder -->
+                <!-- After Effects 2024 Submitter folder location -->
                 <folder>
                     <description>After Effects 2024 Script UI Folder</description>
                     <destination>${after_effects_script_ui_directory_2024}</destination>
@@ -46,13 +95,62 @@
                 <directoryParameter value="">
                     <name>after_effects_script_ui_directory_2025</name>
                     <description>After Effects 2025 Script UI Directory</description>
-                    <explanation>Path to the script UI directory in After Effects 2025 resources. Default directory: ${default_ae_script_ui_path_25}</explanation>
+                    <explanation>Path to the script UI directory in After Effects 2025 resources.</explanation>
                     <allowEmptyValue>1</allowEmptyValue>
                     <ask>yes</ask>
+                    <!-- Set default paths right before this page is shown -->
+                    <preShowPageActionList>
+                        <if>
+                            <conditionRuleList>
+                                <compareText logic="equals" text="${installscope}" value="user"/>
+                            </conditionRuleList>
+                            <actionList>
+                                <!-- For user installation, always set the default path -->
+                                <setInstallerVariable>
+                                    <name>after_effects_script_ui_directory_2025</name>
+                                    <value>${installdir}/AE2025</value>
+                                </setInstallerVariable>
+                            </actionList>
+                            <elseActionList>
+                                <!-- For system installation, set the default path based on OS -->
+                                <if>
+                                    <conditionRuleList>
+                                        <platformTest type="osx"/>
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable>
+                                            <name>default_ae_script_ui_path_25</name>
+                                            <value>/Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels</value>
+                                        </setInstallerVariable>
+                                    </actionList>
+                                    <elseActionList>
+                                        <setInstallerVariable>
+                                            <name>default_ae_script_ui_path_25</name>
+                                            <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
+                                        </setInstallerVariable>
+                                    </elseActionList>
+                                </if>
+                                <!-- Check if the directory exists for system installs before setting install path as default -->
+                                <if>
+                                    <conditionRuleList>
+                                        <fileExists>
+                                            <path>${default_ae_script_ui_path_25}</path>
+                                        </fileExists>
+                                    </conditionRuleList>
+                                    <actionList>
+                                        <setInstallerVariable>
+                                            <name>after_effects_script_ui_directory_2025</name>
+                                            <value>${default_ae_script_ui_path_25}</value>
+                                        </setInstallerVariable>
+                                    </actionList>
+                                </if>
+                            </elseActionList>
+                        </if>
+                    </preShowPageActionList>
                 </directoryParameter>
             </parameterList>
             <folderList>
-                <!-- After Effects 2025 folder -->
+                <!-- After Effects 2025 Submitter folder location -->
                 <folder>
                     <description>After Effects 2025 Script UI Folder</description>
                     <destination>${after_effects_script_ui_directory_2025}</destination>
@@ -68,51 +166,6 @@
         </component>
     </componentList>
     <initializationActionList>
-        <!-- Define default ScriptUI file paths variables based on OS type and install type -->
-        <if>
-            <conditionRuleList>
-                <compareText logic="equals" text="${installscope}" value="user"/>
-            </conditionRuleList>
-            <actionList>
-                <!-- For user installation, set paths to regular installdir location -->
-                <setInstallerVariable>
-                    <name>default_ae_script_ui_path_25</name>
-                    <value>${installdir}/AE2025</value>
-                </setInstallerVariable>
-                <setInstallerVariable>
-                    <name>default_ae_script_ui_path_24</name>
-                    <value>${installdir}/AE2024</value>
-                </setInstallerVariable>
-            </actionList>
-            <elseActionList>
-                <!-- For system installation, use the elevated privileges location under default Applications path -->
-                <setInstallerVariable>
-                    <name>default_ae_script_ui_path_25</name>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
-                </setInstallerVariable>
-                <setInstallerVariable>
-                    <name>default_ae_script_ui_path_24</name>
-                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
-                </setInstallerVariable>
-                <if>
-                    <ruleList>
-                        <platformTest>
-                            <type>osx</type>
-                        </platformTest>
-                    </ruleList>
-                    <actionList>
-                        <setInstallerVariable>
-                            <name>default_ae_script_ui_path_25</name>
-                            <value>/Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels</value>
-                        </setInstallerVariable>
-                        <setInstallerVariable>
-                            <name>default_ae_script_ui_path_24</name>
-                            <value>/Applications/Adobe After Effects 2024/Scripts/ScriptUI Panels</value>
-                        </setInstallerVariable>
-                    </actionList>
-                </if>
-            </elseActionList>
-        </if>
         <!-- Non-Linux OS validation -->
         <if>
             <conditionRuleList>
@@ -128,40 +181,6 @@
             </actionList>
             <elseActionList>
                 <setInstallerVariable name="component(deadline_cloud_for_after_effects).show" value="0" />
-            </elseActionList>
-        </if>
-        <!-- After Effects 2024 and 2025 script directory selection -->
-        <if>
-            <conditionRuleList>
-                <compareText logic="equals" text="${installscope}" value="system"/>
-            </conditionRuleList>
-            <actionList>
-                <!-- For system installation, first check if folder exists, then move files there. Otherwise leave folder selection blank -->
-                <if>
-                    <conditionRuleList>
-                        <fileExists>
-                            <path>${default_ae_script_ui_path_24}</path>
-                        </fileExists>
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="after_effects_script_ui_directory_2024" value="${default_ae_script_ui_path_24}"/>
-                    </actionList>
-                </if>
-                <if>
-                    <conditionRuleList>
-                        <fileExists>
-                            <path>${default_ae_script_ui_path_25}</path>
-                        </fileExists>
-                    </conditionRuleList>
-                    <actionList>
-                        <setInstallerVariable name="after_effects_script_ui_directory_2025" value="${default_ae_script_ui_path_25}"/>
-                    </actionList>
-                </if>
-            </actionList>
-            <elseActionList>
-                <!-- For user installation, set directory to default location because it will be created -->
-                <setInstallerVariable name="after_effects_script_ui_directory_2024" value="${default_ae_script_ui_path_24}"/>
-                <setInstallerVariable name="after_effects_script_ui_directory_2025" value="${default_ae_script_ui_path_25}"/>
             </elseActionList>
         </if>
     </initializationActionList>

--- a/installer/DeadlineCloudForAfterEffectsSubmitter.xml
+++ b/installer/DeadlineCloudForAfterEffectsSubmitter.xml
@@ -20,7 +20,7 @@
     <windowsUninstallerExecutableIcon>icon.ico</windowsUninstallerExecutableIcon>
 
     <!-- Run as Admin for AfterEffects specifically -->
-    <requireInstallationByRootUser>1</requireInstallationByRootUser>
+    <requireInstallationByRootUser>0</requireInstallationByRootUser>
     <requestedExecutionLevel>asInvoker</requestedExecutionLevel>
 
     <functionDefinitionList>

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -140,10 +140,6 @@ def uninstaller_path():
     yield uninstaller_path
 
 
-@pytest.mark.skipif(
-    not _is_admin(),
-    reason="After Effects submitter installation requires admin permissions",
-)
 def test_default_location(installer_path: Path):
     """Ensures that the default output location reported by the installer is accurate.
        The help text will only show it for the default scope (user). Example help output:
@@ -260,15 +256,12 @@ def test_did_not_build_with_evaluation_mode(installer_path: Path, tmp_path: Path
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="Only run on Linux and MacOS"
 )
-@pytest.mark.skipif(
-    not _is_admin(),
-    reason="After Effects submitter installation requires admin permissions",
-)
 class TestLinuxAndMacOS:
     def test_user_permissions(self, user_installation: Path):
         # GIVEN / WHEN / THEN
         self._validate_posix_permissions(user_installation)
 
+    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
     def test_system_permissions(self, system_installation):
         # GIVEN / WHEN / THEN
         self._validate_posix_permissions(system_installation)
@@ -319,10 +312,6 @@ class TestLinuxAndMacOS:
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only run on Windows")
-@pytest.mark.skipif(
-    not _is_admin(),
-    reason="After Effects submitter installation requires admin permissions",
-)
 class TestWindows:
     def test_user_permissions(self, user_installation):
         # GIVEN / WHEN / THEN
@@ -345,6 +334,7 @@ class TestWindows:
             # Service doesn't exist, not on a container
             return False
 
+    @pytest.mark.skipif(not _is_admin(), reason="Tests requires admin privileges")
     def test_system_permissions(self, system_installation):
         # GIVEN / WHEN / THEN
         self._verify_windows_least_privilege(system_installation)
@@ -434,10 +424,6 @@ class TestWindows:
         assert len(bad_perms) == 0, "\n".join(error_message)
 
 
-@pytest.mark.skipif(
-    not _is_admin(),
-    reason="After Effects submitter installation requires admin permissions",
-)
 class TestUserInstall:
     def test_install(self, user_installation: Path):
         # GIVEN / WHEN / THEN
@@ -462,10 +448,7 @@ class TestUserInstall:
         assert not per_test_user_installation.exists()
 
 
-@pytest.mark.skipif(
-    not _is_admin(),
-    reason="After Effects submitter installation requires admin privileges",
-)
+@pytest.mark.skipif(not _is_admin(), reason="System install tests requires admin privileges")
 class TestSystemInstall:
     def test_install(self, system_installation: Path):
         # GIVEN / WHEN / THEN
@@ -491,6 +474,7 @@ class TestSystemInstall:
                 if not per_test_system_installation.exists():
                     break
                 time.sleep(10)
+        # Failure here
         assert not per_test_system_installation.exists()
 
 

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -79,9 +79,6 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--after_effects_script_ui_directory_2025",
         ae2025
     ]
-    if platform.system() == "Darwin":
-        args = ["sudo", "-n", *args]
-
     subprocess.run(args, check=True, capture_output=True, text=True)
 
     return Path(installation_path)
@@ -474,7 +471,6 @@ class TestSystemInstall:
                 if not per_test_system_installation.exists():
                     break
                 time.sleep(10)
-        # Failure here
         assert not per_test_system_installation.exists()
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Deadline Cloud submitter for After Effects has inherently always been a system install and has required customers to have elevated permissions to install the submitter. 

### What was the solution? (How)
After Effects supports allowing the customer to select the script they would like to run. Since the AE submitter is basically a script (technically a script panel though) it can be executed by After Effects when the user selects it via file system exploration. As a result, we'll download the AE submitter under the DeadlineCloudSubmitter folder under the corresponding user folder which won't require elevated permissions! 

### What is the impact of this change?
Customers will be unblocked from doing proper user installs on Windows and Mac! The customer will have a slightly different procedure to running the submitter, but the documentation has been updated for that. The downside of a proper user install for now is that the submitter is no longer dockable, but the tradeoff is acceptable for now in order to support user installs.

### How was this change tested?
Ran AE dev installer on Windows and Mac and verified that the submitter was installed to the correct locations and were properly uninstalled as well! The user installation would install the submitter scripts to a non-privileged location under the DeadlineCloudForAfterEffectsSubmitter folder and the system installation would install the submitter scripts to the privileged location under the AE Plug-ins folder.

I then submitted render jobs from Mac and Windows for System and User installs and verified that all renders passed successfully!

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
Ran installer tests on Mac and Windows at the user level and system level, all passing!


### Was this change documented?
Yes, README.md instructions have been updated with updated installation and usage instructions and DEVELOPMENT.md has been updated with new instructions on running tests.

### Is this a breaking change?
No!

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
