### PR TITLE
fix: repaired getTempFolder() function logic

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -345,7 +345,7 @@ function __generateUtil() {
         }
 
         //Build list of alternate paths to try
-        var altPaths = [Folder.temp.fsName];
+        const altPaths = [Folder.temp.fsName];
         var testFileSuffix;
         if (system.osName == "MacOS") {
             altPaths.push("~/.deadline/DeadlineCloudAETemp");
@@ -358,8 +358,8 @@ function __generateUtil() {
         }
 
         // Test every path in our list by creating a test file
-        for (var i = 0; i < altPaths.length; i++) {
-            var folder = new Folder(altPaths[i]);
+        for (var altPath of altPaths) {
+            const folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();
@@ -369,13 +369,13 @@ function __generateUtil() {
 
             // List all files and check for errors
             // Not having list permissions is a common source of errors
-            var existingFiles = folder.getFiles();
+            folder.getFiles();
             if (folder.error) {
                 continue;
             }
 
             // Create and write to a test file to make sure we have write permissions
-            var file = new File(folder.fsName + testFileSuffix);
+            const file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
             file.close();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -358,8 +358,8 @@ function __generateUtil() {
         }
 
         // Test every path in our list by creating a test file
-        for (var altPath of altPaths) {
-            const folder = new Folder(altPaths[i]);
+        for (var i = 0; i < altPaths.length; i++) {
+            var folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -357,29 +357,24 @@ function __generateUtil() {
             testFileSuffix = "\\testFile.txt";
         }
 
-        //Test every path in our list by creating a test file
-        for (var altPath in altPaths) {
-            var folder = new Folder(altPath);
+        // Test every path in our list by creating a test file
+        for (var i = 0; i < altPaths.length; i++) {
+            var folder = new Folder(altPaths[i]);
 
-            //Create the path if it does not already exist
+            // Create the path if it does not already exist
             folder.create();
-            if (folder.exists) {
+            if (!folder.exists) {
                 continue;
             }
 
-            //List all files and check for errors
-            //Not having list permissions is a common source of errors
+            // List all files and check for errors
+            // Not having list permissions is a common source of errors
             var existingFiles = folder.getFiles();
-            if (!folder.error) {
+            if (folder.error) {
                 continue;
             }
 
-            //Delete any existing files in the path
-            for (var existingFile in existingFiles) {
-                existingFile.remove();
-            }
-
-            //Create and write to a test file to make sure we have write permissions
+            // Create and write to a test file to make sure we have write permissions
             var file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
@@ -394,11 +389,11 @@ function __generateUtil() {
             break;
         }
 
-        //If no alternate path was found, alert the user and return the default temp path
+        // If no alternate path was found, alert the user and return the default temp path
         if (_cachedTempFolder == "") {
             adcAlert("Error: No valid temporary directory found. Check permissions to one of these paths: " + altPaths.join(", "));
 
-            //we don't want to cache the result on a failure, just return the default value
+            // We don't want to cache the result on a failure, just return the default value
             return Folder.temp.fsName;
         }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -354,8 +354,8 @@ function __generateUtil() {
         }
 
         // Test every path in our list by creating a test file
-        for (var altPath of altPaths) {
-            const folder = new Folder(altPaths[i]);
+        for (var i = 0; i < altPaths.length; i++) {
+            var folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -353,29 +353,24 @@ function __generateUtil() {
             testFileSuffix = "\\testFile.txt";
         }
 
-        //Test every path in our list by creating a test file
-        for (var altPath in altPaths) {
-            var folder = new Folder(altPath);
+        // Test every path in our list by creating a test file
+        for (var i = 0; i < altPaths.length; i++) {
+            var folder = new Folder(altPaths[i]);
 
-            //Create the path if it does not already exist
+            // Create the path if it does not already exist
             folder.create();
-            if (folder.exists) {
+            if (!folder.exists) {
                 continue;
             }
 
-            //List all files and check for errors
-            //Not having list permissions is a common source of errors
+            // List all files and check for errors
+            // Not having list permissions is a common source of errors
             var existingFiles = folder.getFiles();
-            if (!folder.error) {
+            if (folder.error) {
                 continue;
             }
 
-            //Delete any existing files in the path
-            for (var existingFile in existingFiles) {
-                existingFile.remove();
-            }
-
-            //Create and write to a test file to make sure we have write permissions
+            // Create and write to a test file to make sure we have write permissions
             var file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
@@ -390,11 +385,11 @@ function __generateUtil() {
             break;
         }
 
-        //If no alternate path was found, alert the user and return the default temp path
+        // If no alternate path was found, alert the user and return the default temp path
         if (_cachedTempFolder == "") {
             adcAlert("Error: No valid temporary directory found. Check permissions to one of these paths: " + altPaths.join(", "));
 
-            //we don't want to cache the result on a failure, just return the default value
+            // We don't want to cache the result on a failure, just return the default value
             return Folder.temp.fsName;
         }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -341,7 +341,7 @@ function __generateUtil() {
         }
 
         //Build list of alternate paths to try
-        var altPaths = [Folder.temp.fsName];
+        const altPaths = [Folder.temp.fsName];
         var testFileSuffix;
         if (system.osName == "MacOS") {
             altPaths.push("~/.deadline/DeadlineCloudAETemp");
@@ -354,8 +354,8 @@ function __generateUtil() {
         }
 
         // Test every path in our list by creating a test file
-        for (var i = 0; i < altPaths.length; i++) {
-            var folder = new Folder(altPaths[i]);
+        for (var altPath of altPaths) {
+            const folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();
@@ -365,13 +365,13 @@ function __generateUtil() {
 
             // List all files and check for errors
             // Not having list permissions is a common source of errors
-            var existingFiles = folder.getFiles();
+            folder.getFiles();
             if (folder.error) {
                 continue;
             }
 
             // Create and write to a test file to make sure we have write permissions
-            var file = new File(folder.fsName + testFileSuffix);
+            const file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
             file.close();


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/196, errors with submitter not working

### What was the problem/requirement? (What/Why)
Recently we rolled out a change to support alternative temp folders to use in case the submitter user is using a hardened machine with locked down permissions. However, there were a collection of bugs in this code change that were not caught and needed to be fixed.

### What was the solution? (How)
- Fix the for-looping logic since it should be `for-of` not `for-in` for array-based looping.
- Fix the incorrect `if` check on folder error
- Fix the incorrect `if` check on folder creation
- Remove code to clear the contents of the temp folder, no need to do this every time. 

### What is the impact of this change?
Restores ability to submit jobs with the AE submitter.

### How was this change tested?
- [x] AE 25 on Mac
- [x] AE 24 on Mac
- [x] AE 25 on Windows
- [x] AE 24 on Windows

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A

### Was this change documented?
No, no need.

### Is this a breaking change?
No, this is a fix.


---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
