### PR TITLE
fix: include setting minor version for CondaPackages field and added version mismatch warnings

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,6 +92,9 @@ Make sure to right click the new files in the dist folder in VSCode and do "Form
 
 Then reopen the submitter panel from the application to test your change.
 
+#### Version Support
+If you are adding support for a new Conda package for AE, add it to the list of allowlisted AE versions supported in Deadline Cloud SMF located in the SUPPORTED_VERSIONS variable in Utils.jsx.
+
 ## AE Installer Environment Setup
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ To install fonts for non-Adobe apps in Creative Cloud:
 
 ## Setting up After Effects with your Deadline Cloud Farm
 
-After Effects 24.6.4 and 25.1 conda packages are now available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
+After Effects 24.6.4, 25.1, and 25.2.2 conda packages are now available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
 [the instruction](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html).
 You can also use After Effects conda recipe in
 [deadline-cloud-sample package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-25.0)

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -764,7 +764,7 @@ function __generateUtil() {
 
     function getCompatibleAEVersion() {
         /* Return compatible After Effects version for job submission.
-         * Warns if current version is not officially supported.
+         * Warns if current version is not officially supported on service-managed fleets.
          * Returns the version as float.
          */
         const currentVersion = getAEVersion();
@@ -776,7 +776,7 @@ function __generateUtil() {
         // Show warning if version is not supported
         adcAlert(
             "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported. Supported versions are: 24.6, 25.1, and 25.2. " +
+            " is not officially supported on service-managed fleets. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
             "This may result in compatibility issues or failed jobs.",
             false
         );

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3,6 +3,7 @@
 // Please change the source files and regenerate this file instead.
 
 var scriptFolder = Folder.current.fsName;
+const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
 
 function readFile(filePath) {
     var f = new File(filePath);
@@ -756,9 +757,31 @@ function __generateUtil() {
 
     function getAEVersion() {
         /* Return After Effects version as float. */
-        var versionAsString = app.version.substring(0, 4);
-        var version = parseFloat(versionAsString);
+        const versionAsString = app.version.substring(0, 4);
+        const version = parseFloat(versionAsString);
         return version
+    }
+
+    function getCompatibleAEVersion() {
+        /* Return compatible After Effects version for job submission.
+         * Warns if current version is not officially supported.
+         * Returns the version as float.
+         */
+        const currentVersion = getAEVersion();
+
+        if (SUPPORTED_VERSIONS.indexOf(currentVersion) !== -1) {
+            return currentVersion;
+        }
+
+        // Show warning if version is not supported
+        adcAlert(
+            "Warning: Your After Effects version " + currentVersion +
+            " is not officially supported. Supported versions are: 24.6, 25.1, and 25.2. " +
+            "This may result in compatibility issues or failed jobs.",
+            false
+        );
+
+        return Math.floor(currentVersion);
     }
 
     return {
@@ -794,6 +817,7 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
+        "getCompatibleAEVersion": getCompatibleAEVersion,
         "getTempFolder": getTempFolder
     }
 }
@@ -1620,8 +1644,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
             logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
         }
-        const aftereffectsVersion = app.version[0] + app.version[1];
-        logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
+        const aftereffectsVersion = dcUtil.getCompatibleAEVersion();
+        logger.debug("The compatible version of After Effects is " + aftereffectsVersion, submitBundleFile);
 
         var paramDefCopy = templateObject.parameterDefinitions;
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -151,8 +151,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
             logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
         }
-        const aftereffectsVersion = app.version[0] + app.version[1];
-        logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
+        const aftereffectsVersion = dcUtil.getCompatibleAEVersion();
+        logger.debug("The compatible version of After Effects is " + aftereffectsVersion, submitBundleFile);
 
         var paramDefCopy = templateObject.parameterDefinitions;
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -760,7 +760,7 @@ function __generateUtil() {
 
     function getCompatibleAEVersion() {
         /* Return compatible After Effects version for job submission.
-         * Warns if current version is not officially supported.
+         * Warns if current version is not officially supported on service-managed fleets.
          * Returns the version as float.
          */
         const currentVersion = getAEVersion();
@@ -772,7 +772,7 @@ function __generateUtil() {
         // Show warning if version is not supported
         adcAlert(
             "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported. Supported versions are: 24.6, 25.1, and 25.2. " +
+            " is not officially supported on service-managed fleets. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
             "This may result in compatibility issues or failed jobs.",
             false
         );

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1,4 +1,5 @@
 var scriptFolder = Folder.current.fsName;
+const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
 
 function readFile(filePath) {
     var f = new File(filePath);
@@ -752,9 +753,31 @@ function __generateUtil() {
 
     function getAEVersion() {
         /* Return After Effects version as float. */
-        var versionAsString = app.version.substring(0, 4);
-        var version = parseFloat(versionAsString);
+        const versionAsString = app.version.substring(0, 4);
+        const version = parseFloat(versionAsString);
         return version
+    }
+
+    function getCompatibleAEVersion() {
+        /* Return compatible After Effects version for job submission.
+         * Warns if current version is not officially supported.
+         * Returns the version as float.
+         */
+        const currentVersion = getAEVersion();
+
+        if (SUPPORTED_VERSIONS.indexOf(currentVersion) !== -1) {
+            return currentVersion;
+        }
+
+        // Show warning if version is not supported
+        adcAlert(
+            "Warning: Your After Effects version " + currentVersion +
+            " is not officially supported. Supported versions are: 24.6, 25.1, and 25.2. " +
+            "This may result in compatibility issues or failed jobs.",
+            false
+        );
+
+        return Math.floor(currentVersion);
     }
 
     return {
@@ -790,6 +813,7 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
+        "getCompatibleAEVersion": getCompatibleAEVersion,
         "getTempFolder": getTempFolder
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/203

### What was the problem/requirement? (What/Why)
If a customer submits a job from AE 25.1 locally to their service-managed fleet, the AE version is defaulting to 25, which means our fleet will get the latest conda package of AE we have, which is AE 25.2, which results in a version mismatch and causes renders to fail.

### What was the solution? (How)
Add minor version to the conda package parameter field to prevent version mismatch. If the customer has a version of AE we don't support, we just default to the major version setting and issue a warning.

### What is the impact of this change?
Removes the annoying experience of setting the minor version every time an artist wants to submit a job.

### How was this change tested?

On MacOS, I attempted submitting jobs from AE 24.6, AE 25.1, AE 25.2 and AE 25.3. I verified that the minor version was set correctly for all of these versions except 25.3, where I got a warning message and the version just defaulted to 25.

Supported version submissions:
<img width="581" alt="Screenshot 2025-06-19 at 11 06 03 AM" src="https://github.com/user-attachments/assets/e0cf6f23-d0d6-4d5c-8146-b4e8b519136b" />
<img width="537" alt="Screenshot 2025-06-19 at 11 08 53 AM" src="https://github.com/user-attachments/assets/72044868-9da7-4b94-9214-bc388175950d" />
<img width="557" alt="Screenshot 2025-06-19 at 4 02 19 PM" src="https://github.com/user-attachments/assets/6cbefafe-7acf-4360-8a9b-b05c63aed1fb" />


And here's the AE 25.3 submission, which we don't support:
<img width="374" alt="Screenshot 2025-06-19 at 3 42 45 PM" src="https://github.com/user-attachments/assets/1abff620-c7f5-40a3-9757-069b668070f4" />
<img width="540" alt="Screenshot 2025-06-19 at 3 42 56 PM" src="https://github.com/user-attachments/assets/3e6fc70d-e319-4d22-a08f-1db1e1b953fb" />

Then I did the same on Windows for AE 25.2 and AE 25.3 (skipped 24.6 and 25.1 because it would've been redundant) and it worked the same way

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

### Was this change documented?

Yes, in DEVELOPMENT.md

### Is this a breaking change?
Nope


---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
