### PR TITLE
fix: check folder permissions during installation

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -328,9 +328,81 @@ function __generateUtil() {
         /**
          * Return File instance from temporary directory with the given name.
          */
-        var _tempFilePath = normalizePath(Folder.temp.fsName + "/" + fileName);
+        var _tempFilePath = normalizePath(getTempFolder() + "/" + fileName);
         var _tempFile = File(_tempFilePath);
         return _tempFile;
+    }
+
+    var _cachedTempFolder = "";
+
+    function getTempFolder() {
+        /**
+         * Fetches a temporary directory that has read/write access. Defaults to Folder.temp.
+         * Once a working temporary directory is found, the result is cached.
+         */
+        if (_cachedTempFolder != "") {
+            return _cachedTempFolder;
+        }
+
+        //Build list of alternate paths to try
+        var altPaths = [Folder.temp.fsName];
+        var testFileSuffix;
+        if (system.osName == "MacOS") {
+            altPaths.push("~/.deadline/DeadlineCloudAETemp");
+            altPaths.push(Folder.myDocuments.fsName + "/DeadlineCloudAETemp");
+            testFileSuffix = "/testFile.txt";
+        } else {
+            altPaths.push(Folder.userData.fsName + "\\DeadlineCloudAETemp");
+            altPaths.push(Folder.myDocuments.fsName + "\\DeadlineCloudAETemp");
+            testFileSuffix = "\\testFile.txt";
+        }
+
+        //Test every path in our list by creating a test file
+        for (var altPath in altPaths) {
+            var folder = new Folder(altPath);
+
+            //Create the path if it does not already exist
+            folder.create();
+            if (folder.exists) {
+                continue;
+            }
+
+            //List all files and check for errors
+            //Not having list permissions is a common source of errors
+            var existingFiles = folder.getFiles();
+            if (!folder.error) {
+                continue;
+            }
+
+            //Delete any existing files in the path
+            for (var existingFile in existingFiles) {
+                existingFile.remove();
+            }
+
+            //Create and write to a test file to make sure we have write permissions
+            var file = new File(folder.fsName + testFileSuffix);
+            file.open("w");
+            file.writeln("test");
+            file.close();
+            if (!file.exists || file.error) {
+                continue;
+            }
+            file.remove();
+
+            //Cache the folder that passed all the checks so we don't have to repeat the checks
+            _cachedTempFolder = folder.fsName;
+            break;
+        }
+
+        //If no alternate path was found, alert the user and return the default temp path
+        if (_cachedTempFolder == "") {
+            adcAlert("Error: No valid temporary directory found. Check permissions to one of these paths: " + altPaths.join(", "));
+
+            //we don't want to cache the result on a failure, just return the default value
+            return Folder.temp.fsName;
+        }
+
+        return _cachedTempFolder;
     }
 
     function wrappedCallSystem(cmd) {
@@ -546,43 +618,43 @@ function __generateUtil() {
 
         var hostRequirements = {
             "attributes": [{
-                    "name": "attr.worker.os.family",
-                    "anyOf": [
-                        osGroup.OSDropdownList.selection.text.toLowerCase()
-                    ]
-                },
-                {
-                    "name": "attr.worker.cpu.arch",
-                    "anyOf": [
-                        cpuArchGroup.cpuDropdownList.selection.text
-                    ]
-                }
+                "name": "attr.worker.os.family",
+                "anyOf": [
+                    osGroup.OSDropdownList.selection.text.toLowerCase()
+                ]
+            },
+            {
+                "name": "attr.worker.cpu.arch",
+                "anyOf": [
+                    cpuArchGroup.cpuDropdownList.selection.text
+                ]
+            }
             ],
             "amounts": [{
-                    "name": "amount.worker.vcpu",
-                    "min": parseInt(cpuGroup.cpuMinText.text),
-                    "max": parseInt(cpuGroup.cpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.memory",
-                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.gpu",
-                    "min": parseInt(gpuGroup.gpuMinText.text),
-                    "max": parseInt(gpuGroup.gpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.gpu.memory",
-                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.disk.scratch",
-                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-                }
+                "name": "amount.worker.vcpu",
+                "min": parseInt(cpuGroup.cpuMinText.text),
+                "max": parseInt(cpuGroup.cpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.memory",
+                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.gpu",
+                "min": parseInt(gpuGroup.gpuMinText.text),
+                "max": parseInt(gpuGroup.gpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.gpu.memory",
+                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.disk.scratch",
+                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+            }
             ]
         }
 
@@ -726,11 +798,13 @@ function __generateUtil() {
         "removePercentageFromFileName": removePercentageFromFileName,
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
-        "getAEVersion": getAEVersion
+        "getAEVersion": getAEVersion,
+        "getTempFolder": getTempFolder
     }
 }
 
 dcUtil = __generateUtil();
+
 
 
 var LOG_LEVEL = {
@@ -1357,7 +1431,7 @@ function getFontsFromFileLegacy() {
  **/
 function generateFontReferences(fontPaths) {
     // Create a temp folder where all used fonts get gathered
-    var _tempFontsFolder = dcUtil.normPath(Folder.temp.fsName + '/' + "tempFonts");
+    var _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
     var formattedFontsPaths = [];
     var tempFontPath = new Folder(_tempFontsFolder);
     if (!tempFontPath.exists) {
@@ -1572,7 +1646,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     function generateBundle() {
         // create the job bundle folder
         var bundleRoot = new Folder(
-            Folder.temp.fsName + "/DeadlineCloudAESubmission"
+            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
         ); //forward slash works on all operating systems
         recursiveDelete(bundleRoot);
         bundleRoot.create();
@@ -1608,7 +1682,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     var bundle = generateBundle();
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
-    var logFile = new File(Folder.temp.fsName + "/submitter_output.log");
+    var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
     logFile.open("w"); // Erase contents of active log file
     logFile.close();
     var submitScriptContents = "";
@@ -1616,11 +1690,11 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     var cmd = "";
     if ($.os.toString().slice(0, 7) === "Windows") {
         var tempBatFile = new File(
-            Folder.temp.fsName + "/DeadlineCloudAESubmission.bat"
+            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission.bat"
         );
         cmd =
             'deadline bundle gui-submit \"' + bundle.fsName + '\" --output json --install-gui --submitter-name \"After Effects\"';
-        submitScriptContents = cmd + " > " + Folder.temp.fsName + "\\submitter_output.log 2>&1";
+        submitScriptContents = cmd + " > " + dcUtil.getTempFolder() + "\\submitter_output.log 2>&1";
         tempBatFile.open("w");
         tempBatFile.writeln("@echo off");
         tempBatFile.writeln("echo:"); //this empty print statement is required to circumvent a weird bug
@@ -1653,6 +1727,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
 }
 
 
+
 /**
 This file is sourced from https://github.com/ExtendScript/extendscript-es5-shim .
 
@@ -1673,67 +1748,67 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 // Production steps of ECMA-262, Edition 5, 15.4.4.14
 // Reference: http://es5.github.io/#x15.4.4.14
 if (!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function(searchElement, fromIndex) {
-        // 1. Let o be the result of calling ToObject passing
-        //    the this value as the argument.
-        if (this === void 0 || this === null) {
-            throw new TypeError(
-                "Array.prototype.indexOf called on null or undefined"
-            );
-        }
+  Array.prototype.indexOf = function (searchElement, fromIndex) {
+    // 1. Let o be the result of calling ToObject passing
+    //    the this value as the argument.
+    if (this === void 0 || this === null) {
+      throw new TypeError(
+        "Array.prototype.indexOf called on null or undefined"
+      );
+    }
 
-        var k;
-        var o = Object(this);
+    var k;
+    var o = Object(this);
 
-        // 2. Let lenValue be the result of calling the Get
-        //    internal method of o with the argument "length".
-        // 3. Let len be ToUint32(lenValue).
-        var len = o.length >>> 0;
+    // 2. Let lenValue be the result of calling the Get
+    //    internal method of o with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    var len = o.length >>> 0;
 
-        // 4. If len is 0, return -1.
-        if (len === 0) {
-            return -1;
-        }
+    // 4. If len is 0, return -1.
+    if (len === 0) {
+      return -1;
+    }
 
-        // 5. If argument fromIndex was passed let n be
-        //    ToInteger(fromIndex); else let n be 0.
-        var n = +fromIndex || 0;
+    // 5. If argument fromIndex was passed let n be
+    //    ToInteger(fromIndex); else let n be 0.
+    var n = +fromIndex || 0;
 
-        if (Math.abs(n) === Infinity) {
-            n = 0;
-        }
+    if (Math.abs(n) === Infinity) {
+      n = 0;
+    }
 
-        // 6. If n >= len, return -1.
-        if (n >= len) {
-            return -1;
-        }
+    // 6. If n >= len, return -1.
+    if (n >= len) {
+      return -1;
+    }
 
-        // 7. If n >= 0, then Let k be n.
-        // 8. Else, n<0, Let k be len - abs(n).
-        //    If k is less than 0, then let k be 0.
-        k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+    // 7. If n >= 0, then Let k be n.
+    // 8. Else, n<0, Let k be len - abs(n).
+    //    If k is less than 0, then let k be 0.
+    k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
 
-        // 9. Repeat, while k < len
-        while (k < len) {
-            // a. Let Pk be ToString(k).
-            //   This is implicit for LHS operands of the in operator
-            // b. Let kPresent be the result of calling the
-            //    HasProperty internal method of o with argument Pk.
-            //   This step can be combined with c
-            // c. If kPresent is true, then
-            //    i.  Let elementK be the result of calling the Get
-            //        internal method of o with the argument ToString(k).
-            //   ii.  Let same be the result of applying the
-            //        Strict Equality Comparison Algorithm to
-            //        searchElement and elementK.
-            //  iii.  If same is true, return k.
-            if (k in o && o[k] === searchElement) {
-                return k;
-            }
-            k++;
-        }
-        return -1;
-    };
+    // 9. Repeat, while k < len
+    while (k < len) {
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the
+      //    HasProperty internal method of o with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      //    i.  Let elementK be the result of calling the Get
+      //        internal method of o with the argument ToString(k).
+      //   ii.  Let same be the result of applying the
+      //        Strict Equality Comparison Algorithm to
+      //        searchElement and elementK.
+      //  iii.  If same is true, return k.
+      if (k in o && o[k] === searchElement) {
+        return k;
+      }
+      k++;
+    }
+    return -1;
+  };
 }
 //json2.js
 //  json2.js
@@ -1892,344 +1967,340 @@ if (!Array.prototype.indexOf) {
 // methods in a closure to avoid creating global variables.
 
 if (typeof JSON !== "object") {
-    JSON = {};
+  JSON = {};
 }
 
-(function() {
-    "use strict";
+(function () {
+  "use strict";
 
-    var rx_one = /^[\],:{}\s]*$/;
-    var rx_two = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g;
-    var rx_three =
-        /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g;
-    var rx_four = /(?:^|:|,)(?:\s*\[)+/g;
-    var rx_escapable =
-        /[\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
-    var rx_dangerous =
-        /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+  var rx_one = /^[\],:{}\s]*$/;
+  var rx_two = /\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g;
+  var rx_three =
+    /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g;
+  var rx_four = /(?:^|:|,)(?:\s*\[)+/g;
+  var rx_escapable =
+    /[\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
+  var rx_dangerous =
+    /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
 
-    function f(n) {
-        // Format integers to have at least two digits.
-        return n < 10 ? "0" + n : n;
+  function f(n) {
+    // Format integers to have at least two digits.
+    return n < 10 ? "0" + n : n;
+  }
+
+  function this_value() {
+    return this.valueOf();
+  }
+
+  if (typeof Date.prototype.toJSON !== "function") {
+    Date.prototype.toJSON = function () {
+      return isFinite(this.valueOf())
+        ? this.getUTCFullYear() +
+            "-" +
+            f(this.getUTCMonth() + 1) +
+            "-" +
+            f(this.getUTCDate()) +
+            "T" +
+            f(this.getUTCHours()) +
+            ":" +
+            f(this.getUTCMinutes()) +
+            ":" +
+            f(this.getUTCSeconds()) +
+            "Z"
+        : null;
+    };
+
+    Boolean.prototype.toJSON = this_value;
+    Number.prototype.toJSON = this_value;
+    String.prototype.toJSON = this_value;
+  }
+
+  var gap;
+  var indent;
+  var meta;
+  var rep;
+
+  function quote(string) {
+    // If the string contains no control characters, no quote characters, and no
+    // backslash characters, then we can safely slap some quotes around it.
+    // Otherwise we must also replace the offending characters with safe escape
+    // sequences.
+
+    rx_escapable.lastIndex = 0;
+    return rx_escapable.test(string)
+      ? '"' +
+          string.replace(rx_escapable, function (a) {
+            var c = meta[a];
+            return typeof c === "string"
+              ? c
+              : "\\u" + ("0000" + a.charCodeAt(0).toString(16)).slice(-4);
+          }) +
+          '"'
+      : '"' + string + '"';
+  }
+
+  function str(key, holder) {
+    // Produce a string from holder[key].
+
+    var i; // The loop counter.
+    var k; // The member key.
+    var v; // The member value.
+    var length;
+    var mind = gap;
+    var partial;
+    var value = holder[key];
+
+    // If the value has a toJSON method, call it to obtain a replacement value.
+
+    if (
+      value &&
+      typeof value === "object" &&
+      typeof value.toJSON === "function"
+    ) {
+      value = value.toJSON(key);
     }
 
-    function this_value() {
-        return this.valueOf();
+    // If we were called with a replacer function, then call the replacer to
+    // obtain a replacement value.
+
+    if (typeof rep === "function") {
+      value = rep.call(holder, key, value);
     }
 
-    if (typeof Date.prototype.toJSON !== "function") {
-        Date.prototype.toJSON = function() {
-            return isFinite(this.valueOf()) ?
-                this.getUTCFullYear() +
-                "-" +
-                f(this.getUTCMonth() + 1) +
-                "-" +
-                f(this.getUTCDate()) +
-                "T" +
-                f(this.getUTCHours()) +
-                ":" +
-                f(this.getUTCMinutes()) +
-                ":" +
-                f(this.getUTCSeconds()) +
-                "Z" :
-                null;
-        };
+    // What happens next depends on the value's type.
 
-        Boolean.prototype.toJSON = this_value;
-        Number.prototype.toJSON = this_value;
-        String.prototype.toJSON = this_value;
+    switch (typeof value) {
+      case "string":
+        return quote(value);
+
+      case "number":
+        // JSON numbers must be finite. Encode non-finite numbers as null.
+
+        return isFinite(value) ? String(value) : "null";
+
+      case "boolean":
+      case "null":
+        // If the value is a boolean or null, convert it to a string. Note:
+        // typeof null does not produce "null". The case is included here in
+        // the remote chance that this gets fixed someday.
+
+        return String(value);
+
+      // If the type is "object", we might be dealing with an object or an array or
+      // null.
+
+      case "object":
+        // Due to a specification blunder in ECMAScript, typeof null is "object",
+        // so watch out for that case.
+
+        if (!value) {
+          return "null";
+        }
+
+        // Make an array to hold the partial results of stringifying this object value.
+
+        gap += indent;
+        partial = [];
+
+        // Is the value an array?
+
+        if (Object.prototype.toString.apply(value) === "[object Array]") {
+          // The value is an array. Stringify every element. Use null as a placeholder
+          // for non-JSON values.
+
+          length = value.length;
+          for (i = 0; i < length; i += 1) {
+            partial[i] = str(i, value) || "null";
+          }
+
+          // Join all of the elements together, separated with commas, and wrap them in
+          // brackets.
+
+          v =
+            partial.length === 0
+              ? "[]"
+              : gap
+              ? "[\n" + gap + partial.join(",\n" + gap) + "\n" + mind + "]"
+              : "[" + partial.join(",") + "]";
+          gap = mind;
+          return v;
+        }
+
+        // If the replacer is an array, use it to select the members to be stringified.
+
+        if (rep && typeof rep === "object") {
+          length = rep.length;
+          for (i = 0; i < length; i += 1) {
+            if (typeof rep[i] === "string") {
+              k = rep[i];
+              v = str(k, value);
+              if (v) {
+                partial.push(quote(k) + (gap ? ": " : ":") + v);
+              }
+            }
+          }
+        } else {
+          // Otherwise, iterate through all of the keys in the object.
+
+          for (k in value) {
+            if (Object.prototype.hasOwnProperty.call(value, k)) {
+              v = str(k, value);
+              if (v) {
+                partial.push(quote(k) + (gap ? ": " : ":") + v);
+              }
+            }
+          }
+        }
+
+        // Join all of the member texts together, separated with commas,
+        // and wrap them in braces.
+
+        v =
+          partial.length === 0
+            ? "{}"
+            : gap
+            ? "{\n" + gap + partial.join(",\n" + gap) + "\n" + mind + "}"
+            : "{" + partial.join(",") + "}";
+        gap = mind;
+        return v;
     }
+  }
 
-    var gap;
-    var indent;
-    var meta;
-    var rep;
+  // If the JSON object does not yet have a stringify method, give it one.
 
-    function quote(string) {
-        // If the string contains no control characters, no quote characters, and no
-        // backslash characters, then we can safely slap some quotes around it.
-        // Otherwise we must also replace the offending characters with safe escape
-        // sequences.
+  if (typeof JSON.stringify !== "function") {
+    meta = {
+      // table of character substitutions
+      "\b": "\\b",
+      "\t": "\\t",
+      "\n": "\\n",
+      "\f": "\\f",
+      "\r": "\\r",
+      '"': '\\"',
+      "\\": "\\\\",
+    };
+    JSON.stringify = function (value, replacer, space) {
+      // The stringify method takes a value and an optional replacer, and an optional
+      // space parameter, and returns a JSON text. The replacer can be a function
+      // that can replace values, or an array of strings that will select the keys.
+      // A default replacer method can be provided. Use of the space parameter can
+      // produce text that is more easily readable.
 
-        rx_escapable.lastIndex = 0;
-        return rx_escapable.test(string) ?
-            '"' +
-            string.replace(rx_escapable, function(a) {
-                var c = meta[a];
-                return typeof c === "string" ?
-                    c :
-                    "\\u" + ("0000" + a.charCodeAt(0).toString(16)).slice(-4);
-            }) +
-            '"' :
-            '"' + string + '"';
-    }
+      var i;
+      gap = "";
+      indent = "";
 
-    function str(key, holder) {
-        // Produce a string from holder[key].
+      // If the space parameter is a number, make an indent string containing that
+      // many spaces.
 
-        var i; // The loop counter.
-        var k; // The member key.
-        var v; // The member value.
-        var length;
-        var mind = gap;
-        var partial;
+      if (typeof space === "number") {
+        for (i = 0; i < space; i += 1) {
+          indent += " ";
+        }
+
+        // If the space parameter is a string, it will be used as the indent string.
+      } else if (typeof space === "string") {
+        indent = space;
+      }
+
+      // If there is a replacer, it must be a function or an array.
+      // Otherwise, throw an error.
+
+      rep = replacer;
+      if (
+        replacer &&
+        typeof replacer !== "function" &&
+        (typeof replacer !== "object" || typeof replacer.length !== "number")
+      ) {
+        throw new Error("JSON.stringify");
+      }
+
+      // Make a fake root object containing our value under the key of "".
+      // Return the result of stringifying the value.
+
+      return str("", { "": value });
+    };
+  }
+
+  // If the JSON object does not yet have a parse method, give it one.
+
+  if (typeof JSON.parse !== "function") {
+    JSON.parse = function (text, reviver) {
+      // The parse method takes a text and an optional reviver function, and returns
+      // a JavaScript value if the text is a valid JSON text.
+
+      var j;
+
+      function walk(holder, key) {
+        // The walk method is used to recursively walk the resulting structure so
+        // that modifications can be made.
+
+        var k;
+        var v;
         var value = holder[key];
-
-        // If the value has a toJSON method, call it to obtain a replacement value.
-
-        if (
-            value &&
-            typeof value === "object" &&
-            typeof value.toJSON === "function"
-        ) {
-            value = value.toJSON(key);
+        if (value && typeof value === "object") {
+          for (k in value) {
+            if (Object.prototype.hasOwnProperty.call(value, k)) {
+              v = walk(value, k);
+              if (v !== undefined) {
+                value[k] = v;
+              } else {
+                delete value[k];
+              }
+            }
+          }
         }
+        return reviver.call(holder, key, value);
+      }
 
-        // If we were called with a replacer function, then call the replacer to
-        // obtain a replacement value.
+      // Parsing happens in four stages. In the first stage, we replace certain
+      // Unicode characters with escape sequences. JavaScript handles many characters
+      // incorrectly, either silently deleting them, or treating them as line endings.
 
-        if (typeof rep === "function") {
-            value = rep.call(holder, key, value);
-        }
+      text = String(text);
+      rx_dangerous.lastIndex = 0;
+      if (rx_dangerous.test(text)) {
+        text = text.replace(rx_dangerous, function (a) {
+          return "\\u" + ("0000" + a.charCodeAt(0).toString(16)).slice(-4);
+        });
+      }
 
-        // What happens next depends on the value's type.
+      // In the second stage, we run the text against regular expressions that look
+      // for non-JSON patterns. We are especially concerned with "()" and "new"
+      // because they can cause invocation, and "=" because it can cause mutation.
+      // But just to be safe, we want to reject all unexpected forms.
 
-        switch (typeof value) {
-            case "string":
-                return quote(value);
+      // We split the second stage into 4 regexp operations in order to work around
+      // crippling inefficiencies in IE's and Safari's regexp engines. First we
+      // replace the JSON backslash pairs with "@" (a non-JSON character). Second, we
+      // replace all simple value tokens with "]" characters. Third, we delete all
+      // open brackets that follow a colon or comma or that begin the text. Finally,
+      // we look to see that the remaining characters are only whitespace or "]" or
+      // "," or ":" or "{" or "}". If that is so, then the text is safe for eval.
 
-            case "number":
-                // JSON numbers must be finite. Encode non-finite numbers as null.
+      if (
+        rx_one.test(
+          text.replace(rx_two, "@").replace(rx_three, "]").replace(rx_four, "")
+        )
+      ) {
+        // In the third stage we use the eval function to compile the text into a
+        // JavaScript structure. The "{" operator is subject to a syntactic ambiguity
+        // in JavaScript: it can begin a block or an object literal. We wrap the text
+        // in parens to eliminate the ambiguity.
 
-                return isFinite(value) ? String(value) : "null";
+        j = eval("(" + text + ")");
 
-            case "boolean":
-            case "null":
-                // If the value is a boolean or null, convert it to a string. Note:
-                // typeof null does not produce "null". The case is included here in
-                // the remote chance that this gets fixed someday.
+        // In the optional fourth stage, we recursively walk the new structure, passing
+        // each name/value pair to a reviver function for possible transformation.
 
-                return String(value);
+        return typeof reviver === "function" ? walk({ "": j }, "") : j;
+      }
 
-                // If the type is "object", we might be dealing with an object or an array or
-                // null.
+      // If the text is not JSON parseable, then a SyntaxError is thrown.
 
-            case "object":
-                // Due to a specification blunder in ECMAScript, typeof null is "object",
-                // so watch out for that case.
-
-                if (!value) {
-                    return "null";
-                }
-
-                // Make an array to hold the partial results of stringifying this object value.
-
-                gap += indent;
-                partial = [];
-
-                // Is the value an array?
-
-                if (Object.prototype.toString.apply(value) === "[object Array]") {
-                    // The value is an array. Stringify every element. Use null as a placeholder
-                    // for non-JSON values.
-
-                    length = value.length;
-                    for (i = 0; i < length; i += 1) {
-                        partial[i] = str(i, value) || "null";
-                    }
-
-                    // Join all of the elements together, separated with commas, and wrap them in
-                    // brackets.
-
-                    v =
-                        partial.length === 0 ?
-                        "[]" :
-                        gap ?
-                        "[\n" + gap + partial.join(",\n" + gap) + "\n" + mind + "]" :
-                        "[" + partial.join(",") + "]";
-                    gap = mind;
-                    return v;
-                }
-
-                // If the replacer is an array, use it to select the members to be stringified.
-
-                if (rep && typeof rep === "object") {
-                    length = rep.length;
-                    for (i = 0; i < length; i += 1) {
-                        if (typeof rep[i] === "string") {
-                            k = rep[i];
-                            v = str(k, value);
-                            if (v) {
-                                partial.push(quote(k) + (gap ? ": " : ":") + v);
-                            }
-                        }
-                    }
-                } else {
-                    // Otherwise, iterate through all of the keys in the object.
-
-                    for (k in value) {
-                        if (Object.prototype.hasOwnProperty.call(value, k)) {
-                            v = str(k, value);
-                            if (v) {
-                                partial.push(quote(k) + (gap ? ": " : ":") + v);
-                            }
-                        }
-                    }
-                }
-
-                // Join all of the member texts together, separated with commas,
-                // and wrap them in braces.
-
-                v =
-                    partial.length === 0 ?
-                    "{}" :
-                    gap ?
-                    "{\n" + gap + partial.join(",\n" + gap) + "\n" + mind + "}" :
-                    "{" + partial.join(",") + "}";
-                gap = mind;
-                return v;
-        }
-    }
-
-    // If the JSON object does not yet have a stringify method, give it one.
-
-    if (typeof JSON.stringify !== "function") {
-        meta = {
-            // table of character substitutions
-            "\b": "\\b",
-            "\t": "\\t",
-            "\n": "\\n",
-            "\f": "\\f",
-            "\r": "\\r",
-            '"': '\\"',
-            "\\": "\\\\",
-        };
-        JSON.stringify = function(value, replacer, space) {
-            // The stringify method takes a value and an optional replacer, and an optional
-            // space parameter, and returns a JSON text. The replacer can be a function
-            // that can replace values, or an array of strings that will select the keys.
-            // A default replacer method can be provided. Use of the space parameter can
-            // produce text that is more easily readable.
-
-            var i;
-            gap = "";
-            indent = "";
-
-            // If the space parameter is a number, make an indent string containing that
-            // many spaces.
-
-            if (typeof space === "number") {
-                for (i = 0; i < space; i += 1) {
-                    indent += " ";
-                }
-
-                // If the space parameter is a string, it will be used as the indent string.
-            } else if (typeof space === "string") {
-                indent = space;
-            }
-
-            // If there is a replacer, it must be a function or an array.
-            // Otherwise, throw an error.
-
-            rep = replacer;
-            if (
-                replacer &&
-                typeof replacer !== "function" &&
-                (typeof replacer !== "object" || typeof replacer.length !== "number")
-            ) {
-                throw new Error("JSON.stringify");
-            }
-
-            // Make a fake root object containing our value under the key of "".
-            // Return the result of stringifying the value.
-
-            return str("", {
-                "": value
-            });
-        };
-    }
-
-    // If the JSON object does not yet have a parse method, give it one.
-
-    if (typeof JSON.parse !== "function") {
-        JSON.parse = function(text, reviver) {
-            // The parse method takes a text and an optional reviver function, and returns
-            // a JavaScript value if the text is a valid JSON text.
-
-            var j;
-
-            function walk(holder, key) {
-                // The walk method is used to recursively walk the resulting structure so
-                // that modifications can be made.
-
-                var k;
-                var v;
-                var value = holder[key];
-                if (value && typeof value === "object") {
-                    for (k in value) {
-                        if (Object.prototype.hasOwnProperty.call(value, k)) {
-                            v = walk(value, k);
-                            if (v !== undefined) {
-                                value[k] = v;
-                            } else {
-                                delete value[k];
-                            }
-                        }
-                    }
-                }
-                return reviver.call(holder, key, value);
-            }
-
-            // Parsing happens in four stages. In the first stage, we replace certain
-            // Unicode characters with escape sequences. JavaScript handles many characters
-            // incorrectly, either silently deleting them, or treating them as line endings.
-
-            text = String(text);
-            rx_dangerous.lastIndex = 0;
-            if (rx_dangerous.test(text)) {
-                text = text.replace(rx_dangerous, function(a) {
-                    return "\\u" + ("0000" + a.charCodeAt(0).toString(16)).slice(-4);
-                });
-            }
-
-            // In the second stage, we run the text against regular expressions that look
-            // for non-JSON patterns. We are especially concerned with "()" and "new"
-            // because they can cause invocation, and "=" because it can cause mutation.
-            // But just to be safe, we want to reject all unexpected forms.
-
-            // We split the second stage into 4 regexp operations in order to work around
-            // crippling inefficiencies in IE's and Safari's regexp engines. First we
-            // replace the JSON backslash pairs with "@" (a non-JSON character). Second, we
-            // replace all simple value tokens with "]" characters. Third, we delete all
-            // open brackets that follow a colon or comma or that begin the text. Finally,
-            // we look to see that the remaining characters are only whitespace or "]" or
-            // "," or ":" or "{" or "}". If that is so, then the text is safe for eval.
-
-            if (
-                rx_one.test(
-                    text.replace(rx_two, "@").replace(rx_three, "]").replace(rx_four, "")
-                )
-            ) {
-                // In the third stage we use the eval function to compile the text into a
-                // JavaScript structure. The "{" operator is subject to a syntactic ambiguity
-                // in JavaScript: it can begin a block or an object literal. We wrap the text
-                // in parens to eliminate the ambiguity.
-
-                j = eval("(" + text + ")");
-
-                // In the optional fourth stage, we recursively walk the new structure, passing
-                // each name/value pair to a reviver function for possible transformation.
-
-                return typeof reviver === "function" ? walk({
-                    "": j
-                }, "") : j;
-            }
-
-            // If the text is not JSON parseable, then a SyntaxError is thrown.
-
-            throw new SyntaxError("JSON.parse");
-        };
-    }
+      throw new SyntaxError("JSON.parse");
+    };
+  }
 })();
 
 
@@ -2564,3 +2635,4 @@ if (isSecurityPrefSet()) {
         this.layout.resize();
     };
 }
+

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -445,7 +445,7 @@ function getFontsFromFileLegacy() {
  **/
 function generateFontReferences(fontPaths) {
     // Create a temp folder where all used fonts get gathered
-    var _tempFontsFolder = dcUtil.normPath(Folder.temp.fsName + '/' + "tempFonts");
+    var _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
     var formattedFontsPaths = [];
     var tempFontPath = new Folder(_tempFontsFolder);
     if (!tempFontPath.exists) {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -172,7 +172,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     function generateBundle() {
         // create the job bundle folder
         var bundleRoot = new Folder(
-            Folder.temp.fsName + "/DeadlineCloudAESubmission"
+            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
         ); //forward slash works on all operating systems
         recursiveDelete(bundleRoot);
         bundleRoot.create();
@@ -208,7 +208,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     var bundle = generateBundle();
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
-    var logFile = new File(Folder.temp.fsName + "/submitter_output.log");
+    var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
     logFile.open("w"); // Erase contents of active log file
     logFile.close();
     var submitScriptContents = "";
@@ -216,11 +216,11 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     var cmd = "";
     if ($.os.toString().slice(0, 7) === "Windows") {
         var tempBatFile = new File(
-            Folder.temp.fsName + "/DeadlineCloudAESubmission.bat"
+            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission.bat"
         );
         cmd =
             'deadline bundle gui-submit \"' + bundle.fsName + '\" --output json --install-gui --submitter-name \"After Effects\"';
-        submitScriptContents = cmd + " > " + Folder.temp.fsName + "\\submitter_output.log 2>&1";
+        submitScriptContents = cmd + " > " + dcUtil.getTempFolder() + "\\submitter_output.log 2>&1";
         tempBatFile.open("w");
         tempBatFile.writeln("@echo off");
         tempBatFile.writeln("echo:"); //this empty print statement is required to circumvent a weird bug


### PR DESCRIPTION
Fixes: an issue where submissions were failing because access to the temp folder was restricted.

### What was the problem/requirement? (What/Why)
Some users didn't have access to the directory that Folder.temp.fsName pointed to. This meant that their submitter couldn't write the required job bundle files.

### What was the solution? (How)
I added a utility function that checks folder permissions and automatically falls back to alternate temp folder paths. I then made sure to replace instances of Folder.temp with the utility function.

### What is the impact of this change?
Submissions are more robust.

### How was this change tested?
I ran submissions on my own farm.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

### Was this change documented?

None of this really needs to be updated because the user experience doesn't change except that some people who were unable to render before can now render.

### Is this a breaking change?

No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
