### PR TITLE
docs: include instructions for running submitter with system install

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The submitter includes a folder `DeadlineCloudSubmitter_Assets` and a file `Dead
 
 ### To use the submitter:
 
+1. Launch After Effects. If you did a system install of Deadline Cloud Submitter, run After Effects as Admin.
 1. Add a composition to your render queue and set up your render settings, output module, and output path.
 1. To open the Deadline Cloud Submitter Panel, there is a different approach depending on whether it's a User Install or a System Install.
    - **System Install**: Open submitter by clicking **Window > DeadlineCloudSubmitter.jsx**.

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1640,7 +1640,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         // the PATH correctly.
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
-            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
+            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
         submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
         output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -240,7 +240,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         // the PATH correctly.
         var shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
-            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name \\\"After Effects\\\"';
+            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
         submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
         output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
     }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

**Two changes in this PR**
- Small docs change, need to explain how to run AE submitter if Deadline Cloud Submitter was run as a system install.
- Additionally, we were passing in submitter name incorrectly for Mac to Deadline GUI submitter, so I fixed that.

### What was the solution? (How)
Provide instructions for how to do system install and fix the submitter name being passed in.

### What is the impact of this change?
The docs update clarifies how to run AE submitter if it was a System install.
The submitter name fix helps with our data collection so that we know roughly that an After Effects job is being submitted.

### Was this change documented?
Yes

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
