### PR TITLE
chore(installer): modify AE submitter install location to default to user install location on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
       - Follow the prompts and select which submitters you would like to install. Here are the following OS-specific default submitters paths depending on your install approach:
          - **Windows with System Installation**: `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
          - **Windows with User Installation**: `C:\Users\<user>\DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
-         - **macOS with System Installation**: `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
          - **macOS with User Installation**: `/Users/<user>/DeadlineCloudSubmitter\Submitters/AfterEffects\AE<version>`
+         - - **macOS with System Installation**: (not yet supported on submitter installer, but the theoretical path would be `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`)
       - If choosing a User Install and you provide a custom install path, be sure to save that path for later reference.
 
    - **Manual Installation Approach**

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -24,47 +24,45 @@
                     <preShowPageActionList>
                         <if>
                             <conditionRuleList>
-                                <compareText logic="equals" text="${installscope}" value="user"/>
+                                <platformTest type="osx"/>
                             </conditionRuleList>
                             <actionList>
-                                <!-- For user installation, always set the default path -->
+                                <!-- For macOS, default to user install approach regardless of installscope until we support system installs -->
                                 <setInstallerVariable>
                                     <name>after_effects_script_ui_directory_2024</name>
                                     <value>${installdir}/AE2024</value>
                                 </setInstallerVariable>
                             </actionList>
                             <elseActionList>
-                                <!-- For system installation, set the default path based on OS -->
+                                <!-- For Windows, handle install path based on install scope -->
                                 <if>
                                     <conditionRuleList>
-                                        <platformTest type="osx"/>
+                                        <compareText logic="equals" text="${installscope}" value="user"/>
                                     </conditionRuleList>
                                     <actionList>
+                                        <!-- For Windows user installation -->
                                         <setInstallerVariable>
-                                            <name>default_ae_script_ui_path_24</name>
-                                            <value>/Applications/Adobe After Effects 2024/Scripts/ScriptUI Panels</value>
+                                            <name>after_effects_script_ui_directory_2024</name>
+                                            <value>${installdir}/AE2024</value>
                                         </setInstallerVariable>
                                     </actionList>
                                     <elseActionList>
-                                        <setInstallerVariable>
-                                            <name>default_ae_script_ui_path_24</name>
-                                            <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
-                                        </setInstallerVariable>
+                                        <!-- For Windows system installation -->
+                                        <!-- Check if the directory exists for system installs before setting install path as default -->
+                                        <if>
+                                            <conditionRuleList>
+                                                <fileExists>
+                                                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
+                                                </fileExists>
+                                            </conditionRuleList>
+                                            <actionList>
+                                                <setInstallerVariable>
+                                                    <name>after_effects_script_ui_directory_2024</name>
+                                                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
+                                                </setInstallerVariable>
+                                            </actionList>
+                                        </if>
                                     </elseActionList>
-                                </if>
-                                <!-- Check if the directory exists for system installs before setting install path as default -->
-                                <if>
-                                    <conditionRuleList>
-                                        <fileExists>
-                                            <path>${default_ae_script_ui_path_24}</path>
-                                        </fileExists>
-                                    </conditionRuleList>
-                                    <actionList>
-                                        <setInstallerVariable>
-                                            <name>after_effects_script_ui_directory_2024</name>
-                                            <value>${default_ae_script_ui_path_24}</value>
-                                        </setInstallerVariable>
-                                    </actionList>
                                 </if>
                             </elseActionList>
                         </if>
@@ -102,47 +100,45 @@
                     <preShowPageActionList>
                         <if>
                             <conditionRuleList>
-                                <compareText logic="equals" text="${installscope}" value="user"/>
+                                <platformTest type="osx"/>
                             </conditionRuleList>
                             <actionList>
-                                <!-- For user installation, always set the default path -->
+                                <!-- For macOS, always use user install approach regardless of installscope until we support system installs -->
                                 <setInstallerVariable>
                                     <name>after_effects_script_ui_directory_2025</name>
                                     <value>${installdir}/AE2025</value>
                                 </setInstallerVariable>
                             </actionList>
                             <elseActionList>
-                                <!-- For system installation, set the default path based on OS -->
+                                <!-- For Windows, handle based on installscope -->
                                 <if>
                                     <conditionRuleList>
-                                        <platformTest type="osx"/>
+                                        <compareText logic="equals" text="${installscope}" value="user"/>
                                     </conditionRuleList>
                                     <actionList>
+                                        <!-- For Windows user installation -->
                                         <setInstallerVariable>
-                                            <name>default_ae_script_ui_path_25</name>
-                                            <value>/Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels</value>
+                                            <name>after_effects_script_ui_directory_2025</name>
+                                            <value>${installdir}/AE2025</value>
                                         </setInstallerVariable>
                                     </actionList>
                                     <elseActionList>
-                                        <setInstallerVariable>
-                                            <name>default_ae_script_ui_path_25</name>
-                                            <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
-                                        </setInstallerVariable>
+                                        <!-- For Windows system installation -->
+                                        <!-- Check if the directory exists for system installs before setting install path as default -->
+                                        <if>
+                                            <conditionRuleList>
+                                                <fileExists>
+                                                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
+                                                </fileExists>
+                                            </conditionRuleList>
+                                            <actionList>
+                                                <setInstallerVariable>
+                                                    <name>after_effects_script_ui_directory_2025</name>
+                                                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
+                                                </setInstallerVariable>
+                                            </actionList>
+                                        </if>
                                     </elseActionList>
-                                </if>
-                                <!-- Check if the directory exists for system installs before setting install path as default -->
-                                <if>
-                                    <conditionRuleList>
-                                        <fileExists>
-                                            <path>${default_ae_script_ui_path_25}</path>
-                                        </fileExists>
-                                    </conditionRuleList>
-                                    <actionList>
-                                        <setInstallerVariable>
-                                            <name>after_effects_script_ui_directory_2025</name>
-                                            <value>${default_ae_script_ui_path_25}</value>
-                                        </setInstallerVariable>
-                                    </actionList>
                                 </if>
                             </elseActionList>
                         </if>

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -159,7 +159,7 @@ def test_default_location(installer_path: Path):
             [installer_path, *text_mode, "--help"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=15,
         )
         assert (
             help_result.returncode == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The user/system choice selection is disabled on OSX for now, which means the installscope variable is not being set.

### What was the solution? (How)
Default to user install approach on OSX without checking the installscope variable because it's not being set in the Mac installer currently.

### What is the impact of this change?
Enables user install on Mac

### How was this change tested?
Ran submitter install on Mac and Windows, both worked for user install and Windows system install.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

All tests passed on Windows and Mac

### Was this change documented?
Yes

### Is this a breaking change?
No, this hasn't been released yet.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
