### PR TITLE
feat!: Support multiple composition submissions in one job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ node_modules
 .idea
 *.code-workspace
 .vscode
+jsconfig.json
 
 # macOS
 .DS_Store

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1810,7 +1810,7 @@ if (typeof submitBundleFile == 'undefined') {
     const submitBundleFile = "SubmitButton.jsx";
 }
 
-// Validate that the RenderQueueIndex for each selectionItem is still valid
+// Validate that the RenderQueueIndex for each selectionItem is still valid and update list if they're out of date
 function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
     if (
         renderQueueIndex < 1 ||

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2131,9 +2131,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
 
         // Calculate frame range using the utility function
-        const frameRange = dcUtil.calculateFrameRange(renderQueueItem);
-        const startFrame = frameRange.startFrame;
-        const endFrame = frameRange.endFrame;
+        var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+        var startFrame = frameRange.startFrame;
+        var endFrame = frameRange.endFrame;
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3196,8 +3196,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
-        newList.preferredSize.height = 400
-        newList.preferredSize.width = 500
+        newList.preferredSize.height = 200;
+        newList.preferredSize.width = 500;
 
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1944,7 +1944,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex,
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
-//      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
+//      Replacing the parameters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
 function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3243,11 +3243,6 @@ function buildUI(thisObj) {
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
-            const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
-            var maxCpuUsagePercentage = undefined;
-            if (mfrCheckBox.value) {
-                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
-            }
             if (list.selection === null) {
                 return;
             }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1054,8 +1054,11 @@ function UiSettingsState() {
 }
 function UiSettingsStore(name) {
     this.name = name;
+    // _framesPerTask: string
     this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    // _multiFrameRendering: bool
     this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    // _maxCpuUsagePercentage: string
     this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
 
     this.framesPerTask = function () {
@@ -1063,7 +1066,7 @@ function UiSettingsStore(name) {
     }
     this.setFramesPerTask = function (value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
-        this._framesPerTask = value
+        this._framesPerTask = typeof value === "string" ? value : value.toString()
     }
 
     this.multiFrameRendering = function () {
@@ -1071,7 +1074,7 @@ function UiSettingsStore(name) {
     }
     this.setMultiFrameRendering = function (value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
-        this._multiFrameRendering = value
+        this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
     }
 
     this.maxCpuUsagePercentage = function () {
@@ -1079,8 +1082,26 @@ function UiSettingsStore(name) {
     }
     this.setMaxCpuUsagePercentage = function (value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        this._maxCpuUsagePercentage = value
+        this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
+}
+
+UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+    if (!this.settings[compId]) {
+        this.settings[compId] = new UiSettingsStore(compId)
+    }
+    if (framesPerTask === undefined) {
+        framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+    }
+    if (multiFrameRendering === undefined) {
+        multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    }
+    if (maxCpuUsagePercentage === undefined) {
+        maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+    }
+    this.settings[compId].setFramesPerTask(framesPerTask);
+    this.settings[compId].setMultiFrameRendering(multiFrameRendering);
+    this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
 }
 
 UiSettingsState.prototype.get = function(compId) {
@@ -1127,7 +1148,7 @@ function parameterValues(
         },
         {
             name: prefix + "_MultiFrameRendering",
-            value: multiFrameRendering,
+            value: multiFrameRendering === true ? "ON" : "OFF",
         },
     ];
     if (maxCpuUsagePercentage) {
@@ -2686,7 +2707,67 @@ function buildUI(thisObj) {
     const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
-    var list = null;
+
+    const bounds = list == null ? undefined : list.bounds;
+    var list = listGroup.add("listbox", bounds, "", {
+        multiselect: true,
+        numberOfColumns: 4,
+        showHeaders: true,
+        columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
+        columnWidths: [32, 160, 120, 240],
+    });
+    list.preferredSize.height = 400;
+    list.preferredSize.width = 500;
+
+    function onSelectionChange() {
+        const selection = list.selection;
+        if (selection == null) {
+            refreshList(list, uiSettingsState);
+            framesPerTaskTextBox.text = "";
+            return;
+        }
+        submitButton.enabled = true;
+        submitButton.active = false;
+        submitButton.active = true;
+
+        // Disable everything
+        framesPerTaskTextBox.enabled = false
+        mfrCheckBox.enabled = false
+        maxCpuUsagePercentageTextBox.enabled = false
+
+        if (selection.length !== 1) {
+            return
+        }
+        const selectionItem = selection[0]
+        logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
+        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+        framesPerTaskTextBox.enabled = imageOutput
+        mfrCheckBox.enabled = true
+        maxCpuUsagePercentageTextBox.enabled = true
+
+        logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
+        framesPerTaskTextBox.text = selectionItem.subItems[1].text
+
+        const settings = uiSettingsState.get(selectionItem.compId)
+        if (settings === undefined) {
+            logger.warning("Could not find settings for : " + selectionItem.compId);
+            return
+        }
+
+        if (imageOutput === true) {
+            logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+        }
+        logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
+        mfrCheckBox.value = settings.multiFrameRendering()
+        logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
+        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
+
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+    }
+
+    list.onChange = onSelectionChange;
+
     const controlsGroup = root.add("group", undefined, "");
     controlsGroup.orientation = 'column';
     controlsGroup.alignment = ['fill', 'bottom'];
@@ -2727,6 +2808,9 @@ function buildUI(thisObj) {
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
         for (var s = 0; s < list.selection.length; s++) {
+            if (list.selection == null) {
+                return;
+            }
             const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
@@ -3016,12 +3100,15 @@ function buildUI(thisObj) {
     }
 
     updateList();
+    refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
         const selectionItem = list.selection[0]
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
-    refreshButton.onClick = updateList;
+    refreshButton.onClick = function() {
+        refreshList(list, uiSettingsState);
+    }
 
     submitterPanel.layout.layout(true);
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1874,8 +1874,38 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const startFrame = frameRange.startFrame;
     const endFrame = frameRange.endFrame;
 
-    const aftereffectsVersion = app.version[0] + app.version[1];
-    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
+    // Check if warning should be shown
+    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
+    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
+    const currentVersion = dcUtil.getAEVersion();
+
+    // Is this AE version not supported in the deadline-cloud channel?
+    if (SUPPORTED_VERSIONS.indexOf(currentVersion) === -1) {
+        // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
+        if (!ignoreWarning || savedVersion !== currentVersion) {
+            const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
+            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
+            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
+
+            // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            if (confirm(versionMismatchWarningMessage)) {
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
+            } else {
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                return;
+            }
+        } else {
+            logger.debug("Version mismatch already acknowledged, version warning skipped.");
+        }
+        logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
+    }
+
+    var aftereffectsCondaVersion = dcUtil.getAEVersion();
+    if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
+        aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
+    }
+    logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
     /**
      * Generates parameter_values json file

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -926,9 +926,8 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.timeSpanStart * rqi.comp.frameRate));
-        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
-        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+        const startFrame = Number(Math.round(rqi.timeSpanStart * rqi.comp.frameRate));
+        const endFrame = Number(Math.round((rqi.timeSpanStart + rqi.timeSpanDuration) * rqi.comp.frameRate))
         return {
             startFrame: startFrame,
             endFrame: endFrame

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1050,6 +1050,49 @@ var logger = Logger(logFileName, logNormDirectoryPath);
 
 
 
+function UiSettingsState() {
+    this.settings = {}
+}
+function UiSettingsStore(name) {
+    this.name = name;
+    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+
+    this.framesPerTask = function () {
+        return this._framesPerTask
+    }
+    this.setFramesPerTask = function (value) {
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        this._framesPerTask = value
+    }
+
+    this.multiFrameRendering = function () {
+        return this._multiFrameRendering
+    }
+    this.setMultiFrameRendering = function (value) {
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        this._multiFrameRendering = value
+    }
+
+    this.maxCpuUsagePercentage = function () {
+        return this._maxCpuUsagePercentage
+    }
+    this.setMaxCpuUsagePercentage = function (value) {
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
+        this._maxCpuUsagePercentage = value
+    }
+}
+
+UiSettingsState.prototype.get = function(compId) {
+    if (!this.settings[compId]) {
+        this.settings[compId] = new UiSettingsStore(compId)
+    }
+    return this.settings[compId]
+}
+
+
+
 var jobTemplateHelperFile = "JobTemplateHelper.json";
 /**
  * Generates the basic parameterValue file for the job template
@@ -1064,58 +1107,39 @@ function parameterValues(
     endFrame,
     chunkSize,
     multiFrameRendering,
-    maxCpuUsagePercentage
+    maxCpuUsagePercentage,
+    prefix
 ) {
     var parameterValuesList = [{
-            name: "deadline:targetTaskRunStatus",
-            value: "READY",
-        },
-        {
-            name: "deadline:maxFailedTasksCount",
-            value: 20,
-        },
-        {
-            name: "deadline:maxRetriesPerTask",
-            value: 5,
-        },
-        {
-            name: "deadline:priority",
-            value: 50,
-        },
-        {
-            name: "ProjectFile",
-            value: projectFile,
-        },
-        {
-            name: "RenderQueueIndex",
+            name: prefix + "_RenderQueueIndex",
             value: renderQueueIndex,
         },
         {
-            name: "OutputDir",
+            name: prefix + "_OutputDir",
             value: outputDir,
         },
         {
-            name: "OutputFileName",
+            name: prefix + "_OutputFileName",
             value: outputFileName,
         },
         {
-            name: "Frames",
+            name: prefix + "_Frames",
             value: startFrame.toString() + "-" + endFrame.toString(),
         },
         {
-            name: "MultiFrameRendering",
+            name: prefix + "_MultiFrameRendering",
             value: multiFrameRendering,
         },
     ];
     if (maxCpuUsagePercentage) {
         parameterValuesList.push({
-            name: "MaxCpuUsagePercentage",
+            name: prefix + "_MaxCpuUsagePercentage",
             value: maxCpuUsagePercentage,
         })
     }
     if (isImageSeq) {
         parameterValuesList.push({
-            name: "ChunkSize",
+            name: prefix + "_ChunkSize",
             value: chunkSize,
         });
     }
@@ -1558,11 +1582,9 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         return;
     }
 
-    var renderQueueIndex = selection.renderQueueIndex;
-    var rqi;
 
-    // because our panel is updated independently of the render queue, the two may become out of sync
-    // we need to verify that the selection made actually matches what is in the render queue
+// Validate that the RenderQueueIndex for each selectionItem is still valid
+function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
     if (
         renderQueueIndex < 1 ||
         renderQueueIndex > app.project.renderQueue.numItems
@@ -1571,34 +1593,33 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             "Error: Render Queue has changed since last refreshing. Refreshing panel now. Please try again.", true
         );
         updateList();
-        return;
+        return false;
     }
-    rqi = app.project.renderQueue.item(renderQueueIndex);
-    if (rqi == null || rqi.comp.id != selection.compId) {
+
+    var renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+    if (renderQueueItem == null || renderQueueItem.comp.id != selectionItem.compId) {
         adcAlert(
             "Error: Render Queue has changed since last refresh. Refreshing panel now. Please try again.", true
         );
         updateList();
-        return;
+        return false;
     }
-    if (rqi.numOutputModules > 1) {
+    if (renderQueueItem.numOutputModules > 1) {
         adcAlert(
             "Warning: Multiple output modules detected. It is not supported in current submitter. Please raise an issue on Github repo for feature request.", false
         );
-        return;
+        return false;
     }
+    return true;
+}
 
-    //We have a valid selection
-    var confirmation = confirm("Project must be saved before submitting. Continue?");
-    if (!confirmation) {
-        return;
-    } else {
-        app.project.save();
-    }
-    if (app.project.file == null) {
-        // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
-        // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
-        return;
+// Validate that our outputModule is set
+function validateRenderQueueItemOutputModule(renderQueueItem) {
+    // We have already validated that we don't have more than 1 `numOutputModels`
+    var outputModule = renderQueueItem.outputModule(1).file;
+    if (outputModule == null) {
+        adcAlert("Error: Render Queue Item " + renderQueueItem.comp.name + " does not have its output file set", true);
+        return false;
     }
 
     // Check if warning should be shown
@@ -1656,18 +1677,30 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const startFrame = frameRange.startFrame;
     const endFrame = frameRange.endFrame;
 
-    var dependencies = findJobAttachments(rqi.comp); // list of filenames
-    var compName = dcUtil.removeIllegalCharacters(rqi.comp.name);
+    return templateObject
+}
 
-    function generateAssetReferences(bundlePath, sanitizedOutputFolder) {
-        // Write the asset_references.json file
-        var jobAttachmentsContents = jobAttachmentsJson(
-            dependencies,
-            sanitizedOutputFolder
+// Generates the job bundle and copies files from our template source folder into it
+function generateBundle() {
+    // create the job bundle folder
+    var bundleRoot = new Folder(
+        dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
+    ); //forward slash works on all operating systems
+    recursiveDelete(bundleRoot);
+    bundleRoot.create();
+
+    var jobTemplateSourceFolder = new Folder(
+        scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
+    );
+    if (!jobTemplateSourceFolder.exists) {
+        adcAlert(
+            "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
         );
-        var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents, null, 4));
+        return null;
     }
+    recursiveCopy(jobTemplateSourceFolder, bundleRoot);
+    return bundleRoot;
+}
 
     /**
      * Generates parameter_values json file
@@ -1694,29 +1727,15 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             )
         );
     }
+    var stepParametersContents = readFile(path);
+    // Parse the template string to a JSON object
+    var stepParametersObject = JSON.parse(stepParametersContents);
 
-    /**
-     * Generates job template json file
-     **/
-    function generateTemplate(bundlePath, isImageSeq) {
-        // Open the template depending on the output type
-        var path = bundlePath + "/video_template.json";
-        if (isImageSeq) {
-            path = bundlePath + "/image_template.json";
-        }
-        var templateContents = readFile(path);
-        // Parse the template string to a JSON object
-        var templateObject = JSON.parse(templateContents);
-        templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
-        logger.debug("The template name is " + templateObject.name, submitBundleFile);
-        try {
-            if (templateObject.steps[0].name) {
-                templateObject.steps[0].name = compName;
-                logger.debug("The step name is " + templateObject.steps[0].name, submitBundleFile);
-            }
-        } catch (e) {
-            adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
-            logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
+    var updatedParameterDefinitions = []
+    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
+        if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
+            // Don't modify these values
+            continue
         }
         try {
             if (templateObject.steps[0].script && templateObject.steps[0].script.actions) {
@@ -1737,58 +1756,261 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         }
         logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
-        var paramDefCopy = templateObject.parameterDefinitions;
+        updatedParameterDefinitions.push(replacedDefinition)
+    }
+    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
+    return stepParametersObject
+}
 
         for (var i = paramDefCopy.length - 1; i >= 0; i--) {
             if (paramDefCopy[i].name == "CondaPackages") {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsCondaVersion;
             }
         }
-        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4));
-        logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
+    }
+    return jobEnvironmentsObject
+}
+
+/**
+ * Submit the selected render queue item
+ **/
+function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+    const submitBundleFile = "SubmitButton.jsx";
+    var renderQueueItems = []
+
+    // Check to make sure that all of our selection indices are correct
+    for (var i=0;i<selection.length;i++) {
+        var selectionItem = selection[i];
+        var renderQueueIndex = selectionItem.renderQueueIndex;
+        var renderQueueItem;
+
+        // because our panel is updated independently of the render queue, the two may become out of sync
+        // we need to verify that the selection made actually matches what is in the render queue
+        if (!UpdateRenderQueueIndices(renderQueueIndex, selectionItem)) {
+            return;
+        }
+        renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+        renderQueueItems.push([renderQueueItem, renderQueueIndex])
     }
 
-    /**
-     * Generates the job bundle, including template.json, parameter_values.json
-     * and asset_references.json
-     **/
-    function generateBundle() {
-        // create the job bundle folder
-        var bundleRoot = new Folder(
-            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
-        ); //forward slash works on all operating systems
-        recursiveDelete(bundleRoot);
-        bundleRoot.create();
-        var bundlePath = bundleRoot.fsName;
+    // We have valid selections check for saving
+    if (app.project.dirty) {
+        var confirmation = confirm("Project must be saved before submitting. Continue?");
+        if (!confirmation) {
+            return;
+        } else {
+            app.project.save();
+        }
+        if (app.project.file == null) {
+            // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
+            // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
+            return;
+        }
+    }
+
+
+    const aftereffectsVersion = app.version[0] + app.version[1];
+    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
+
+    var bundle = generateBundle();
+    var jobAssetReferences = {
+        assetReferences: {
+            inputs: {
+                directories: [],
+                filenames: [],
+            },
+            outputs: {
+                directories: [],
+            },
+            referencedPaths: [],
+        },
+    };
+    var jobParameterDefinitions = {
+      "parameterDefinitions": [
+        {
+          "name": "ProjectFile",
+          "type": "PATH",
+          "objectType": "FILE",
+          "dataFlow": "IN",
+          "userInterface": {
+            "control": "CHOOSE_INPUT_FILE",
+            "label": "Project file",
+            "groupLabel": "Source",
+            "fileFilters": [
+              {
+                "label": "After Effects project files",
+                "patterns": [
+                  "*.aep",
+                  "*.aepx"
+                ]
+              },
+              {
+                "label": "All Files",
+                "patterns": [
+                  "*"
+                ]
+              }
+            ]
+          },
+          "description": "The After Effects project file to render."
+        },
+        {
+          "name": "JobScriptDir",
+          "description": "Directory containing embedded scripts.",
+          "userInterface": {
+            "control": "HIDDEN"
+          },
+          "type": "PATH",
+          "objectType": "DIRECTORY",
+          "dataFlow": "IN",
+          "default": "scripts"
+        },
+        {
+          "name": "CondaPackages",
+          "type": "STRING",
+          "userInterface": {
+            "control": "HIDDEN"
+          },
+          "default": "aftereffects=" + aftereffectsVersion,
+          "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        }
+      ]
+    }
+    var jobParameterValues = {
+        parameterValues: [
+            {
+                name: "deadline:targetTaskRunStatus",
+                value: "READY",
+            },
+            {
+                name: "deadline:maxFailedTasksCount",
+                value: 20,
+            },
+            {
+                name: "deadline:maxRetriesPerTask",
+                value: 5,
+            },
+            {
+                name: "deadline:priority",
+                value: 50,
+            },
+            {
+                name: "ProjectFile",
+                value: app.project.file.fsName,
+            },
+        ]
+    }
+
+    var template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
+    template.steps = []
+    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
+
+    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
+    var stepOutputFolderParameters = [];
+
+    for (var i=0;i<renderQueueItems.length;i++) {
+        var renderQueueItem = renderQueueItems[i][0];
+        var renderQueueIndex = renderQueueItems[i][1];
+
+        if (!validateRenderQueueItemOutputModule(renderQueueItem)) {
+            return;
+        }
+
+        var stepFramesPerTask = parseInt(selectionSettings.get(selectionItem.compId).framesPerTask() || framesPerTask)
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(selectionItem.compId).maxCpuUsagePercentage() || maxCpuUsagePercentage)
+        var stepMultiFrameRendering = selectionSettings.get(selectionItem.compId).multiFrameRendering() || multiFrameRendering
+
+        var outputModule = renderQueueItem.outputModule(1).file;
+        var outputPath = outputModule.fsName;
+        var outputFile = outputModule.name;
+        var outputFolder = outputModule.parent.fsName;
+
+        logger.debug("OutputPath is: " + outputPath, submitBundleFile);
+        logger.debug("OutputFile is: " + outputFile, submitBundleFile);
+        logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
+
+        var renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
+        var startFrame = Number(
+            timeToFrames(
+                Number(renderSettings["Time Span Start"]),
+                Number(renderSettings["Use this frame rate"])
+            )
+        );
+        var endFrame =
+            Number(
+                timeToFrames(
+                    Number(renderSettings["Time Span End"]),
+                    Number(renderSettings["Use this frame rate"])
+                )
+            ) - 1; // end frame is inclusive so we subtract 1
+
+        var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
+        var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
 
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
-        const outputFileNameNoRegex = getFileNameNoRegex(outputFile);
-        const extension = getFileExtension(outputFileNameNoRegex);
+        var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
+        var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        const isImageSeq = isImageOutput(extension);
+        var isImageSeq = isImageOutput(extension);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
-        generateAssetReferences(bundlePath, sanitizedOutputFolder);
-        generateParameterValues(bundlePath, sanitizedOutputFolder, sanitizedOutputFileName, isImageSeq);
-
-        var jobTemplateSourceFolder = new Folder(
-            scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
-        );
-        if (!jobTemplateSourceFolder.exists) {
-            adcAlert(
-                "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
-            );
-            return null;
+        // Push step asset references
+        for (var d=0;d<dependencies.length;d++) {
+            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
         }
-        recursiveCopy(jobTemplateSourceFolder, bundleRoot);
+        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
 
-        generateTemplate(bundlePath, isImageSeq);
-        return bundleRoot;
+        var parameterValues = generateParameterValuesForStep(
+            compName,
+            renderQueueIndex,
+            sanitizedOutputFolder,
+            sanitizedOutputFileName,
+            isImageSeq,
+            startFrame,
+            endFrame,
+            stepFramesPerTask,
+            stepMultiFrameRendering,
+            stepMaxCpuUsagePercentage
+        )
+
+        for (var p=0;p<parameterValues.parameterValues.length;p++) {
+            if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
+                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
+            }
+        }
+
+        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
+
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName)
+        for (var s=0;s<stepTemplate.steps.length;s++) {
+            template.steps.push(stepTemplate.steps[s])
+        }
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
+        for (var p=0;p<stepParameters.parameterDefinitions.length;p++) {
+            var parameterExists = false;
+            for (var tpd=0;tpd<template.parameterDefinitions.length;tpd++) {
+                var templateParameterDefinition = template.parameterDefinitions[tpd];
+                var stepParameterDefinition = stepParameters.parameterDefinitions[p];
+                if (templateParameterDefinition.name == stepParameterDefinition.name) {
+                    parameterExists = true
+                    break
+                }
+            }
+            if (parameterExists === false) {
+                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p])
+            }
+        }
     }
-    var bundle = generateBundle();
+    var generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
+    template.jobEnvironments = generatedJobEnvironment.jobEnvironments
+
+    writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
+
+    writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));
+    logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
     var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
@@ -1834,7 +2056,6 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
     }
 }
-
 
 
 /**
@@ -2424,6 +2645,8 @@ function buildUI(thisObj) {
         resizable: true
     });
 
+    var uiSettingsState = new UiSettingsState();
+
     var root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
@@ -2473,7 +2696,7 @@ function buildUI(thisObj) {
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
-    framesPerTaskTextBox.onChange = function() {
+    function onFramesPerTaskChanged() {
         const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
         if (isNaN(newFramesPerTaskValue)) {
             framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
@@ -2485,7 +2708,12 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
+        }
     }
+    framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
     const mfrGroup = settingsGroup.add("group", undefined, "");
@@ -2511,7 +2739,7 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
     maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
-    maxCpuUsagePercentageTextBox.onChange = function() {
+    function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
@@ -2521,20 +2749,34 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
+        }
     }
+    maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
-    mfrCheckBox.onClick = function() {
+    function onMfrCheckBoxClicked() {
         const isMfrChecked = mfrCheckBox.value;
+        var settingsStateValue = false
         if (!isMfrChecked) {
             maxCpuUsagePercentageTextBox.text = "N/A";
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+            settingsStateValue = false
         } else {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
+            settingsStateValue = true
         }
+
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+        }
     }
+    mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
     // Add Timeouts settings group
     const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
@@ -2627,14 +2869,35 @@ function buildUI(thisObj) {
         if (rqi.numOutputModules == 1) {
             var outputModule = rqi.outputModule(1).file;
             if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
+                var outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                var extension = getFileExtension(outputFileNameNoRegex);
                 return isImageOutput(extension);
             }
         }
-        // Default to true so that we don't block any customers in case we can't
-        // sufficiently verify whether they're submitting an image sequence or not
-        return true;
+        return false
+    }
+
+    // Check for duplicate names
+    function checkForInvalidCompositionNames(selection) {
+        var names = [];
+        var duplicateNames = [];
+        for (var i=0;i<selection.length;i++) {
+            var selectionItem = selection[i];
+            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
+            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
+            if (names.indexOf(compName) !== -1) {
+                duplicateNames.push(renderQueueItem.comp.name);
+            }
+        }
+        if (duplicateNames.length !== 0) {
+            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
+            for (var i=0;i<duplicateNames.length;i++) {
+                message = message + "\n\t" + duplicateNames[i];
+            }
+            adcAlert(message, true)
+            return true
+        }
+        return false
     }
 
     var submitButton = controlsGroup.add("button", undefined, "Submit");
@@ -2660,6 +2923,7 @@ function buildUI(thisObj) {
     function updateList() {
         var bounds = list == null ? undefined : list.bounds;
         var newList = listGroup.add("listbox", bounds, "", {
+            multiselect: true,
             numberOfColumns: 4,
             showHeaders: true,
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
@@ -2678,6 +2942,8 @@ function buildUI(thisObj) {
             var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
+            // Create a default entry for each comp as needed.
+            uiSettingsState.get(item.compId)
             item.subItems[0].text = rqi.comp.name;
             // Calculate frame range using the utility function
             var frameRange = dcUtil.calculateFrameRange(rqi);
@@ -2698,34 +2964,59 @@ function buildUI(thisObj) {
             listGroup.remove(list);
         }
         list = newList;
-        list.onChange = function() {
-            framesPerTaskTextBox.enabled = isFramesPerTaskEnabled(list.selection);
-            // If no selection, update list and set text box blank. But if there's a selection
-            // and frames per task is disabled, fill textbox with default start-end frame to show that
-            // no image chunking will occur. But if there is a selection and frames per task is enabled,
-            // set it to their default value.
-            if (list.selection == null) {
+
+        function onSelectionChange() {
+            var selection = list.selection;
+            if (selection == null) {
                 updateList();
                 framesPerTaskTextBox.text = "";
-            } else if (!framesPerTaskTextBox.enabled) {
-                framesPerTaskTextBox.text = list.selection.subItems[1].text;
-            } else {
-                framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+                return;
             }
-
-            submitButton.enabled = list.selection != null;
+            submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
-        };
+
+            // Disable everything
+            framesPerTaskTextBox.enabled = false
+            mfrCheckBox.enabled = false
+            maxCpuUsagePercentageTextBox.enabled = false
+
+            if (selection.length !== 1) {
+                return
+            }
+            var selectionItem = selection[0]
+            logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
+            var imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            framesPerTaskTextBox.enabled = imageOutput
+            mfrCheckBox.enabled = true
+            maxCpuUsagePercentageTextBox.enabled = true
+
+            framesPerTaskTextBox.text = selectionItem.subItems[1].text
+
+            var settings = uiSettingsState.get(selectionItem.compId)
+            if (settings === undefined) {
+                logger.warning("Could not find settings for : " + selectionItem.compId);
+                return
+            }
+
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+            mfrCheckBox.value = settings.multiFrameRendering()
+            maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
+
+            maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+        }
+
+        list.onChange = onSelectionChange;
         list.selection = null;
     }
 
     updateList();
-    framesPerTaskTextBox.enabled = isFramesPerTaskEnabled(list.selection);
-
-    refreshButton.onClick = function() {
-        updateList();
+    if (list.selection != null && list.selection.length === 1) {
+        var selectionItem = list.selection[0]
+        var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
+        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
+    refreshButton.onClick = updateList;
 
     submitterPanel.layout.layout(true);
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2948,7 +2948,7 @@ function buildUI(thisObj) {
     listGroup.alignment = ['fill', 'top'];
     listGroup.alignChildren = ['fill', 'top'];
     listGroup.orientation = "column";
-    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
+    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click, Command+Click (Mac), or Ctrl+Click (Windows) can be used to select multiple render queue items and group them together as a single job submission", {
         multiline: true
     });
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
@@ -2966,7 +2966,7 @@ function buildUI(thisObj) {
     controlsPanel.alignment = ['fill', 'top'];
 
     // Container with settings to modify comp-specific settings
-    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Precomp-Specific Settings");
+    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Render Queue Item Settings");
     perCompSettingsGroup.orientation = "column";
     perCompSettingsGroup.alignment = ['fill', 'top'];
     perCompSettingsGroup.alignChildren = ['left', 'top'];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1210,6 +1210,8 @@ function UiSettingsState() {
     // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
 
+    this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
+
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
         return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
@@ -1283,7 +1285,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(this.xmpPath, RQIID);
+        this.settings[RQIID] = new UiSettingsStore(dcUtil.composeXMPPath(this.xmpPath, "rqi_specific_settings"), RQIID);
     }
     return this.settings[RQIID]
 }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2004,7 +2004,7 @@ function SubmitSelection(selection, selectionSettings) {
     // Validate timeout values during job submission
     if (taskTimeoutSeconds <= 0) {
         adcAlert("The following timeout value must be greater than 0: TaskRun", true);
-        throw new Error("Task run timeout must be greater than zero");
+        return;
     }
 
     const renderQueueItems = [];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3132,24 +3132,26 @@ function buildUI(thisObj) {
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled;
+    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled();
 
     const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
     const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, uiSettingsState.taskRunDays());
     taskRunDaysInput.characters = 3;
     taskRunDaysGroup.add("statictext", undefined, "days");
+    taskRunDaysInput.text = uiSettingsState.taskRunDays();
 
     const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
     const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, uiSettingsState.taskRunHours());
     taskRunHoursInput.characters = 3;
     taskRunHoursGroup.add("statictext", undefined, "hours");
+    taskRunHoursInput.text = uiSettingsState.taskRunHours();
 
     const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
     const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, uiSettingsState.taskRunMinutes());
     taskRunMinutesInput.characters = 3;
     taskRunMinutesGroup.add("statictext", undefined, "minutes");
+    taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
 
-    // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
         if (taskRunCheckbox.value) {
             if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
@@ -3165,9 +3167,13 @@ function buildUI(thisObj) {
                 onTaskRunMinutesChanged();
             }
         }
+        taskRunDaysInput.enabled = taskRunCheckbox.value;
+        taskRunHoursInput.enabled = taskRunCheckbox.value;
+        taskRunMinutesInput.enabled = taskRunCheckbox.value;
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
     }
-    taskRunCheckbox.onClick = onTaskRunCheckboxClicked
+    taskRunCheckbox.onClick = onTaskRunCheckboxClicked;
+    onTaskRunCheckboxClicked();
 
     function onTaskRunDaysChanged() {
         var original_value = uiSettingsState.taskRunDays();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -216,8 +216,8 @@ function __generateUtil() {
 
     /**
      * Appends stem to existing XMP path
-     * @param {String} root 
-     * @param {String} stem 
+     * @param {String} root
+     * @param {String} stem
      * @returns {String}
      */
     function composeXMPPath(root, stem) {
@@ -226,8 +226,8 @@ function __generateUtil() {
 
     /**
      * Saves item to project's XMP Metadata
-     * @param {String} key 
-     * @param {*} value 
+     * @param {String} key
+     * @param {*} value
      * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
      */
     function saveToMetadata(key, value, type) {
@@ -238,7 +238,7 @@ function __generateUtil() {
 
     /**
      * Checks if item with given key exists in project's XMPMetadata
-     * @param {String} key 
+     * @param {String} key
      * @returns {boolean}
      */
     function metadataKeyExists(key) {
@@ -247,11 +247,11 @@ function __generateUtil() {
     }
 
     /**
-     * Loads value from project's XMP metadata 
-     * @param {String} key 
+     * Loads value from project's XMP metadata
+     * @param {String} key
      * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
      * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
-     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
+     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist.
      */
     function loadFromMetadata(key, defaultValue, type) {
         if (!metadataKeyExists(key)) {
@@ -534,7 +534,7 @@ function __generateUtil() {
             }
 
             // Create and write to a test file to make sure we have write permissions
-            const file = new File(folder.fsName + testFileSuffix);
+            var file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
             file.close();
@@ -726,11 +726,11 @@ function __generateUtil() {
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
             folderName = subFolders[idx].fullName;
-            const match = folderName.match(regex);
+            var match = folderName.match(regex);
             if (!match) {
                 continue;
             }
-            const seqNr = parseInt(match[1]) // Convert first capture group to int
+            var seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
                 maxSeqNumber = seqNr;
             }
@@ -770,7 +770,7 @@ function __generateUtil() {
         // Remark: gpu memory and worker memory need to be scaled with *1024, for some of the amount capabilities, the unit displayed on the UI is different
         // then the unit used within template, so use this factor to scale the input values.
 
-        const hostRequirements = {
+        var hostRequirements = {
             "attributes": [{
                 "name": "attr.worker.os.family",
                 "anyOf": [
@@ -863,7 +863,7 @@ function __generateUtil() {
         var comp = itemName;
         const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
-            const item = app.project.rootFolder.items[i];
+            var item = app.project.rootFolder.items[i];
 
             if (item instanceof CompItem) {
                 compList.push(app.project.activeItem.name);
@@ -1144,7 +1144,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
                 continue;
             }
             var j = i + 1;
-            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
+            var rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file
@@ -1484,9 +1484,9 @@ function getFontsFromFile() {
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
         for (var i = 0; i < usedList.length; i++) {
-            const font = usedList[i].font;
-            const fontPostScriptName = font.postScriptName;
-            const fontLocation = font.location || getLocationForFont(fontPostScriptName);
+            var font = usedList[i].font;
+            var fontPostScriptName = font.postScriptName;
+            var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
                 adcAlert(
                     "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
@@ -1494,7 +1494,7 @@ function getFontsFromFile() {
                 );
                 continue;
             }
-            const fontName = createFontFilename(fontLocation, fontPostScriptName);
+            var fontName = createFontFilename(fontLocation, fontPostScriptName);
             if (fontName) {
                 fontLocations.push([fontName, fontLocation]);
             }
@@ -1540,7 +1540,7 @@ function getPythonExecutable() {
         try {
             output = system.callSystem(pythonExecutable + " --version");
             if (output && output.indexOf("Python ") !== -1) {
-                const pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
+                var pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
                 if (pythonVersion >= 3) {
                     return pythonExecutable;
                 }
@@ -1681,18 +1681,18 @@ function getFontsFromFileLegacy() {
     const fontLocations = [];
     const items = app.project.items;
     for (var i = items.length; i >= 1; i--) {
-        const item = app.project.item(i);
+        var item = app.project.item(i);
         // Only look at CompItems
         if (!(item instanceof CompItem)) {
             continue;
         }
         for (var j = item.layers.length; j >= 1; j--) {
-            const layer = item.layers[j];
+            var layer = item.layers[j];
             // Only look at TextLayers
             if (!(layer instanceof TextLayer)) {
                 continue;
             }
-            const sourceText = layer.text.sourceText;
+            var sourceText = layer.text.sourceText;
             // Check if the sourceText property has keys.
             // If it has keys, the font can change over time and we need to check all keys for their font
             if (sourceText.numKeys) {
@@ -1764,12 +1764,12 @@ function generateFontReferences(fontPaths) {
 
     // Copy the font files to the temp folder
     for (var i = 0; i < fontPaths.length; i++) {
-        const fontName = fontPaths[i][0];
-        const fontLocation = fontPaths[i][1];
+        var fontName = fontPaths[i][0];
+        var fontLocation = fontPaths[i][1];
 
-        const fontFile = File(fontLocation);
-        const _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        const fontCopied = fontFile.copy(_tempFontPath);
+        var fontFile = File(fontLocation);
+        var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        var fontCopied = fontFile.copy(_tempFontPath);
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -966,6 +966,39 @@ function __generateUtil() {
         return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
     }
 
+    function getXMPPathLeaf(path) {
+        const regex = /.*xmp:(.*)/;
+        return regex.exec(path)[1];
+    }
+
+    function deleteUnusedMetadata(renderMetadataRoot) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        var paths = []
+        var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
+        while (property = iterator.next()) {
+            paths.push(property.path);
+        }
+        var ids = []
+        for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
+            ids.push(getRQIID(i));
+        }
+        for (var i = 0; i < paths.length; i++) {
+            var presentInArray = false;
+            var currentPath = paths[i];
+            for (var j = 0; j < ids.length; j++) {
+                var renderQueueID = ids[j];
+                if (getXMPPathLeaf(currentPath) === renderQueueID) {
+                    presentInArray=true;
+                    break;
+                }
+            }
+            if (!presentInArray) {
+                metadata.deleteProperty(XMPConst.NS_XMP, currentPath);
+            }
+        }
+        app.project.xmpPacket = metadata.serialize();
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -1014,7 +1047,8 @@ function __generateUtil() {
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
-        "metadataKeyExists": metadataKeyExists
+        "metadataKeyExists": metadataKeyExists,
+        "deleteUnusedMetadata": deleteUnusedMetadata
     }
 }
 
@@ -1211,6 +1245,7 @@ function UiSettingsState() {
     this.settings = {}
 
     this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
+    this.rqiXmpPath = dcUtil.composeXMPPath(this.xmpPath, "rqiSpecificSettings");
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
@@ -1285,7 +1320,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(dcUtil.composeXMPPath(this.xmpPath, "rqi_specific_settings"), RQIID);
+        this.settings[RQIID] = new UiSettingsStore(this.rqiXmpPath, RQIID);
     }
     return this.settings[RQIID]
 }
@@ -3153,6 +3188,8 @@ function buildUI(thisObj) {
     submitButton.enabled = false;
 
     function updateList() {
+        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
+
         const bounds = list == null ? undefined : list.bounds;
         const newList = listGroup.add("listbox", bounds, "", {
             multiselect: true,
@@ -3163,6 +3200,7 @@ function buildUI(thisObj) {
         });
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
+
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -975,6 +975,7 @@ function __generateUtil() {
         var metadata = new XMPMeta(app.project.xmpPacket);
         var paths = []
         var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
+        var property;
         while (property = iterator.next()) {
             paths.push(property.path);
         }
@@ -1800,7 +1801,7 @@ var JobParams = [
     "ProjectFile"
 ]
 
-var paramPattern = "Param\.";
+var paramPattern = "Param\\.";
 for (var p = 0; p < JobParams.length; p++) {
     paramPattern = paramPattern + "(?!" + JobParams[p] + ")";
 }
@@ -3241,7 +3242,7 @@ function buildUI(thisObj) {
             if (imageOutput) {
                 framesPerTaskTextBox.text = settings.framesPerTask();
                 framesPerTaskTextBox.enabled = true;
-                framesPerTaskTextBox.onChange()
+                framesPerTaskTextBox.onChange();
             } else {
                 framesPerTaskTextBox.text = "Selection is not image sequence";
                 framesPerTaskTextBox.enabled = false;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3316,11 +3316,13 @@ function buildUI(thisObj) {
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = "";
 
-            submitButton.enabled = true;
-            submitButton.active = false;
-            submitButton.active = true;
+            if (selection === null) {
+                submitButton.enabled = false;
+            } else {
+                submitButton.enabled = true;
+            }
 
-            if (selection == null || selection.length !== 1) {
+            if (selection === null || selection.length !== 1) {
                 return;
             }
             const selectionItem = selection[0];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -186,7 +186,7 @@ function validateType(item, itemType) {
 
 function __generateUtil() {
 
-    const scriptFileUtilName = "Util.jsx";
+    const scriptFileUtilName = "Utils.jsx";
 
 
     function toBooleanString(value) {
@@ -926,8 +926,10 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.round(rqi.timeSpanStart * rqi.comp.frameRate));
-        const endFrame = Number(Math.round((rqi.timeSpanStart + rqi.timeSpanDuration) * rqi.comp.frameRate))
+        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
+        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+
         return {
             startFrame: startFrame,
             endFrame: endFrame
@@ -952,10 +954,9 @@ function __generateUtil() {
     }
 
     function getSelection(list) {
-        for (var s = 0; s < list.selection.length; s++) {
-            return list.selection[s];
+        if (list.selection.length >= 1) {
+            return list.selection[0];
         }
-        return list.selection[0];
     }
 
     function getRenderQueueItemID(renderQueueIndex) {
@@ -1042,7 +1043,6 @@ function __generateUtil() {
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
-        "getTempFolder": getTempFolder,
         "getRenderQueueItemID": getRenderQueueItemID,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
@@ -1057,6 +1057,7 @@ var dcUtil = __generateUtil();
 // Getting a setting that doesn't already exist will set it to its default value
 dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
 dcUtil.getStringMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
+
 
 
 var LOG_LEVEL = {
@@ -1837,6 +1838,7 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
         );
         return false;
     }
+    validateRenderQueueItemOutputModule(renderQueueItem);
     return true;
 }
 
@@ -2307,6 +2309,7 @@ function SubmitSelection(selection, selectionSettings) {
         logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
     }
 }
+
 
 
 /**

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -688,7 +688,7 @@ function __generateUtil() {
          */
         // If submit layers pressed -> itemName is not comp name and therefore comp will not be found with render command
         // Check if itemName is an available comp in the project, if not, it is a layer submission
-        const comp = itemName;
+        var comp = itemName;
         const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
             const item = app.project.rootFolder.items[i];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -926,7 +926,7 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor(rqi.timeSpanStart * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
         return {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -111,10 +111,10 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
-function validateType(item, item_type) {
-    var actual_type = typeof item;
-    if (actual_type !== item_type) {
-        throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
+function validateType(item, itemType) {
+    var actualType = typeof item;
+    if (actualType !== itemType) {
+        throw new Error("Object has type " + actualType + " instead of desired type " + itemType);
     }
 }
 
@@ -156,17 +156,17 @@ function __generateUtil() {
         app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
-    function getBoolSetting(sectionName, keyName, default_value) {
+    function getBoolSetting(sectionName, keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
-         * Set default_value to undefined to error on missing setting
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
             }
-            saveBoolSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
+            saveBoolSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "defaultValue");
         }
         return parseBool(app.settings.getSetting(sectionName, keyName));
     }
@@ -179,24 +179,24 @@ function __generateUtil() {
         app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
-    function getNumberSetting(sectionName, keyName, default_value) {
+    function getNumberSetting(sectionName, keyName, defaultValue) {
         /**
-         * Gets number value from app settings, or sets default_value if setting does not exist
-         * Set default_value to undefined to error on missing setting
+         * Gets number value from app settings, or sets defaultValue if setting does not exist
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            saveNumberSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+            saveNumberSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            saveNumberSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
+            saveNumberSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + defaultValue);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
     }
@@ -211,15 +211,15 @@ function __generateUtil() {
 
     function getStringSetting(sectionName, keyName, defaultValue) {
         /**
-         * Gets string value from app settings, or sets default_value if setting does not exist
-         * Set default_value to undefined to error on missing setting
+         * Gets string value from app settings, or sets defaultValue if setting does not exist
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            setStringSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+            setStringSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
         }
         return app.settings.getSetting(sectionName, keyName)
     }
@@ -659,10 +659,10 @@ function __generateUtil() {
         return folder;
     }
 
-    function getPartialExportDir(job_history_dir) {
+    function getPartialExportDir(jobHistoryDir) {
         /**
          * Creates string with correct name and format to be used in job history directory creation.
-         * @param {string} job_history_dir: Directory where job bundles is written to on submission.
+         * @param {string} jobHistoryDir: Directory where job bundles is written to on submission.
          * Returns partial job history directory.
          */
         const currentDate = new Date();
@@ -673,7 +673,7 @@ function __generateUtil() {
         // Create the formatted string
         const formattedYearMonth = year + '-' + month;
         const formattedDate = year + '-' + month + '-' + day;
-        const dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
+        const dir = jobHistoryDir + "//" + formattedYearMonth + "//" + formattedDate + "-";
         return dir;
     }
 
@@ -1365,7 +1365,7 @@ function findJobAttachments(rootComp) {
     exploredItems[rootComp.id] = true;
     const queue = [rootComp];
     while (queue.length > 0) {
-        const comp = queue.pop();
+        var comp = queue.pop();
         var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
         for (var i = 1; i <= comp.numLayers; i++) {
             var layer = comp.layer(i);
@@ -1888,9 +1888,9 @@ function generatePrettyParameterName(index, compName, parameter) {
         parameter = "";
     }
     index = index.toString();
-    const max_length = 10;
-    if (compName.length >= max_length) {
-        compName = compName.substring(0, max_length - 3) + "...";
+    const maxLength = 10;
+    if (compName.length >= maxLength) {
+        compName = compName.substring(0, maxLength - 3) + "...";
     }
     return "(" + index + "_" + compName + ") " + parameter;
 }
@@ -3087,13 +3087,12 @@ function buildUI(thisObj) {
     onTaskRunCheckboxClicked();
 
     function onTaskRunDaysChanged() {
-        var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunDaysInput.text);
-        if (taskRunDaysInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunDaysInput.text);
+        if (taskRunDaysInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunDays(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunDays(newValue);
             }
         }
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
@@ -3101,13 +3100,12 @@ function buildUI(thisObj) {
     taskRunDaysInput.onChange = onTaskRunDaysChanged;
 
     function onTaskRunHoursChanged() {
-        var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunHoursInput.text);
-        if (taskRunHoursInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunHoursInput.text);
+        if (taskRunHoursInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunHours(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunHours(newValue);
             }
         }
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
@@ -3115,13 +3113,12 @@ function buildUI(thisObj) {
     taskRunHoursInput.onChange = onTaskRunHoursChanged;
 
     function onTaskRunMinutesChanged() {
-        var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunMinutesInput.text);
-        if (taskRunMinutesInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunMinutesInput.text);
+        if (taskRunMinutesInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunMinutes(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunMinutes(newValue);
             }
         }
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1940,15 +1940,14 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 /**
  * Submit the selected render queue item
  **/
-function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
+function SubmitSelection(selection, selectionSettings) {
     // Calculate task run timeout in seconds
-    var taskTimeoutSeconds = 0;
+    var taskTimeoutSeconds = (selectionSettings.taskRunDays() * 24 * 60 * 60) + (selectionSettings.taskRunHours() * 60 * 60) + (selectionSettings.taskRunMinutes() * 60);
     // Validate timeout values during job submission
-    if (taskTimeoutDays === 0 && taskTimeoutHours === 0 && taskTimeoutMinutes === 0) {
+    if (taskTimeoutSeconds <= 0) {
         adcAlert("The following timeout value must be greater than 0: TaskRun", true);
         throw new Error("Task run timeout must be greater than zero");
     }
-    taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
     const renderQueueItems = [];
 
@@ -2116,9 +2115,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
 
-        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask);
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage);
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering;
+        var stepFramesPerTask = selectionSettings.get(renderQueueItem.comp.id).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -3255,11 +3254,7 @@ function buildUI(thisObj) {
             if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }
-            if (taskRunCheckbox.value) {
-                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
-            } else {
-                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
-            }
+            SubmitSelection(list.selection, uiSettingsState);
             list.selection = null;
         }
     }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2842,9 +2842,15 @@ function buildUI(thisObj) {
     }
     const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
     const listGroup = root.add("panel", undefined, "");
-    listGroup.alignment = ['fill', 'fill'];
-    listGroup.alignChildren = ['fill', 'fill']
-
+    listGroup.alignment = ['fill', 'top'];
+    listGroup.alignChildren = ['fill', 'top']
+    listGroup.orientation = "column"
+    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
+        multiline: true
+    })
+    // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
+    multiCompLabel.maximumSize.height = 30;
+    multiCompLabel.alignment = ['fill', 'top'];
     var list = listGroup.add("listbox", undefined, "", {
         multiselect: true,
         numberOfColumns: 4,
@@ -2927,14 +2933,14 @@ function buildUI(thisObj) {
     const controlsPanel = controlsGroup.add("panel", undefined, "");
     controlsPanel.alignment = ['fill', 'top'];
 
-    // Container with all settings to modify job submission
-    const settingsGroup = controlsPanel.add("group", undefined, "");
-    settingsGroup.orientation = "column";
-    settingsGroup.alignment = ['fill', 'top'];
-    settingsGroup.alignChildren = ['left', 'top'];
+    // Container with settings to modify comp-specific settings
+    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Precomp-Specific Settings");
+    perCompSettingsGroup.orientation = "column";
+    perCompSettingsGroup.alignment = ['fill', 'top'];
+    perCompSettingsGroup.alignChildren = ['left', 'top'];
 
     // Setting up frame per task GUI
-    const framesPerTaskGroup = settingsGroup.add("group", undefined, "");
+    const framesPerTaskGroup = perCompSettingsGroup.add("group", undefined, "");
     framesPerTaskGroup.orientation = "row";
     framesPerTaskGroup.alignment = ['fill', 'top'];
     framesPerTaskGroup.alignChildren = ['left', 'center'];
@@ -2970,7 +2976,7 @@ function buildUI(thisObj) {
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
-    const mfrGroup = settingsGroup.add("group", undefined, "");
+    const mfrGroup = perCompSettingsGroup.add("group", undefined, "");
     mfrGroup.orientation = "column";
     mfrGroup.alignment = ['fill', 'top'];
     mfrGroup.alignChildren = ['left', 'center'];
@@ -3045,13 +3051,16 @@ function buildUI(thisObj) {
         return false
     }
 
-
+    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings")
+    globalSettingsGroup.orientation = "column";
+    globalSettingsGroup.alignment = ['fill', 'top'];
+    globalSettingsGroup.alignChildren = ['left', 'top'];
     // Add Timeouts settings group
-    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
+    const timeoutsPanel = globalSettingsGroup.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
     timeoutsPanel.alignment = ['fill', 'top'];
     timeoutsPanel.alignChildren = ['left', 'center'];
-    timeoutsPanel.margins = 5;
+    timeoutsPanel.margins = 10;
 
     // Task run timeout
     const taskRunGroup = timeoutsPanel.add("group");

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2849,37 +2849,6 @@ function populateListBoxItem(item, renderQueueItem, index) {
 }
 
 
-function refreshList(listBox, uiSettingsState) {
-    listBox.removeAll();
-
-    const InvalidRenderQueueItemStatuses = [
-        RQItemStatus.RENDERING,
-        RQItemStatus.WILL_CONTINUE,
-        RQItemStatus.USER_STOPPED,
-        RQItemStatus.ERR_STOPPED,
-        RQItemStatus.DONE
-    ];
-    for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
-        var renderQueueItem = app.project.renderQueue.item(index);
-        if (renderQueueItem == null) {
-            continue;
-        }
-
-        if (InvalidRenderQueueItemStatuses.indexOf(renderQueueItem.status) !== -1) {
-            // Status is in InvalidRenderQueueItemStatuses.
-            continue;
-        }
-
-        var item = listBox.add('item', index.toString());
-        populateListBoxItem(item, renderQueueItem, index);
-        // TODO: Value
-
-        uiSettingsState.create(item.compId);
-    }
-
-    listBox.selection = null;
-}
-
 /**
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
@@ -2919,80 +2888,9 @@ function buildUI(thisObj) {
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
     multiCompLabel.maximumSize.height = 30;
     multiCompLabel.alignment = ['fill', 'top'];
-    var list = listGroup.add("listbox", undefined, "", {
-        multiselect: true,
-        numberOfColumns: 4,
-        showHeaders: true,
-        columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
-        columnWidths: [32, 160, 120, 240],
-    });
-    list.preferredSize.height = 400;
-    list.preferredSize.width = 500;
-
-    function onSelectionChange() {
-        const selection = list.selection;
-        if (selection == null) {
-            refreshList(list, uiSettingsState);
-            framesPerTaskTextBox.text = "";
-            return;
-        }
-        submitButton.enabled = true;
-        submitButton.active = false;
-        submitButton.active = true;
-
-        // Disable everything
-        framesPerTaskTextBox.enabled = false;
-        mfrCheckBox.enabled = false;
-        maxCpuUsagePercentageTextBox.enabled = false;
-        taskRunCheckbox.enabled = false;
-        taskRunDaysInput.enabled = false;
-        taskRunHoursInput.enabled = false;
-        taskRunMinutesInput.enabled = false;
-
-        if (selection.length !== 1) {
-            return;
-        }
-        const selectionItem = selection[0];
-        logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-        framesPerTaskTextBox.enabled = imageOutput;
-        mfrCheckBox.enabled = true;
-        maxCpuUsagePercentageTextBox.enabled = true;
-        taskRunCheckbox.enabled = true;
-        taskRunDaysInput.enabled = true;
-        taskRunHoursInput.enabled = true;
-        taskRunMinutesInput.enabled = true;
-
-        logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
-        framesPerTaskTextBox.text = selectionItem.subItems[1].text;
-
-        const settings = uiSettingsState.get(selectionItem.compId);
-        if (settings === undefined) {
-            logger.warning("Could not find settings for : " + selectionItem.compId);
-            return;
-        }
-
-        if (imageOutput === true) {
-            logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text;
-        }
-        logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
-        mfrCheckBox.value = settings.multiFrameRendering();
-        logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
-        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
-
-        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-
-        taskRunCheckbox.value = settings.taskRunTimeoutEnabled();
-        taskRunDaysInput.enabled = taskRunCheckbox.value;
-        taskRunDaysInput.text = settings.taskRunDays();
-        taskRunHoursInput.enabled = taskRunCheckbox.value;
-        taskRunHoursInput.text = settings.taskRunHours();
-        taskRunMinutesInput.enabled = taskRunCheckbox.value;
-        taskRunMinutesInput.text = settings.taskRunMinutes();
-    }
-
-    list.onChange = onSelectionChange;
+    // The list can't be populated until everything else is defined but we still need the variable set
+    // So it can be referenced by other UI elements
+    var list = null;
 
     const controlsGroup = root.add("group", undefined, "");
     controlsGroup.orientation = 'column';
@@ -3340,20 +3238,19 @@ function buildUI(thisObj) {
             mfrCheckBox.value = settings.multiFrameRendering();
             mfrCheckBox.onClick();
         }
-        onSelectionChange();
         list.onChange = onSelectionChange;
         list.selection = null;
+        onSelectionChange();
     }
 
     updateList();
-    refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
         const selectionItem = list.selection[0];
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
     refreshButton.onClick = function() {
-        refreshList(list, uiSettingsState);
+        updateList();
     }
 
     submitterPanel.layout.layout(true);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -346,7 +346,7 @@ function __generateUtil() {
 
         // Test every path in our list by creating a test file
         for (var i = 0; i < altPaths.length; i++) {
-            const folder = new Folder(altPaths[i]);
+            var folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -870,6 +870,13 @@ function __generateUtil() {
         return list.selection[0];
     }
 
+    function getRQIID(renderQueueIndex) {
+        /** Calculates an ID for the Render Queue Item with the given index in the render queue
+        * Not guaranteed to be unique
+        */
+        return app.project.file.name + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -2826,27 +2833,6 @@ if (typeof JSON !== "object") {
 
 
 
-
-
-function populateListBoxItem(item, renderQueueItem, index) {
-    item.renderQueueIndex = index;
-    item.compId = renderQueueItem.comp.id;
-    item.subItems[0].text = renderQueueItem.comp.name;
-
-    var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
-    var startFrame = frameRange.startFrame;
-    var endFrame = frameRange.endFrame;
-
-    item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
-    if (renderQueueItem.numOutputModules <= 0) {
-        item.subItems[2].text = "<not set>";
-    } else if (renderQueueItem.numOutputModules == 1) {
-        const outputFile = renderQueueItem.outputModule(1).file;
-        item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
-    } else {
-        item.subItems[2].text = "<multiple output modules>";
-    }
-}
 
 
 /**

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2,14 +2,16 @@
 // Manual changes in this file may be overwritten by a new installation.
 // Please change the source files and regenerate this file instead.
 
-if ( ExternalObject.AdobeXMPScript == undefined ) {
-    ExternalObject.AdobeXMPScript = new ExternalObject( "lib:AdobeXMPScript");
+if (ExternalObject.AdobeXMPScript == undefined) {
+    ExternalObject.AdobeXMPScript = new ExternalObject("lib:AdobeXMPScript");
 }
 
 var scriptFolder = Folder.current.fsName;
 
 // Global constants, wrapped with if-blocks to ensure they are only defined once
 // to avoid errors due to redeclaration
+// Note that once these values have been set their values will persist until Aftereffects is relaunched,
+// So make sure to restart Aftereffects is you change them
 if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
     const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
 }
@@ -19,8 +21,8 @@ if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
 if (typeof SUPPORTED_VERSIONS === "undefined") {
     const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
 }
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "DeadlineCloudSubmitter";
+if (typeof DEADLINECLOUD_SETTINGS_ROOT === "undefined") {
+    const DEADLINECLOUD_SETTINGS_ROOT = "xmp:DeadlineCloudSubmitter";
 }
 if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
     const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
@@ -213,105 +215,112 @@ function __generateUtil() {
     }
 
     /**
-     * Combines prefix and key to construct a key for accessing a value in XMPMetadata 
-     * @param {String} prefix 
-     * @param {String} key 
+     * Appends stem to existing XMP path
+     * @param {String} root 
+     * @param {String} stem 
      * @returns {String}
      */
-    function buildMetadataKey(prefix, key) {
-        return "xmp:" + prefix + "__" + key;
+    function composeXMPPath(root, stem) {
+        return root + "/xmp:" + stem;
+    }
+
+    /**
+     * Creates XMP path to access field of struct 
+     * @param {String} structPath 
+     * @param {String} fieldName 
+     * @returns 
+     */
+    function composeXMPField(structPath, fieldName) {
+        return structPath + "/xmp:" + fieldName
     }
 
     /**
      * Saves item to project's XMP Metadata
-     * @param {String} prefix 
      * @param {String} key 
      * @param {*} value 
      * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
      */
-    function saveToMetadata(prefix, key, value, type) {
+    function saveToMetadata(key, value, type) {
         var metadata = new XMPMeta(app.project.xmpPacket);
-        metadata.setProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), value, type);
+        metadata.setProperty(XMPConst.NS_XMP, key, value, type);
         app.project.xmpPacket = metadata.serialize();
     }
 
     /**
      * Checks if item with given key exists in project's XMPMetadata
-     * @param {String} prefix 
      * @param {String} key 
      * @returns {boolean}
      */
-    function metadataKeyExists(prefix, key) {
+    function metadataKeyExists(key) {
         var metadata = new XMPMeta(app.project.xmpPacket);
-        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key)) !== undefined;
+        return metadata.getProperty(XMPConst.NS_XMP, key) !== undefined;
     }
 
     /**
      * Loads value from project's XMP metadata 
-     * @param {String} prefix 
      * @param {String} key 
      * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
      * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
      * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
      */
-    function loadFromMetadata(prefix, key, defaultValue, type) {
-        if (!metadataKeyExists(prefix, key)) {
+    function loadFromMetadata(key, defaultValue, type) {
+        if (!metadataKeyExists(key)) {
             if (defaultValue !== undefined) {
-                saveToMetadata(prefix, key, defaultValue, type);
+                saveToMetadata(key, defaultValue, type);
             } else {
-                throw Error("Key '" + buildMetadataKey(prefix, key) + "' does not exist in project XMP Metadata, and no default value is set.")
+                throw Error("Key '" + key + "' does not exist in project XMP Metadata, and no default value is set.")
             }
         }
         var metadata = new XMPMeta(app.project.xmpPacket);
-        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), type).value;
+        return metadata.getProperty(XMPConst.NS_XMP, key, type).value;
     }
 
-    function saveBoolSetting(sectionName, keyName, value) {
+    function saveBoolSetting(keyName, value) {
         /**
          * Sets boolean value in app settings
          */
         validateType(value, "boolean");
-        saveToMetadata(sectionName, keyName, value, XMPConst.BOOLEAN);
+        saveToMetadata(keyName, value, XMPConst.BOOLEAN);
     }
 
-    function getBoolSetting(sectionName, keyName, defaultValue) {
+    function getBoolSetting(keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.BOOLEAN)
+        return loadFromMetadata(keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
-    function saveNumberSetting(sectionName, keyName, value) {
+    function saveNumberSetting(keyName, value) {
         /**
          * Sets integer value in app settings
          */
         validateType(value, "number");
-        saveToMetadata(sectionName, keyName, value, XMPConst.NUMBER);
+        saveToMetadata(keyName, value, XMPConst.NUMBER);
     }
 
-    function getNumberSetting(sectionName, keyName, defaultValue) {
+    function getNumberSetting(keyName, defaultValue) {
         /**
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.NUMBER);
+        return loadFromMetadata(keyName, defaultValue, XMPConst.NUMBER);
     }
 
-    function saveStringSetting(sectionName, keyName, value) {
+    function saveStringSetting(keyName, value) {
         /**
          * Sets string in app settings
          */
         validateType(value, "string");
-        saveToMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
+        saveToMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
-    function getStringSetting(sectionName, keyName, defaultValue) {
+    function getStringSetting(keyName, defaultValue) {
         /**
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
+        return loadFromMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -964,7 +973,7 @@ function __generateUtil() {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
          * Not guaranteed to be unique if render queue items are reordered
          */
-        return app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+        return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
     }
 
     return {
@@ -1011,15 +1020,20 @@ function __generateUtil() {
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder,
-        "getRQIID": getRQIID
+        "getRQIID": getRQIID,
+        "composeXMPPath": composeXMPPath,
+        "composeXMPField": composeXMPField,
+        "saveToMetadata": saveToMetadata,
+        "loadFromMetadata": loadFromMetadata,
+        "metadataKeyExists": metadataKeyExists
     }
 }
 
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
-dcUtil.getStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
 
 
 var LOG_LEVEL = {
@@ -1207,88 +1221,78 @@ function UiSettingsState() {
     // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
 
-    // () -> bool
+    this.xmpPath = DEADLINECLOUD_SETTINGS_ROOT;
+
+    /**
+     * @returns {boolean} 
+     */
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
-    // (value: bool) -> void
+
+    /**
+     * @param {boolean} value 
+     */
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
 
-function UiSettingsStore(name) {
+function UiSettingsStore(xmpPathPrefix, name) {
     /**
      * Stores comp-specific settings for the comp with given name.
      */
     this.name = name;
+    this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value);
-    }
-}
-
-UiSettingsState.prototype.create = function(RQIID, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
-    /**
-     * Adds new UISettingsStore to store settings for the comp associated with Render Queue Item ID
-     */
-    if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(RQIID);
-    }
-    if (framesPerTask !== undefined) {
-        this.settings[RQIID].setFramesPerTask(framesPerTask);
-    }
-    if (multiFrameRendering !== undefined) {
-        this.settings[RQIID].setMultiFrameRendering(multiFrameRendering);
-    }
-    if (maxCpuUsagePercentage !== undefined) {
-        this.settings[RQIID].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 
@@ -1297,7 +1301,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(RQIID);
+        this.settings[RQIID] = new UiSettingsStore(this.xmpPath, RQIID);
     }
     return this.settings[RQIID]
 }
@@ -2046,8 +2050,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, 0);
+    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -2059,11 +2063,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            dcUtil.saveStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -111,6 +111,13 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
+function validateType(item, item_type) {
+    actual_type = typeof item;
+    if (actual_type !== item_type) {
+        throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
+    }
+}
+
 function __generateUtil() {
 
     const scriptFileUtilName = "Util.jsx";
@@ -139,6 +146,82 @@ function __generateUtil() {
             return true;
 
         return false;
+    }
+
+    function saveBoolSetting(sectionName, keyName, value) {
+        /**
+         * Sets boolean value in app settings
+         */
+        validateType(value, "boolean")
+        app.settings.saveSetting(sectionName, keyName, value.toString())
+    }
+
+    function getBoolSetting(sectionName, keyName, default_value) {
+        /**
+         * Gets boolean value from app settings, or sets it to the default value if no setting exists.
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
+            }
+            setBoolSetting(sectionName, keyName, default_value);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
+        }
+        return parseBool(app.settings.getSetting(sectionName, keyName));
+    }
+
+    function saveNumberSetting(sectionName, keyName, value) {
+        /**
+         * Sets integer value in app settings
+         */
+        validateType(value, "number")
+        app.settings.saveSetting(sectionName, keyName, value.toString())
+    }
+
+    function getNumberSetting(sectionName, keyName, default_value) {
+        /**
+         * Gets number value from app settings, or sets default_value if setting does not exist
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
+            }
+            setNumberSetting(sectionName, keyName, default_value)
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+        }
+        if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
+            }
+            setNumberSetting(sectionName, keyName, default_value)
+            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
+        }
+        return Number(app.settings.getSetting(sectionName, keyName));
+    }
+
+    function saveStringSetting(sectionName, keyName, value) {
+        /**
+         * Sets string in app settings
+         */
+        validateType(value, "string");
+        app.settings.saveSetting(sectionName, keyName, value);
+    }
+
+    function getStringSetting(sectionName, keyName, defaultValue) {
+         /**
+         * Gets string value from app settings, or sets default_value if setting does not exist
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
+            }
+            setStringSetting(sectionName, keyName, default_value);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+        }
+        return app.settings.getSetting(sectionName, keyName) 
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -764,14 +847,16 @@ function __generateUtil() {
     }
 
     function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+        /**
+         * Parses in input strings for days, hours, and minutes in timeout, validates them, and alerts user if invalid
+         */
         if (enabled) {
-            var days = parseInt(daysInput.text) || 0;
-            var hours = parseInt(hoursInput.text) || 0;
+            var days = parseInt(daysInput) || 0;
+            var hours = parseInt(hoursInput) || 0;
             var minutes = parseInt(minutesInput.text) || 0;
 
             if (days === 0 && hours === 0 && minutes === 0) {
                 adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
                 return false;
             }
         }
@@ -789,6 +874,12 @@ function __generateUtil() {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
         "parseBool": parseBool,
+        "saveBoolSetting": saveBoolSetting,
+        "getBoolSetting": getBoolSetting,
+        "saveNumberSetting": saveNumberSetting,
+        "getNumberSetting": getNumberSetting,
+        "saveStringSetting": saveStringSetting,
+        "getStringSetting": getStringSetting,
         "trimIllegalChars": trimIllegalChars,
         "sliderTextSync": sliderTextSync,
         "changeTextValue": changeTextValue,
@@ -867,32 +958,33 @@ if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
 if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
     const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
 }
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
+}
+if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
+    const DEFAULT_FRAMESPERTASK = 10;
+}
+if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
+    const DEFAULT_MULTI_FRAME_RENDERING = false;
+}
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE) {
+    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
+
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
 }
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+    saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
 }
 
 
@@ -1074,120 +1166,102 @@ var logger = Logger(logFileName, logNormDirectoryPath);
 
 
 function UiSettingsState() {
+    /**
+     * Container that stores all of the configurable properties in the submitter UI
+     */
+
+    // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
-}
 
-function UiSettingsStore(name) {
-    this.name = name;
-    // _framesPerTask: string
-    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
-    // _multiFrameRendering: bool
-    this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
-    // _maxCpuUsagePercentage: string
-    this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-
-    // _taskRunTimeout: bool
-    this._taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-    // _taskRunDays: string
-    this._taskRunDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
-    // _taskRunHours: string
-    this._taskRunHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
-    // _taskRunMinutes: string
-    this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
-
-    this.framesPerTask = function() {
-        return this._framesPerTask
+    // () -> bool
+    this.taskRunTimeoutEnabled = function() {
+        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
-    this.setFramesPerTask = function(value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
-        this._framesPerTask = typeof value === "string" ? value : value.toString()
+    // (value: bool) -> void
+    this.setTaskRunTimeoutEnabled = function(value) {
+        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, value);
     }
-
-    this.multiFrameRendering = function() {
-        return this._multiFrameRendering
-    }
-    this.setMultiFrameRendering = function(value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
-        this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
-    }
-
-    this.maxCpuUsagePercentage = function() {
-        return this._maxCpuUsagePercentage
-    }
-    this.setMaxCpuUsagePercentage = function(value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
-    }
-
-    this.taskRunTimeout = function() {
-        return this._taskRunTimeout
-    }
-    this.setTaskRunTimeout = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
-        this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
-    }
-
+    // () -> int
     this.taskRunDays = function() {
-        return this._taskRunDays
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
+
     this.setTaskRunDays = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
-        this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, value);
     }
 
     this.taskRunHours = function() {
-        return this._taskRunHours
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
+
     this.setTaskRunHours = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
-        this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, value);
     }
 
     this.taskRunMinutes = function() {
-        return this._taskRunMinutes
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
+
     this.setTaskRunMinutes = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
-        this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, value);
+    }
+
+}
+
+function UiSettingsStore(name) {
+    /**
+     * Stores comp-specific settings for the comp with given name.
+     */
+    this.name = name;
+
+    this.framesPerTask = function() {
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name +"_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+    }
+    this.setFramesPerTask = function(value) {
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
+    }
+
+    this.multiFrameRendering = function() {
+        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
+    }
+    this.setMultiFrameRendering = function(value) {
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
+    }
+
+    this.maxCpuUsagePercentage = function() {
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE)
+
+    }
+    this.setMaxCpuUsagePercentage = function(value) {
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name+"_"+DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value)
     }
 }
 
-UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
+UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+    /**
+     * Adds new UISettingsStore to store settings for the comp associated with compId
+     */
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId);
     }
-    if (framesPerTask === undefined) {
-        framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+    if (framesPerTask !== undefined) {
+        this.settings[compId].setFramesPerTask(framesPerTask);
     }
-    if (multiFrameRendering === undefined) {
-        multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    if (multiFrameRendering !== undefined) {
+        this.settings[compId].setMultiFrameRendering(multiFrameRendering);
     }
-    if (maxCpuUsagePercentage === undefined) {
-        maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+    if (maxCpuUsagePercentage !== undefined) {
+        this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
     }
-    if (taskRunTimeout === undefined) {
-        taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-    }
-    if (taskRunTimeoutDays === undefined) {
-        taskRunTimeoutDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
-    }
-    if (taskRunTimeoutHours === undefined) {
-        taskRunTimeoutHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
-    }
-    if (taskRunTimeoutMinutes === undefined) {
-        taskRunTimeoutMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
-    }
-
-    this.settings[compId].setFramesPerTask(framesPerTask);
-    this.settings[compId].setMultiFrameRendering(multiFrameRendering);
-    this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
-    this.settings[compId].setTaskRunTimeout(taskRunTimeout);
-    this.settings[compId].setTaskRunDays(taskRunTimeoutDays);
-    this.settings[compId].setTaskRunHours(taskRunTimeoutHours);
-    this.settings[compId].setTaskRunMinutes(taskRunTimeoutMinutes);
 }
 
 UiSettingsState.prototype.get = function(compId) {
+    /**
+     * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
+     */
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId)
     }
@@ -1909,8 +1983,8 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
 
     // Check if warning should be shown
-    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
+    const ignoreWarning = dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
+    const savedVersion = dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -1922,11 +1996,11 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString())
             if (confirm(versionMismatchWarningMessage)) {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true)
             } else {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false)
                 return;
             }
         } else {
@@ -2780,10 +2854,7 @@ function populateListBoxItem(item, renderQueueItem, index) {
 
 function refreshList(listBox, uiSettingsState) {
     listBox.removeAll();
-    const framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK) || "50"
-    const multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)
-    const maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)
-
+   
     const InvalidRenderQueueItemStatuses = [
         RQItemStatus.RENDERING,
         RQItemStatus.WILL_CONTINUE,
@@ -2806,7 +2877,7 @@ function refreshList(listBox, uiSettingsState) {
         populateListBoxItem(item, renderQueueItem, index);
         // TODO: Value
 
-        uiSettingsState.create(item.compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage);
+        uiSettingsState.create(item.compId);
     }
 
     listBox.selection = null;
@@ -2915,7 +2986,7 @@ function buildUI(thisObj) {
 
         maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
 
-        taskRunCheckbox.value = settings.taskRunTimeout()
+        taskRunCheckbox.value = settings.taskRunTimeoutEnabled()
         taskRunDaysInput.enabled = taskRunCheckbox.value
         taskRunDaysInput.text = settings.taskRunDays()
         taskRunHoursInput.enabled = taskRunCheckbox.value
@@ -2954,22 +3025,18 @@ function buildUI(thisObj) {
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
 
     function onFramesPerTaskChanged() {
-        const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
-        if (isNaN(newFramesPerTaskValue)) {
-            framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
-        } else if (newFramesPerTaskValue > 9999) {
-            framesPerTaskTextBox.text = "9999";
-        } else {
-            // Need to reassign in case input string is a number followed my random characters
-            // since parseInt parses the first number it finds in a provided string.
-            framesPerTaskTextBox.text = newFramesPerTaskValue;
-        }
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
         if (list.selection == null) {
             return;
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
+            if (isNaN(newFramesPerTaskValue)){
+                framesPerTaskTextBox.text = uiSettingsState.get(selectionItem.compId).framesPerTask;
+            } else if (newFramesPerTaskValue > 9999) {
+                framesPerTaskTextBox.text = "9999"
+            } else {
+                framesPerTaskTextBox.text = newFramesPerTaskValue
+            }
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -2983,7 +3050,7 @@ function buildUI(thisObj) {
     mfrGroup.margins = 5;
 
     const mfrCheckBox = mfrGroup.add("checkbox", undefined, "Enable Multi-Frame Rendering");
-    mfrCheckBox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING) === "true";
+    mfrCheckBox.value = DEFAULT_MULTI_FRAME_RENDERING;
 
     const maxCpuUsagePercentageGroup = mfrGroup.add("group", undefined, "");
     maxCpuUsagePercentageGroup.orientation = "row";
@@ -2998,21 +3065,21 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.alignment = ['fill', 'top'];
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
+    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? DEFAULT_MAX_CPU_USAGE_PERCENTAGE : "N/A";
 
     function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+            maxCpuUsagePercentageTextBox.text = DEFAULT_MAX_CPU_USAGE_PERCENTAGE;
         } else {
             // Need to reassign in case input string is a number followed my random characters
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        const selectionItem = dcUtil.getSelection(list);
+        const selectionItem = dcUtil.getSelection(list)
         if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
+            var compId = selectionItem.compId;
+            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuPercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -3020,22 +3087,18 @@ function buildUI(thisObj) {
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
         const isMfrChecked = mfrCheckBox.value;
-        var settingsStateValue = false
-        if (!isMfrChecked) {
-            maxCpuUsagePercentageTextBox.text = "N/A";
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-        } else {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
-            settingsStateValue = true
-        }
-
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+            var compId = selectionItem.compId;
+            if (!isMfrChecked) {
+                maxCpuUsagePercentageTextBox.text = "N/A";
+                uiSettingsState.get(compId).setMultiFrameRendering(false);
+            } else {
+                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(compId).maxCpuUsagePercentage();
+                uiSettingsState.get(compId).setMultiFrameRendering(true);
+            }
         }
+        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
@@ -3068,72 +3131,82 @@ function buildUI(thisObj) {
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled;
 
     const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
+    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, uiSettingsState.taskRunDays());
     taskRunDaysInput.characters = 3;
     taskRunDaysGroup.add("statictext", undefined, "days");
 
     const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
+    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, uiSettingsState.taskRunHours());
     taskRunHoursInput.characters = 3;
     taskRunHoursGroup.add("statictext", undefined, "hours");
 
     const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
+    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, uiSettingsState.taskRunMinutes());
     taskRunMinutesInput.characters = 3;
     taskRunMinutesGroup.add("statictext", undefined, "minutes");
 
     // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
+        uiSettingsState.setTaskRunTimeoutEnabled(this.value);
         if (this.value) {
-            dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+            if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+                uiSettingsState.setTaskRunDays(DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS;
+                uiSettingsState.setTaskRunHours(DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_HOURS;
+                uiSettingsState.setTaskRunMinutes(DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_MINUTES;
+            }
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunTimeout(this.value)
-        }
+        uiSettingsState.setTaskRunTimeoutEnabled(this.value)
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunDays(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunDays(parseInt(this.text))
     }
     taskRunDaysInput.onChange = onTaskRunDaysChanged
 
     function onTaskRunHoursChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunHours(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunHours(parseInt(this.text))
     }
     taskRunHoursInput.onChange = onTaskRunHoursChanged
 
     function onTaskRunMinutesChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunMinutes(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunMinutes(parseInt(this.text))
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -225,16 +225,6 @@ function __generateUtil() {
     }
 
     /**
-     * Creates XMP path to access field of struct 
-     * @param {String} structPath 
-     * @param {String} fieldName 
-     * @returns 
-     */
-    function composeXMPField(structPath, fieldName) {
-        return structPath + "/xmp:" + fieldName
-    }
-
-    /**
      * Saves item to project's XMP Metadata
      * @param {String} key 
      * @param {*} value 
@@ -1022,7 +1012,6 @@ function __generateUtil() {
         "getTempFolder": getTempFolder,
         "getRQIID": getRQIID,
         "composeXMPPath": composeXMPPath,
-        "composeXMPField": composeXMPField,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists
@@ -1032,8 +1021,8 @@ function __generateUtil() {
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
-dcUtil.getStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
+dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
 
 
 var LOG_LEVEL = {
@@ -1221,44 +1210,37 @@ function UiSettingsState() {
     // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
 
-    this.xmpPath = DEADLINECLOUD_SETTINGS_ROOT;
-
-    /**
-     * @returns {boolean} 
-     */
+    // () -> bool
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
-
-    /**
-     * @param {boolean} value 
-     */
+    // (value: bool) -> void
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
@@ -1271,28 +1253,28 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 
@@ -2050,8 +2032,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
-    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
+    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -2063,11 +2045,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
+            dcUtil.saveStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1864,9 +1864,40 @@ function generateBundle() {
     return bundleRoot;
 }
 
+function generateParameterName(index, compName, parameter) {
+    /** Generates the name of the parameter to be used in the job submission
+     * by prefixing with the index and compName
+     * Truncates compname to avoid going over character limit.
+     **/
+    if (parameter === undefined) {
+        parameter = "";
+    }
+    if (parameter !== "") {
+        parameter = "_" + parameter;
+    }
+    index = index.toString();
+    compName = compName.substring(0, 15);
+    return "_" + index + "_" + compName + parameter;
+}
+
+function generatePrettyParameterName(index, compName, parameter) {
+    /** Generates name of the parameter to be displayed in job submission UI
+     * Truncates compname to avoid going over character limit
+     **/
+    if (parameter === undefined) {
+        parameter = "";
+    }
+    index = index.toString();
+    const max_length = 10;
+    if (compName.length >= max_length) {
+        compName = compName.substring(0, max_length - 3) + "...";
+    }
+    return "(" + index + "_" + compName + ") " + parameter;
+}
+
 // Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
 //      Adding our `( <RenderQueueItemID> )` to the label and changing the name to prefixed by `<RenderQueueItemID>_`
-function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID) {
+function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex, compName) {
     var path = bundlePath + "/parameter_definitions_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/parameter_definitions_image_fragment.json";
@@ -1882,8 +1913,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID
             continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = renderQueueItemID + "_" + stepParametersObject.parameterDefinitions[i].name;
-        replacedDefinition.userInterface.label = "(" + renderQueueItemID + ") " + replacedDefinition.userInterface.label;
+        replacedDefinition.name = generateParameterName(renderQueueIndex, compName, replacedDefinition.name);
+        replacedDefinition.userInterface.label = generatePrettyParameterName(renderQueueIndex, compName, replacedDefinition.userInterface.label);
 
         updatedParameterDefinitions.push(replacedDefinition);
     }
@@ -1893,7 +1924,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID, taskTimeoutSeconds) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -1905,18 +1936,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID,
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + renderQueueItemID + "_");
-        taskParameters.name = renderQueueItemID + "_" + taskParameters.name;
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_");
+        taskParameters.name = generateParameterName(renderQueueItemIndex, compName, taskParameters.name);
         stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
-    stepTemplateObject.steps[0].name = renderQueueItemID;
+    stepTemplateObject.steps[0].name = generateParameterName(renderQueueItemIndex, compName, "");
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + renderQueueItemID + "_"));
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
@@ -2143,7 +2174,6 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-        var renderQueueItemID = "_" + renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
@@ -2161,7 +2191,7 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
-            renderQueueItemID,
+            generateParameterName(renderQueueIndex, compName, ""),
             renderQueueIndex,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
@@ -2179,13 +2209,13 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + renderQueueItemID + "_OutputDir}}");
+        stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueItemID, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueItemID);
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -265,7 +265,7 @@ function __generateUtil() {
         return metadata.getProperty(XMPConst.NS_XMP, key, type).value;
     }
 
-    function saveBoolSetting(keyName, value) {
+    function saveBoolMetadata(keyName, value) {
         /**
          * Sets boolean value in app settings
          */
@@ -273,7 +273,7 @@ function __generateUtil() {
         saveToMetadata(keyName, value, XMPConst.BOOLEAN);
     }
 
-    function getBoolSetting(keyName, defaultValue) {
+    function getBoolMetadata(keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
@@ -281,7 +281,7 @@ function __generateUtil() {
         return loadFromMetadata(keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
-    function saveNumberSetting(keyName, value) {
+    function saveNumberMetadata(keyName, value) {
         /**
          * Sets integer value in app settings
          */
@@ -289,7 +289,7 @@ function __generateUtil() {
         saveToMetadata(keyName, value, XMPConst.NUMBER);
     }
 
-    function getNumberSetting(keyName, defaultValue) {
+    function getNumberMetadata(keyName, defaultValue) {
         /**
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
@@ -297,7 +297,7 @@ function __generateUtil() {
         return loadFromMetadata(keyName, defaultValue, XMPConst.NUMBER);
     }
 
-    function saveStringSetting(keyName, value) {
+    function saveStringMetadata(keyName, value) {
         /**
          * Sets string in app settings
          */
@@ -305,7 +305,7 @@ function __generateUtil() {
         saveToMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
-    function getStringSetting(keyName, defaultValue) {
+    function getStringMetadata(keyName, defaultValue) {
         /**
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
@@ -1003,12 +1003,12 @@ function __generateUtil() {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
         "parseBool": parseBool,
-        "saveBoolSetting": saveBoolSetting,
-        "getBoolSetting": getBoolSetting,
-        "saveNumberSetting": saveNumberSetting,
-        "getNumberSetting": getNumberSetting,
-        "saveStringSetting": saveStringSetting,
-        "getStringSetting": getStringSetting,
+        "saveBoolMetadata": saveBoolMetadata,
+        "getBoolMetadata": getBoolMetadata,
+        "saveNumberMetadata": saveNumberMetadata,
+        "getNumberMetadata": getNumberMetadata,
+        "saveStringMetadata": saveStringMetadata,
+        "getStringMetadata": getStringMetadata,
         "trimIllegalChars": trimIllegalChars,
         "sliderTextSync": sliderTextSync,
         "changeTextValue": changeTextValue,
@@ -1055,8 +1055,8 @@ function __generateUtil() {
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
-dcUtil.getStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
+dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
 
 
 var LOG_LEVEL = {
@@ -1249,35 +1249,35 @@ function UiSettingsState() {
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
     // (value: bool) -> void
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
@@ -1290,28 +1290,28 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 
@@ -2039,8 +2039,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
-    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
+    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -2052,11 +2052,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
+            dcUtil.saveStringMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
+                dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+                dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -819,79 +819,80 @@ function __generateUtil() {
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
         "getTempFolder": getTempFolder,
-        "calculateFrameRange": calculateFrameRange "validateTimeoutValues": validateTimeoutValues,
+        "calculateFrameRange": calculateFrameRange,
+        "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder
     }
+}
 
-    dcUtil = __generateUtil();
+dcUtil = __generateUtil();
 
 
-    // Global constants, wrapped with if-blocks to ensure they are only defined once
-    // to avoid errors due to redeclaration
-    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-        const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-    }
-    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-        const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-    }
-    if (typeof SUPPORTED_VERSIONS === "undefined") {
-        const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-    }
-    if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-        const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-    }
-    if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-        const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-    }
-    if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-        const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-    }
-    if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-        const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-    }
-    if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-        const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-    }
+// Global constants, wrapped with if-blocks to ensure they are only defined once
+// to avoid errors due to redeclaration
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+}
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+}
+if (typeof SUPPORTED_VERSIONS === "undefined") {
+    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+}
+if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+}
+if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+}
+if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+}
+if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+}
+if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
 }
 
 
@@ -1075,6 +1076,7 @@ var logger = Logger(logFileName, logNormDirectoryPath);
 function UiSettingsState() {
     this.settings = {}
 }
+
 function UiSettingsStore(name) {
     this.name = name;
     // _framesPerTask: string
@@ -1093,66 +1095,66 @@ function UiSettingsStore(name) {
     // _taskRunMinutes: string
     this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
 
-    this.framesPerTask = function () {
+    this.framesPerTask = function() {
         return this._framesPerTask
     }
-    this.setFramesPerTask = function (value) {
+    this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
         this._framesPerTask = typeof value === "string" ? value : value.toString()
     }
 
-    this.multiFrameRendering = function () {
+    this.multiFrameRendering = function() {
         return this._multiFrameRendering
     }
-    this.setMultiFrameRendering = function (value) {
+    this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
         this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.maxCpuUsagePercentage = function () {
+    this.maxCpuUsagePercentage = function() {
         return this._maxCpuUsagePercentage
     }
-    this.setMaxCpuUsagePercentage = function (value) {
+    this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
         this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
 
-    this.taskRunTimeout = function () {
+    this.taskRunTimeout = function() {
         return this._taskRunTimeout
     }
-    this.setTaskRunTimeout = function (value) {
+    this.setTaskRunTimeout = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
         this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunDays = function () {
+    this.taskRunDays = function() {
         return this._taskRunDays
     }
-    this.setTaskRunDays = function (value) {
+    this.setTaskRunDays = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
         this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunHours = function () {
+    this.taskRunHours = function() {
         return this._taskRunHours
     }
-    this.setTaskRunHours = function (value) {
+    this.setTaskRunHours = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
         this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunMinutes = function () {
+    this.taskRunMinutes = function() {
         return this._taskRunMinutes
     }
-    this.setTaskRunMinutes = function (value) {
+    this.setTaskRunMinutes = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
         this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
     }
 }
 
-UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
+UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
     if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId)
+        this.settings[compId] = new UiSettingsStore(compId);
     }
     if (framesPerTask === undefined) {
         framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
@@ -1191,7 +1193,6 @@ UiSettingsState.prototype.get = function(compId) {
     }
     return this.settings[compId]
 }
-
 
 
 var jobTemplateHelperFile = "JobTemplateHelper.json";
@@ -1907,11 +1908,6 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         }
     }
 
-    // Calculate frame range using the utility function
-    const frameRange = dcUtil.calculateFrameRange(rqi);
-    const startFrame = frameRange.startFrame;
-    const endFrame = frameRange.endFrame;
-
     // Check if warning should be shown
     const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
     const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
@@ -2060,20 +2056,10 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         logger.debug("OutputFile is: " + outputFile, submitBundleFile);
         logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
 
-        var renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
-        var startFrame = Number(
-            timeToFrames(
-                Number(renderSettings["Time Span Start"]),
-                Number(renderSettings["Use this frame rate"])
-            )
-        );
-        var endFrame =
-            Number(
-                timeToFrames(
-                    Number(renderSettings["Time Span End"]),
-                    Number(renderSettings["Use this frame rate"])
-                )
-            ) - 1; // end frame is inclusive so we subtract 1
+        // Calculate frame range using the utility function
+        const frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+        const startFrame = frameRange.startFrame;
+        const endFrame = frameRange.endFrame;
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
@@ -2776,8 +2762,9 @@ function populateListBoxItem(item, renderQueueItem, index) {
     item.subItems[0].text = renderQueueItem.comp.name;
 
     const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
-    const startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
-    const endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+    var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+    var startFrame = frameRange.startFrame;
+    var endFrame = frameRange.endFrame;
 
     item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
     if (renderQueueItem.numOutputModules <= 0) {
@@ -3199,14 +3186,14 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            const rqi = app.project.renderQueue.item(i);
+            var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {
                 continue;
             }
             if (rqi.status == RQItemStatus.RENDERING || rqi.status == RQItemStatus.WILL_CONTINUE || rqi.status == RQItemStatus.USER_STOPPED || rqi.status == RQItemStatus.ERR_STOPPED || rqi.status == RQItemStatus.DONE) {
                 continue;
             }
-            const item = newList.add('item', i.toString());
+            var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
@@ -3222,7 +3209,7 @@ function buildUI(thisObj) {
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";
             } else if (rqi.numOutputModules == 1) {
-                const outputFile = rqi.outputModule(1).file;
+                var outputFile = rqi.outputModule(1).file;
                 item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
             } else {
                 item.subItems[2].text = "<multiple output modules>";

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1971,10 +1971,8 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
-    if (stepTemplateObject.steps[0].script.actions.onRun) {
-        stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
-        logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
-    }
+    stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+    logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
 
     return stepTemplateObject;
 }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2161,7 +2161,7 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
-            compName,
+            compName + "_" + renderQueueIndex,
             renderQueueIndex,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
@@ -3098,38 +3098,10 @@ function buildUI(thisObj) {
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
-
-    // Check for duplicate names
-    function checkForInvalidCompositionNames(selection) {
-        const names = [];
-        const duplicateNames = [];
-        for (var i = 0; i < selection.length; i++) {
-            var selectionItem = selection[i];
-            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
-            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-            if (names.indexOf(compName) !== -1) {
-                duplicateNames.push(renderQueueItem.comp.name);
-            }
-            names.push(compName);
-        }
-        if (duplicateNames.length !== 0) {
-            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: ";
-            for (var i = 0; i < duplicateNames.length; i++) {
-                message = message + "\n\t" + duplicateNames[i];
-            }
-            adcAlert(message, true);
-            return true;
-        }
-        return false;
-    }
-
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
             if (list.selection === null) {
-                return;
-            }
-            if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }
             SubmitSelection(list.selection, uiSettingsState);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -872,8 +872,8 @@ function __generateUtil() {
 
     function getRQIID(renderQueueIndex) {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
-        * Not guaranteed to be unique
-        */
+         * Not guaranteed to be unique
+         */
         return app.project.file.name + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
     }
 
@@ -920,7 +920,8 @@ function __generateUtil() {
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
-        "getTempFolder": getTempFolder
+        "getTempFolder": getTempFolder,
+        "getRQIID": getRQIID
     }
 }
 
@@ -1247,32 +1248,32 @@ function UiSettingsStore(name) {
     }
 }
 
-UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+UiSettingsState.prototype.create = function(RQIID, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
     /**
-     * Adds new UISettingsStore to store settings for the comp associated with compId
+     * Adds new UISettingsStore to store settings for the comp associated with Render Queue Item ID
      */
-    if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId);
+    if (!this.settings[RQIID]) {
+        this.settings[RQIID] = new UiSettingsStore(RQIID);
     }
     if (framesPerTask !== undefined) {
-        this.settings[compId].setFramesPerTask(framesPerTask);
+        this.settings[RQIID].setFramesPerTask(framesPerTask);
     }
     if (multiFrameRendering !== undefined) {
-        this.settings[compId].setMultiFrameRendering(multiFrameRendering);
+        this.settings[RQIID].setMultiFrameRendering(multiFrameRendering);
     }
     if (maxCpuUsagePercentage !== undefined) {
-        this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+        this.settings[RQIID].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
     }
 }
 
-UiSettingsState.prototype.get = function(compId) {
+UiSettingsState.prototype.get = function(RQIID) {
     /**
-     * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
+     * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
-    if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId);
+    if (!this.settings[RQIID]) {
+        this.settings[RQIID] = new UiSettingsStore(RQIID);
     }
-    return this.settings[compId]
+    return this.settings[RQIID]
 }
 
 
@@ -2122,9 +2123,9 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(renderQueueItem.comp.id).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering();
+        var stepFramesPerTask = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -2913,13 +2914,13 @@ function buildUI(thisObj) {
         if (selectionItem) {
             var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
             if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(selectionItem.compId).framesPerTask();
+                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).framesPerTask();
             }
             if (newFramesPerTaskValue > 9999) {
                 newFramesPerTaskValue = 9999;
             }
             framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(selectionItem.compId).setFramesPerTask(newFramesPerTaskValue);
+            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -2960,8 +2961,7 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var compId = selectionItem.compId;
-            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
+            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -2971,13 +2971,13 @@ function buildUI(thisObj) {
         const isMfrChecked = mfrCheckBox.value;
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var compId = selectionItem.compId;
+            var RQIID = dcUtil.getRQIID(selectionItem.renderQueueIndex);
             if (!isMfrChecked) {
                 maxCpuUsagePercentageTextBox.text = "N/A";
-                uiSettingsState.get(compId).setMultiFrameRendering(false);
+                uiSettingsState.get(RQIID).setMultiFrameRendering(false);
             } else {
-                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(compId).maxCpuUsagePercentage();
-                uiSettingsState.get(compId).setMultiFrameRendering(true);
+                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(RQIID).maxCpuUsagePercentage();
+                uiSettingsState.get(RQIID).setMultiFrameRendering(true);
             }
         }
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
@@ -3162,7 +3162,7 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
-            uiSettingsState.get(item.compId);
+            uiSettingsState.get(i);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -3206,19 +3206,22 @@ function buildUI(thisObj) {
             const selectionItem = selection[0];
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-            framesPerTaskTextBox.enabled = imageOutput;
-            mfrCheckBox.enabled = true;
-            maxCpuUsagePercentageTextBox.enabled = true;
 
-            const settings = uiSettingsState.get(selectionItem.compId);
+            const settings = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex));
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return;
             }
 
-            framesPerTaskTextBox.text = settings.framesPerTask();
-            framesPerTaskTextBox.onChange();
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
+            if (imageOutput) {
+                framesPerTaskTextBox.text = settings.framesPerTask();
+                framesPerTaskTextBox.enabled = true;
+                framesPerTaskTextBox.onChange()
+            } else {
+                framesPerTaskTextBox.text = "Selection is not image sequence";
+                framesPerTaskTextBox.enabled = false;
+            }
             maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
             maxCpuUsagePercentageTextBox.onChange();
             mfrCheckBox.value = settings.multiFrameRendering();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -782,6 +782,7 @@ function __generateUtil() {
         for (var s = 0; s < list.selection.length; s++) {
             return list.selection[s];
         }
+        return list.selection[0];
     }
 
     return {
@@ -2034,7 +2035,6 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     template.steps = []
     template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
 
-    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
     const stepOutputFolderParameters = [];
 
     for (var i = 0; i < renderQueueItems.length; i++) {
@@ -3029,7 +3029,6 @@ function buildUI(thisObj) {
         if (!isMfrChecked) {
             maxCpuUsagePercentageTextBox.text = "N/A";
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-            settingsStateValue = false
         } else {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -165,7 +165,7 @@ function __generateUtil() {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
             }
-            setBoolSetting(sectionName, keyName, default_value);
+            saveBoolSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
         }
         return parseBool(app.settings.getSetting(sectionName, keyName));
@@ -188,14 +188,14 @@ function __generateUtil() {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
             }
-            setNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value)
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            setNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value)
             logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
@@ -976,15 +976,15 @@ if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
 if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
     const DEFAULT_MULTI_FRAME_RENDERING = false;
 }
-if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE) {
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
 }
 
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
 }
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+    dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
 }
 
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -959,7 +959,7 @@ function __generateUtil() {
         return list.selection[0];
     }
 
-    function getRQIID(renderQueueIndex) {
+    function getRenderQueueItemID(renderQueueIndex) {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
          * Not guaranteed to be unique if render queue items are reordered
          */
@@ -980,7 +980,7 @@ function __generateUtil() {
         }
         var ids = []
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            ids.push(getRQIID(i));
+            ids.push(getRenderQueueItemID(i));
         }
         for (var i = 0; i < paths.length; i++) {
             var presentInArray = false;
@@ -1043,7 +1043,7 @@ function __generateUtil() {
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder,
-        "getRQIID": getRQIID,
+        "getRenderQueueItemID": getRenderQueueItemID,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
@@ -2203,9 +2203,9 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).multiFrameRendering();
+        var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -2993,13 +2993,13 @@ function buildUI(thisObj) {
         if (selectionItem) {
             var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
             if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).framesPerTask();
+                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).framesPerTask();
             }
             if (newFramesPerTaskValue > 9999) {
                 newFramesPerTaskValue = 9999;
             }
             framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -3040,7 +3040,7 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -3050,7 +3050,7 @@ function buildUI(thisObj) {
         const isMfrChecked = mfrCheckBox.value;
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var RQIID = dcUtil.getRQIID(selectionItem.renderQueueIndex);
+            var RQIID = dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex);
             if (!isMfrChecked) {
                 maxCpuUsagePercentageTextBox.text = "N/A";
                 uiSettingsState.get(RQIID).setMultiFrameRendering(false);
@@ -3188,8 +3188,6 @@ function buildUI(thisObj) {
     submitButton.enabled = false;
 
     function updateList() {
-        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
-
         const bounds = list == null ? undefined : list.bounds;
         const newList = listGroup.add("listbox", bounds, "", {
             multiselect: true,
@@ -3232,6 +3230,8 @@ function buildUI(thisObj) {
             }
         }
 
+        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
+
         if (list != null) {
             listGroup.remove(list);
         }
@@ -3258,7 +3258,7 @@ function buildUI(thisObj) {
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
 
-            const settings = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex));
+            const settings = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex));
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -112,7 +112,7 @@ function adcAlert(message, errorIcon) {
 }
 
 function validateType(item, item_type) {
-    actual_type = typeof item;
+    var actual_type = typeof item;
     if (actual_type !== item_type) {
         throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
     }
@@ -152,8 +152,8 @@ function __generateUtil() {
         /**
          * Sets boolean value in app settings
          */
-        validateType(value, "boolean")
-        app.settings.saveSetting(sectionName, keyName, value.toString())
+        validateType(value, "boolean");
+        app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
     function getBoolSetting(sectionName, keyName, default_value) {
@@ -175,8 +175,8 @@ function __generateUtil() {
         /**
          * Sets integer value in app settings
          */
-        validateType(value, "number")
-        app.settings.saveSetting(sectionName, keyName, value.toString())
+        validateType(value, "number");
+        app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
     function getNumberSetting(sectionName, keyName, default_value) {
@@ -186,16 +186,16 @@ function __generateUtil() {
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
             if (default_value === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            saveNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            saveNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
@@ -210,7 +210,7 @@ function __generateUtil() {
     }
 
     function getStringSetting(sectionName, keyName, defaultValue) {
-         /**
+        /**
          * Gets string value from app settings, or sets default_value if setting does not exist
          * Set default_value to undefined to error on missing setting
          */
@@ -221,7 +221,7 @@ function __generateUtil() {
             setStringSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
-        return app.settings.getSetting(sectionName, keyName) 
+        return app.settings.getSetting(sectionName, keyName)
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -315,7 +315,7 @@ function __generateUtil() {
          */
         maxValue.text = maxValue.text.replace(/[^\d]/g, '');
         if (parseInt(maxValue.text) < parseInt(minValue.text)) {
-            maxValue.text = minValue.text
+            maxValue.text = minValue.text;
         }
     }
 
@@ -493,10 +493,10 @@ function __generateUtil() {
         _makeBootstrapBatFile(tempBootstrapBatFile, tempBatFile);
         // Wrapped command with error code output
         cmd = cmd + " > " + tempOutputFile.fsName;
-        cmd += "\nIF %ERRORLEVEL% NEQ 0 ("
-        cmd += "\n echo ERROR CODE: %ERRORLEVEL% >> " + tempOutputFile.fsName
-        cmd += "\n)"
-        cmd += "\nexit"
+        cmd += "\nIF %ERRORLEVEL% NEQ 0 (";
+        cmd += "\n echo ERROR CODE: %ERRORLEVEL% >> " + tempOutputFile.fsName;
+        cmd += "\n)";
+        cmd += "\nexit";
         tempBatFile.open("w");
         tempBatFile.writeln(cmd);
         tempBatFile.close();
@@ -512,7 +512,7 @@ function __generateUtil() {
     }
 
     function _makeBootstrapBatFile(bootstrapFile, tempFile) {
-        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
+        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit";
         bootstrapFile.open("w");
         bootstrapFile.writeln(_cmd);
         bootstrapFile.close();
@@ -549,7 +549,7 @@ function __generateUtil() {
             }
         }
         result = "";
-        message = cmd + " Successful."
+        message = cmd + " Successful.";
         return {
             "return_code": return_code,
             "message": message,
@@ -636,14 +636,14 @@ function __generateUtil() {
         var maxSeqNumber = 0;
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
-            folderName = subFolders[idx].fullName
-            const match = folderName.match(regex)
+            folderName = subFolders[idx].fullName;
+            const match = folderName.match(regex);
             if (!match) {
                 continue;
             }
             const seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
-                maxSeqNumber = seqNr
+                maxSeqNumber = seqNr;
             }
         }
         // 2. Create new export directory with next sequence number
@@ -817,7 +817,7 @@ function __generateUtil() {
     function getUserDirectory() {
         /* Return OS specific user home directory. */
         if (system.osName == "MacOS") {
-            return $.getenv("HOME")
+            return $.getenv("HOME");
         }
         // Windows:
         return $.getenv("USERPROFILE");
@@ -827,7 +827,7 @@ function __generateUtil() {
         /* Return After Effects version as float. */
         const versionAsString = app.version.substring(0, 4);
         const version = parseFloat(versionAsString);
-        return version
+        return version;
     }
 
     function calculateFrameRange(rqi) {
@@ -995,7 +995,7 @@ var LOG_LEVEL = {
     DEBUG: 4
 };
 
-var LOG_LEVEL_MAP = dcUtil.invertObject(LOG_LEVEL)
+var LOG_LEVEL_MAP = dcUtil.invertObject(LOG_LEVEL);
 
 // Global log level
 // Set the desired logging level
@@ -1067,16 +1067,16 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
         // Rollover older files first
         var rolloverFile;
         for (var i = backupCount - 1; i > 0; i--) { // Last file does not need rollover, it is allowed to get overwritten.
-            rolloverFile = new File(logDirectoryPath + logFileName + "." + i)
+            rolloverFile = new File(logDirectoryPath + logFileName + "." + i);
             if (!rolloverFile.exists) {
                 continue;
             }
             var j = i + 1;
-            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
+            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file
-        logFile.copy(logDirectoryPath + logFileName + "." + 1)
+        logFile.copy(logDirectoryPath + logFileName + "." + 1);
         logFile.open("w"); // Erase contents of active log file
         logFile.close();
     }
@@ -1160,7 +1160,7 @@ function getCurrentTimeAsStr() {
 var _scriptFileName = "OpenAeSubmitter.jsx";
 var logFileName = "aftereffects.log";
 var logDirectoryPath = dcUtil.getUserDirectory() + "/.deadline/logs/submitters/";
-var logNormDirectoryPath = dcUtil.normPath(logDirectoryPath)
+var logNormDirectoryPath = dcUtil.normPath(logDirectoryPath);
 var logger = Logger(logFileName, logNormDirectoryPath);
 
 
@@ -1215,10 +1215,10 @@ function UiSettingsStore(name) {
     this.name = name;
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name +"_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
         dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
     }
 
@@ -1226,17 +1226,17 @@ function UiSettingsStore(name) {
         return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
         dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE)
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name+"_"+DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value)
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value);
     }
 }
 
@@ -1263,7 +1263,7 @@ UiSettingsState.prototype.get = function(compId) {
      * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
      */
     if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId)
+        this.settings[compId] = new UiSettingsStore(compId);
     }
     return this.settings[compId]
 }
@@ -1311,7 +1311,7 @@ function parameterValues(
         parameterValuesList.push({
             name: prefix + "_MaxCpuUsagePercentage",
             value: maxCpuUsagePercentage,
-        })
+        });
     }
     if (isImageSeq) {
         parameterValuesList.push({
@@ -1737,18 +1737,17 @@ function isImageOutput(extension) {
 }
 
 
-
 var JobParams = [
     "JobScriptDir",
     "CondaPackages",
     "ProjectFile"
 ]
 
-var paramPattern = "Param\."
+var paramPattern = "Param\.";
 for (var p = 0; p < JobParams.length; p++) {
-    paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
+    paramPattern = paramPattern + "(?!" + JobParams[p] + ")";
 }
-var paramPatternRegex = new RegExp(paramPattern, 'g')
+var paramPatternRegex = new RegExp(paramPattern, 'g');
 
 if (typeof submitBundleFile == 'undefined') {
     const submitBundleFile = "SubmitButton.jsx";
@@ -1820,7 +1819,7 @@ function generateParameterValuesForStep(
         multiFrameRendering,
         maxCpuUsagePercentage,
         prefix,
-    )
+    );
 }
 
 // Loading our default template from disk
@@ -1832,7 +1831,7 @@ function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
     templateObject.name = File.decode(app.project.file.name);
     logger.debug("The template name is " + templateObject.name, submitBundleFile);
 
-    return templateObject
+    return templateObject;
 }
 
 // Generates the job bundle and copies files from our template source folder into it
@@ -1872,16 +1871,16 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
     for (var i = 0; i < stepParametersObject.parameterDefinitions.length; i++) {
         if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
             // Don't modify these values
-            continue
+            continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name
-        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label
+        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name;
+        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label;
 
-        updatedParameterDefinitions.push(replacedDefinition)
+        updatedParameterDefinitions.push(replacedDefinition);
     }
-    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
-    return stepParametersObject
+    stepParametersObject.parameterDefinitions = updatedParameterDefinitions;
+    return stepParametersObject;
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
@@ -1898,26 +1897,26 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_")
-        taskParameters.name = compName + "_" + taskParameters.name
-        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_");
+        taskParameters.name = compName + "_" + taskParameters.name;
+        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
     stepTemplateObject.steps[0].name = compName;
     // Replace any parameter names in onRun script
-    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
+    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"));
     }
-    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
         stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
         logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
     }
 
-    return stepTemplateObject
+    return stepTemplateObject;
 }
 
 // Modifies the `Create Output Directories` job environment by adding all of our output folder parameters
@@ -1935,7 +1934,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
             ]
         }
     }
-    return jobEnvironmentsObject
+    return jobEnvironmentsObject;
 }
 
 /**
@@ -1951,7 +1950,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
-    const renderQueueItems = []
+    const renderQueueItems = [];
 
     // Check to make sure that all of our selection indices are correct
     for (var i = 0; i < selection.length; i++) {
@@ -1964,7 +1963,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
         var initialRenderQueueItem = app.project.renderQueue.item(initialRenderQueueIndex);
-        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
+        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex]);
     }
 
     // We have valid selections check for saving
@@ -1996,11 +1995,11 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString())
+            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true)
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true);
             } else {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false)
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
                 return;
             }
         } else {
@@ -2104,8 +2103,8 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
 
     const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
-    template.steps = []
-    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
+    template.steps = [];
+    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions;
 
     const stepOutputFolderParameters = [];
 
@@ -2117,9 +2116,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
 
-        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage)
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering
+        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask);
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage);
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering;
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -2150,9 +2149,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
 
         // Push step asset references
         for (var d = 0; d < dependencies.length; d++) {
-            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
+            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d]);
         }
-        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
+        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
             compName,
@@ -2165,38 +2164,38 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             stepFramesPerTask,
             stepMultiFrameRendering,
             stepMaxCpuUsagePercentage
-        )
+        );
 
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
-                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
+                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p]);
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
+        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
-            template.steps.push(stepTemplate.steps[s])
+            template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {
                 var templateParameterDefinition = template.parameterDefinitions[tpd];
                 var stepParameterDefinition = stepParameters.parameterDefinitions[p];
                 if (templateParameterDefinition.name == stepParameterDefinition.name) {
-                    parameterExists = true
-                    break
+                    parameterExists = true;
+                    break;
                 }
             }
             if (parameterExists === false) {
-                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p])
+                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p]);
             }
         }
     }
-    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
-    template.jobEnvironments = generatedJobEnvironment.jobEnvironments
+    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","));
+    template.jobEnvironments = generatedJobEnvironment.jobEnvironments;
 
     writeFile(bundle.fsName + "/asset_references.json", JSON.stringify(jobAssetReferences, null, 4));
 
@@ -2861,7 +2860,7 @@ function refreshList(listBox, uiSettingsState) {
         RQItemStatus.USER_STOPPED,
         RQItemStatus.ERR_STOPPED,
         RQItemStatus.DONE
-    ]
+    ];
     for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
         var renderQueueItem = app.project.renderQueue.item(index);
         if (renderQueueItem == null) {
@@ -2896,7 +2895,7 @@ function buildUI(thisObj) {
     const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
-    root.alignChildren = ['fill', 'top']
+    root.alignChildren = ['fill', 'top'];
     const logoGroup = root.add("group");
     logoGroup.alignment = 'left';
     logoGroup.add("image", undefined, logoData());
@@ -2914,11 +2913,11 @@ function buildUI(thisObj) {
     const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
     const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'top'];
-    listGroup.alignChildren = ['fill', 'top']
-    listGroup.orientation = "column"
+    listGroup.alignChildren = ['fill', 'top'];
+    listGroup.orientation = "column";
     var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
         multiline: true
-    })
+    });
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
     multiCompLabel.maximumSize.height = 30;
     multiCompLabel.alignment = ['fill', 'top'];
@@ -2944,55 +2943,55 @@ function buildUI(thisObj) {
         submitButton.active = true;
 
         // Disable everything
-        framesPerTaskTextBox.enabled = false
-        mfrCheckBox.enabled = false
-        maxCpuUsagePercentageTextBox.enabled = false
-        taskRunCheckbox.enabled = false
-        taskRunDaysInput.enabled = false
-        taskRunHoursInput.enabled = false
-        taskRunMinutesInput.enabled = false
+        framesPerTaskTextBox.enabled = false;
+        mfrCheckBox.enabled = false;
+        maxCpuUsagePercentageTextBox.enabled = false;
+        taskRunCheckbox.enabled = false;
+        taskRunDaysInput.enabled = false;
+        taskRunHoursInput.enabled = false;
+        taskRunMinutesInput.enabled = false;
 
         if (selection.length !== 1) {
-            return
+            return;
         }
-        const selectionItem = selection[0]
+        const selectionItem = selection[0];
         logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
-        framesPerTaskTextBox.enabled = imageOutput
-        mfrCheckBox.enabled = true
-        maxCpuUsagePercentageTextBox.enabled = true
-        taskRunCheckbox.enabled = true
-        taskRunDaysInput.enabled = true
-        taskRunHoursInput.enabled = true
-        taskRunMinutesInput.enabled = true
+        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
+        framesPerTaskTextBox.enabled = imageOutput;
+        mfrCheckBox.enabled = true;
+        maxCpuUsagePercentageTextBox.enabled = true;
+        taskRunCheckbox.enabled = true;
+        taskRunDaysInput.enabled = true;
+        taskRunHoursInput.enabled = true;
+        taskRunMinutesInput.enabled = true;
 
         logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
-        framesPerTaskTextBox.text = selectionItem.subItems[1].text
+        framesPerTaskTextBox.text = selectionItem.subItems[1].text;
 
-        const settings = uiSettingsState.get(selectionItem.compId)
+        const settings = uiSettingsState.get(selectionItem.compId);
         if (settings === undefined) {
             logger.warning("Could not find settings for : " + selectionItem.compId);
-            return
+            return;
         }
 
         if (imageOutput === true) {
             logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text;
         }
         logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
-        mfrCheckBox.value = settings.multiFrameRendering()
+        mfrCheckBox.value = settings.multiFrameRendering();
         logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
-        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
+        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
 
-        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
 
-        taskRunCheckbox.value = settings.taskRunTimeoutEnabled()
-        taskRunDaysInput.enabled = taskRunCheckbox.value
-        taskRunDaysInput.text = settings.taskRunDays()
-        taskRunHoursInput.enabled = taskRunCheckbox.value
-        taskRunHoursInput.text = settings.taskRunHours()
-        taskRunMinutesInput.enabled = taskRunCheckbox.value
-        taskRunMinutesInput.text = settings.taskRunMinutes()
+        taskRunCheckbox.value = settings.taskRunTimeoutEnabled();
+        taskRunDaysInput.enabled = taskRunCheckbox.value;
+        taskRunDaysInput.text = settings.taskRunDays();
+        taskRunHoursInput.enabled = taskRunCheckbox.value;
+        taskRunHoursInput.text = settings.taskRunHours();
+        taskRunMinutesInput.enabled = taskRunCheckbox.value;
+        taskRunMinutesInput.text = settings.taskRunMinutes();
     }
 
     list.onChange = onSelectionChange;
@@ -3018,7 +3017,7 @@ function buildUI(thisObj) {
 
     const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task");
     framesPerTaskLabel.alignment = ['left', 'center'];
-    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output."
+    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output.";
 
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
@@ -3077,7 +3076,7 @@ function buildUI(thisObj) {
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        const selectionItem = dcUtil.getSelection(list)
+        const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
             var compId = selectionItem.compId;
             uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
@@ -3112,10 +3111,10 @@ function buildUI(thisObj) {
                 return isImageOutput(extension);
             }
         }
-        return false
+        return false;
     }
 
-    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings")
+    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings");
     globalSettingsGroup.orientation = "column";
     globalSettingsGroup.alignment = ['fill', 'top'];
     globalSettingsGroup.alignChildren = ['left', 'top'];
@@ -3170,7 +3169,7 @@ function buildUI(thisObj) {
         taskRunDaysInput.enabled = taskRunCheckbox.value;
         taskRunHoursInput.enabled = taskRunCheckbox.value;
         taskRunMinutesInput.enabled = taskRunCheckbox.value;
-        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
+        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value);
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked;
     onTaskRunCheckboxClicked();
@@ -3178,11 +3177,11 @@ function buildUI(thisObj) {
     function onTaskRunDaysChanged() {
         var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunDaysInput.text)
+        var new_value = parseInt(taskRunDaysInput.text);
         if (taskRunDaysInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunDays(new_value)
+                uiSettingsState.setTaskRunDays(new_value);
             }
         }
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
@@ -3192,11 +3191,11 @@ function buildUI(thisObj) {
     function onTaskRunHoursChanged() {
         var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunHoursInput.text)
+        var new_value = parseInt(taskRunHoursInput.text);
         if (taskRunHoursInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunHours(new_value)
+                uiSettingsState.setTaskRunHours(new_value);
             }
         }
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
@@ -3206,11 +3205,11 @@ function buildUI(thisObj) {
     function onTaskRunMinutesChanged() {
         var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunMinutesInput.text)
+        var new_value = parseInt(taskRunMinutesInput.text);
         if (taskRunMinutesInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunMinutes(new_value)
+                uiSettingsState.setTaskRunMinutes(new_value);
             }
         }
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
@@ -3232,14 +3231,14 @@ function buildUI(thisObj) {
             names.push(compName);
         }
         if (duplicateNames.length !== 0) {
-            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
+            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: ";
             for (var i = 0; i < duplicateNames.length; i++) {
                 message = message + "\n\t" + duplicateNames[i];
             }
-            adcAlert(message, true)
-            return true
+            adcAlert(message, true);
+            return true;
         }
-        return false
+        return false;
     }
 
     const submitButton = controlsGroup.add("button", undefined, "Submit");
@@ -3248,10 +3247,10 @@ function buildUI(thisObj) {
             const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
             var maxCpuUsagePercentage = undefined;
             if (mfrCheckBox.value) {
-                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
             }
             if (checkForInvalidCompositionNames(list.selection)) {
-                return
+                return;
             }
             if (taskRunCheckbox.value) {
                 SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
@@ -3287,7 +3286,7 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
-            uiSettingsState.get(item.compId)
+            uiSettingsState.get(item.compId);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -3317,27 +3316,27 @@ function buildUI(thisObj) {
 
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
-            maxCpuUsagePercentageTextBox.text = ""
+            maxCpuUsagePercentageTextBox.text = "";
 
             submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
 
             if (selection == null || selection.length !== 1) {
-                return
+                return;
             }
-            const selectionItem = selection[0]
+            const selectionItem = selection[0];
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
             framesPerTaskTextBox.enabled = imageOutput;
             mfrCheckBox.enabled = true;
             maxCpuUsagePercentageTextBox.enabled = true;
 
-            const settings = uiSettingsState.get(selectionItem.compId)
+            const settings = uiSettingsState.get(selectionItem.compId);
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
-                return
+                return;
             }
 
             framesPerTaskTextBox.text = settings.framesPerTask();
@@ -3355,9 +3354,9 @@ function buildUI(thisObj) {
     updateList();
     refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
-        const selectionItem = list.selection[0]
-        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
-        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
+        const selectionItem = list.selection[0];
+        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
+        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
     refreshButton.onClick = function() {
         refreshList(list, uiSettingsState);
@@ -3369,7 +3368,7 @@ function buildUI(thisObj) {
         this.layout.resize();
     }
     if (!(thisObj instanceof Panel)) {
-        submitterPanel.center()
+        submitterPanel.center();
         submitterPanel.show();
         submitterPanel.update();
     }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3172,6 +3172,14 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 200;
         newList.preferredSize.width = 500;
 
+        // Disable all controls if the render queue is empty
+        // This forces the user to click "refresh" when a new project is opened and populate the list
+        controlsGroup.enabled = app.project.renderQueue.numItems > 0;
+        // Also populate timeout settings because the values could be stale if a new project has been opened since the last refresh
+        taskRunDaysInput.text = uiSettingsState.taskRunDays();
+        taskRunHoursInput.text = uiSettingsState.taskRunHours();
+        taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
+
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2708,8 +2708,7 @@ function buildUI(thisObj) {
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
 
-    const bounds = list == null ? undefined : list.bounds;
-    var list = listGroup.add("listbox", bounds, "", {
+    var list = listGroup.add("listbox", undefined, "", {
         multiselect: true,
         numberOfColumns: 4,
         showHeaders: true,

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -757,146 +757,141 @@ function __generateUtil() {
         const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
-
         return {
             startFrame: startFrame,
             endFrame: endFrame
         };
     }
 
-        function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
-            if (enabled) {
-                var days = parseInt(daysInput.text) || 0;
-                var hours = parseInt(hoursInput.text) || 0;
-                var minutes = parseInt(minutesInput.text) || 0;
+    function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+        if (enabled) {
+            var days = parseInt(daysInput.text) || 0;
+            var hours = parseInt(hoursInput.text) || 0;
+            var minutes = parseInt(minutesInput.text) || 0;
 
-                if (days === 0 && hours === 0 && minutes === 0) {
-                    adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        function getSelection(list) {
-            for (var s = 0; s < list.selection.length; s++) {
-                return list.selection[s];
+            if (days === 0 && hours === 0 && minutes === 0) {
+                adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                return false;
             }
         }
-
-        return {
-            "invertObject": invertObject,
-            "toBooleanString": toBooleanString,
-            "parseBool": parseBool,
-            "trimIllegalChars": trimIllegalChars,
-            "sliderTextSync": sliderTextSync,
-            "changeTextValue": changeTextValue,
-            "changeSliderValue": changeSliderValue,
-            "checkGPUAccelType": checkGPUAccelType,
-            "spinBoxLimiterMin": spinBoxLimiterMin,
-            "spinBoxLimiterMax": spinBoxLimiterMax,
-            "getAssetsInScene": getAssetsInScene,
-            "editTextIntValidation": editTextIntValidation,
-            "getDescription": getDescription,
-            "wrappedCallSystem": wrappedCallSystem,
-            "parseErrorData": parseErrorData,
-            "parseVersionData": parseVersionData,
-            "createExportBundleDir": createExportBundleDir,
-            "removeLineBreak": removeLineBreak,
-            "setListBoxSelection": setListBoxSelection,
-            "getPath": getPath,
-            "getPartialExportDir": getPartialExportDir,
-            "collectHostRequirements": collectHostRequirements,
-            "deepCopy": deepCopy,
-            "getActiveComp": getActiveComp,
-            "normalizePath": normalizePath,
-            "normPath": normalizePath,
-            "enforceForwardSlashes": enforceForwardSlashes,
-            "removeIllegalCharacters": removeIllegalCharacters,
-            "removePercentageFromFileName": removePercentageFromFileName,
-            "getTempFile": getTempFile,
-            "getUserDirectory": getUserDirectory,
-            "getAEVersion": getAEVersion,
-            "getTempFolder": getTempFolder,
-            "calculateFrameRange": calculateFrameRange
-            "validateTimeoutValues": validateTimeoutValues,
-            "getSelection": getSelection,
-            "getTempFolder": getTempFolder
+        return true;
     }
 
+    function getSelection(list) {
+        for (var s = 0; s < list.selection.length; s++) {
+            return list.selection[s];
+        }
+    }
+
+    return {
+        "invertObject": invertObject,
+        "toBooleanString": toBooleanString,
+        "parseBool": parseBool,
+        "trimIllegalChars": trimIllegalChars,
+        "sliderTextSync": sliderTextSync,
+        "changeTextValue": changeTextValue,
+        "changeSliderValue": changeSliderValue,
+        "checkGPUAccelType": checkGPUAccelType,
+        "spinBoxLimiterMin": spinBoxLimiterMin,
+        "spinBoxLimiterMax": spinBoxLimiterMax,
+        "getAssetsInScene": getAssetsInScene,
+        "editTextIntValidation": editTextIntValidation,
+        "getDescription": getDescription,
+        "wrappedCallSystem": wrappedCallSystem,
+        "parseErrorData": parseErrorData,
+        "parseVersionData": parseVersionData,
+        "createExportBundleDir": createExportBundleDir,
+        "removeLineBreak": removeLineBreak,
+        "setListBoxSelection": setListBoxSelection,
+        "getPath": getPath,
+        "getPartialExportDir": getPartialExportDir,
+        "collectHostRequirements": collectHostRequirements,
+        "deepCopy": deepCopy,
+        "getActiveComp": getActiveComp,
+        "normalizePath": normalizePath,
+        "normPath": normalizePath,
+        "enforceForwardSlashes": enforceForwardSlashes,
+        "removeIllegalCharacters": removeIllegalCharacters,
+        "removePercentageFromFileName": removePercentageFromFileName,
+        "getTempFile": getTempFile,
+        "getUserDirectory": getUserDirectory,
+        "getAEVersion": getAEVersion,
+        "getTempFolder": getTempFolder,
+        "calculateFrameRange": calculateFrameRange "validateTimeoutValues": validateTimeoutValues,
+        "getSelection": getSelection,
+        "getTempFolder": getTempFolder
+    }
+
+    dcUtil = __generateUtil();
+
+
+    // Global constants, wrapped with if-blocks to ensure they are only defined once
+    // to avoid errors due to redeclaration
+    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+        const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+    }
+    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+        const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+    }
+    if (typeof SUPPORTED_VERSIONS === "undefined") {
+        const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+    }
+    if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+        const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+    }
+    if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+        const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+    }
+    if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+        const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+    }
+    if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+        const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+    }
+    if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+        const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+    }
 }
-
-
-
-dcUtil = __generateUtil();
-
-
-                        // Global constants, wrapped with if-blocks to ensure they are only defined once
-                        // to avoid errors due to redeclaration
-                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-                            const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-                        }
-                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-                            const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-                        }
-                        if (typeof SUPPORTED_VERSIONS === "undefined") {
-                            const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-                        }
-                        if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-                            const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-                        }
-                        if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-                            const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-                        }
-                        if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-                            const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-                        }
-                        if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-                            const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-                        }
-                        if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-                            const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-                        }
 
 
 var LOG_LEVEL = {
@@ -1674,7 +1669,7 @@ var JobParams = [
 ]
 
 var paramPattern = "Param\."
-for (var p=0;p<JobParams.length;p++) {
+for (var p = 0; p < JobParams.length; p++) {
     paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
 }
 var paramPatternRegex = new RegExp(paramPattern, 'g')
@@ -1795,7 +1790,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
     const stepParametersObject = JSON.parse(stepParametersContents);
 
     const updatedParameterDefinitions = []
-    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
+    for (var i = 0; i < stepParametersObject.parameterDefinitions.length; i++) {
         if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
             // Don't modify these values
             continue
@@ -1833,7 +1828,7 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
     const replacedArgs = []
-    for (var i=0;i<scriptArgs.length;i++) {
+    for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
@@ -1853,7 +1848,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
     // Parse the template string to a JSON object
     const jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
 
-    for (var j=0;j<jobEnvironmentsObject.jobEnvironments.length;j++) {
+    for (var j = 0; j < jobEnvironmentsObject.jobEnvironments.length; j++) {
         if (jobEnvironmentsObject.jobEnvironments[j].name === "Create Output Directories") {
             jobEnvironmentsObject.jobEnvironments[j].script.actions.onEnter.args = [
                 "{{Param.JobScriptDir}}/create_output_directory.py",
@@ -1881,7 +1876,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const renderQueueItems = []
 
     // Check to make sure that all of our selection indices are correct
-    for (var i=0;i<selection.length;i++) {
+    for (var i = 0; i < selection.length; i++) {
         var selectionItem = selection[i];
         var initialRenderQueueIndex = selectionItem.renderQueueIndex;
 
@@ -1894,59 +1889,10 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
     }
 
-    //We have a valid selection
-    var confirmation = confirm("Project must be saved before submitting. Continue?");
-    if (!confirmation) {
-        return;
-    } else {
-        app.project.save();
-    }
-    if (app.project.file == null) {
-        // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
-        // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
-        return;
-    }
-
-    // Check if warning should be shown
-    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
-    const currentVersion = dcUtil.getAEVersion();
-
-    // Is this AE version not supported in the deadline-cloud channel?
-    if (SUPPORTED_VERSIONS.indexOf(currentVersion) === -1) {
-        // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
-        if (!ignoreWarning || savedVersion !== currentVersion) {
-            const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
-            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
-
-            // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
-            if (confirm(versionMismatchWarningMessage)) {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
-            } else {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-                return;
-            }
-        } else {
-            logger.debug("Version mismatch already acknowledged, version warning skipped.");
-        }
-        logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
-    }
-
-    var outputPath = "";
-    var outputFile = "";
-    var outputFolder = "";
-    for (var j = 1; j <= rqi.numOutputModules; j++) {
-        var outputModule = rqi.outputModule(j).file;
-        if (outputModule == null) {
-            if (rqi.numOutputModules > 1) {
-                adcAlert("Error: Output module does not have its output file set", true);
-            } else {
-                adcAlert(
-                    "Error: One of your output modules does not have its output file set", true
-                );
-            }
+    // We have valid selections check for saving
+    if (app.project.dirty) {
+        const confirmation = confirm("Project must be saved before submitting. Continue?");
+        if (!confirmation) {
             return;
         } else {
             app.project.save();
@@ -1973,8 +1919,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
         if (!ignoreWarning || savedVersion !== currentVersion) {
             const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
-            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
+                " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
+                "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
@@ -1990,87 +1936,113 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
     }
 
+
     var aftereffectsCondaVersion = dcUtil.getAEVersion();
     if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
         aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
     }
     logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
-    /**
-     * Generates parameter_values json file
-     **/
-    function generateParameterValues(bundlePath, outputFolder, outputFileName, isImageSeq) {
-        var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(
-            parametersOutDir,
-            JSON.stringify(
-                parameterValues(
-                    renderQueueIndex,
-                    app.project.file.fsName,
-                    outputFolder,
-                    outputFileName,
-                    isImageSeq,
-                    startFrame,
-                    endFrame,
-                    framesPerTask,
-                    multiFrameRendering,
-                    maxCpuUsagePercentage
-                ),
-                null,
-                4,
-            )
-        );
+
+    const bundle = generateBundle();
+    const jobAssetReferences = {
+        assetReferences: {
+            inputs: {
+                directories: [],
+                filenames: [],
+            },
+            outputs: {
+                directories: [],
+            },
+            referencedPaths: [],
+        },
+    };
+    const jobParameterDefinitions = {
+        "parameterDefinitions": [{
+                "name": "ProjectFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {
+                    "control": "CHOOSE_INPUT_FILE",
+                    "label": "Project file",
+                    "groupLabel": "Source",
+                    "fileFilters": [{
+                            "label": "After Effects project files",
+                            "patterns": [
+                                "*.aep",
+                                "*.aepx"
+                            ]
+                        },
+                        {
+                            "label": "All Files",
+                            "patterns": [
+                                "*"
+                            ]
+                        }
+                    ]
+                },
+                "description": "The After Effects project file to render."
+            },
+            {
+                "name": "JobScriptDir",
+                "description": "Directory containing embedded scripts.",
+                "userInterface": {
+                    "control": "HIDDEN"
+                },
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "IN",
+                "default": "scripts"
+            },
+            {
+                "name": "CondaPackages",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "HIDDEN"
+                },
+                "default": "aftereffects=" + aftereffectsCondaVersion,
+                "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+            }
+        ]
+    }
+    const jobParameterValues = {
+        parameterValues: [{
+                name: "deadline:targetTaskRunStatus",
+                value: "READY",
+            },
+            {
+                name: "deadline:maxFailedTasksCount",
+                value: 20,
+            },
+            {
+                name: "deadline:maxRetriesPerTask",
+                value: 5,
+            },
+            {
+                name: "deadline:priority",
+                value: 50,
+            },
+            {
+                name: "ProjectFile",
+                value: app.project.file.fsName,
+            },
+        ]
     }
 
-    /**
-     * Generates job template json file
-     **/
-    function generateTemplate(bundlePath, isImageSeq) {
-        // Open the template depending on the output type
-        var path = bundlePath + "/video_template.json";
-        if (isImageSeq) {
-            path = bundlePath + "/image_template.json";
-        }
-        var templateContents = readFile(path);
-        // Parse the template string to a JSON object
-        var templateObject = JSON.parse(templateContents);
-        templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
-        logger.debug("The template name is " + templateObject.name, submitBundleFile);
-        try {
-            if (templateObject.steps[0].name) {
-                templateObject.steps[0].name = compName;
-                logger.debug("The step name is " + templateObject.steps[0].name, submitBundleFile);
-            }
-        } catch (e) {
-            adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
-            logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
-        }
-        try {
-            if (templateObject.steps[0].script && templateObject.steps[0].script.actions) {
-                // Add timeout to the onRun action
-                if (templateObject.steps[0].script.actions.onRun) {
-                    templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
-                    logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
-                }
-            }
-        } catch (e) {
-            adcAlert("Error accessing the template's actions. \nPlease check your template.json.", true);
-            logger.debug("Error accessing the template's actions: " + e.message, submitBundleFile);
-        }
-
-        var aftereffectsCondaVersion = dcUtil.getAEVersion();
-        if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
-            aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
-        }
-        logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
+    const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
+    template.steps = []
+    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
 
     // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
     const stepOutputFolderParameters = [];
 
-        for (var i = paramDefCopy.length - 1; i >= 0; i--) {
-            if (paramDefCopy[i].name == "CondaPackages") {
-                paramDefCopy[i].default = "aftereffects=" + aftereffectsCondaVersion;
-            }
+    for (var i = 0; i < renderQueueItems.length; i++) {
+        var renderQueueItem = renderQueueItems[i][0];
+        var renderQueueIndex = renderQueueItems[i][1];
+
+        if (!validateRenderQueueItemOutputModule(renderQueueItem)) {
+            return;
         }
 
         var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
@@ -2115,7 +2087,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
         // Push step asset references
-        for (var d=0;d<dependencies.length;d++) {
+        for (var d = 0; d < dependencies.length; d++) {
             jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
         }
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
@@ -2133,7 +2105,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             stepMaxCpuUsagePercentage
         )
 
-        for (var p=0;p<parameterValues.parameterValues.length;p++) {
+        for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
                 jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
             }
@@ -2142,13 +2114,13 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
 
         var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
-        for (var s=0;s<stepTemplate.steps.length;s++) {
+        for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s])
         }
         var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
-        for (var p=0;p<stepParameters.parameterDefinitions.length;p++) {
+        for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
-            for (var tpd=0;tpd<template.parameterDefinitions.length;tpd++) {
+            for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {
                 var templateParameterDefinition = template.parameterDefinitions[tpd];
                 var stepParameterDefinition = stepParameters.parameterDefinitions[p];
                 if (templateParameterDefinition.name == stepParameterDefinition.name) {
@@ -2164,9 +2136,9 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
-    writeFile(bundle.fsName + "/asset_references.json",JSON.stringify(jobAssetReferences, null, 4));
+    writeFile(bundle.fsName + "/asset_references.json", JSON.stringify(jobAssetReferences, null, 4));
 
-    writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
+    writeFile(bundle.fsName + "/parameter_values.json", JSON.stringify(jobParameterValues, null, 4));
 
     writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));
     logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);
@@ -2796,6 +2768,61 @@ if (typeof JSON !== "object") {
 
 
 
+function populateListBoxItem(item, renderQueueItem, index) {
+    item.renderQueueIndex = index;
+    item.compId = renderQueueItem.comp.id;
+    item.subItems[0].text = renderQueueItem.comp.name;
+
+    const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
+    const startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
+    const endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+
+    item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
+    if (renderQueueItem.numOutputModules <= 0) {
+        item.subItems[2].text = "<not set>";
+    } else if (renderQueueItem.numOutputModules == 1) {
+        const outputFile = renderQueueItem.outputModule(1).file;
+        item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
+    } else {
+        item.subItems[2].text = "<multiple output modules>";
+    }
+}
+
+
+function refreshList(listBox, uiSettingsState) {
+    listBox.removeAll();
+    const framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK) || "50"
+    const multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)
+    const maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)
+
+    const InvalidRenderQueueItemStatuses = [
+        RQItemStatus.RENDERING,
+        RQItemStatus.WILL_CONTINUE,
+        RQItemStatus.USER_STOPPED,
+        RQItemStatus.ERR_STOPPED,
+        RQItemStatus.DONE
+    ]
+    for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
+        var renderQueueItem = app.project.renderQueue.item(index);
+        if (renderQueueItem == null) {
+            continue;
+        }
+
+        if (InvalidRenderQueueItemStatuses.indexOf(renderQueueItem.status) !== -1) {
+            // Status is in InvalidRenderQueueItemStatuses.
+            continue;
+        }
+
+        var item = listBox.add('item', index.toString());
+        populateListBoxItem(item, renderQueueItem, index);
+        // TODO: Value
+
+        uiSettingsState.create(item.compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage);
+    }
+
+    listBox.selection = null;
+}
+
 /**
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
@@ -2979,6 +3006,42 @@ function buildUI(thisObj) {
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
+    // Disable max CPU percentage textbox when multi frame rendering is disabled
+    function onMfrCheckBoxClicked() {
+        const isMfrChecked = mfrCheckBox.value;
+        var settingsStateValue = false
+        if (!isMfrChecked) {
+            maxCpuUsagePercentageTextBox.text = "N/A";
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+            settingsStateValue = false
+        } else {
+            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
+            settingsStateValue = true
+        }
+
+        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+        }
+    }
+    mfrCheckBox.onClick = onMfrCheckBoxClicked;
+
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem.numOutputModules === 1) {
+            const outputModule = renderQueueItem.outputModule(1).file;
+            if (outputModule != null) {
+                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                const extension = getFileExtension(outputFileNameNoRegex);
+                return isImageOutput(extension);
+            }
+        }
+        return false
+    }
+
+
     // Add Timeouts settings group
     const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
@@ -3062,123 +3125,18 @@ function buildUI(thisObj) {
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 
-    // Disable max CPU percentage textbox when multi frame rendering is disabled
-    function onMfrCheckBoxClicked() {
-        const isMfrChecked = mfrCheckBox.value;
-        var settingsStateValue = false
-        if (!isMfrChecked) {
-            maxCpuUsagePercentageTextBox.text = "N/A";
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-            settingsStateValue = false
-        } else {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
-            settingsStateValue = true
-        }
-
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
-        }
-    }
-    mfrCheckBox.onClick = onMfrCheckBoxClicked;
-
-    function isRenderQueueItemImageOutput(renderQueueItem) {
-        if (renderQueueItem.numOutputModules === 1) {
-            const outputModule = renderQueueItem.outputModule(1).file;
-            if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
+    // Check for duplicate names
+    function checkForInvalidCompositionNames(selection) {
+        const names = [];
+        const duplicateNames = [];
+        for (var i = 0; i < selection.length; i++) {
+            var selectionItem = selection[i];
+            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
+            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
+            if (names.indexOf(compName) !== -1) {
+                duplicateNames.push(renderQueueItem.comp.name);
             }
-        }
-        return false
-    }
-
-    // Add Timeouts settings group
-    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
-    timeoutsPanel.orientation = "column";
-    timeoutsPanel.alignment = ['fill', 'top'];
-    timeoutsPanel.alignChildren = ['left', 'center'];
-    timeoutsPanel.margins = 5;
-
-    // Task run timeout
-    const taskRunGroup = timeoutsPanel.add("group");
-    taskRunGroup.orientation = "row";
-    taskRunGroup.alignment = ['fill', 'top'];
-    taskRunGroup.alignChildren = ['left', 'center'];
-
-    const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-
-    const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
-    taskRunDaysInput.characters = 3;
-    taskRunDaysGroup.add("statictext", undefined, "days");
-
-    const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
-    taskRunHoursInput.characters = 3;
-    taskRunHoursGroup.add("statictext", undefined, "hours");
-
-    const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
-    taskRunMinutesInput.characters = 3;
-    taskRunMinutesGroup.add("statictext", undefined, "minutes");
-
-    // Function to validate timeout values
-    function validateTimeoutValues() {
-        // Check if all values are zero when checkbox is checked
-        if (taskRunCheckbox.value) {
-            var days = parseInt(taskRunDaysInput.text) || 0;
-            var hours = parseInt(taskRunHoursInput.text) || 0;
-            var minutes = parseInt(taskRunMinutesInput.text) || 0;
-
-            if (days === 0 && hours === 0 && minutes === 0) {
-                adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                // Set days back to default value of 2
-                taskRunDaysInput.text = "2";
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Add input validation and save values to settings
-    taskRunCheckbox.onClick = function() {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
-        if (this.value) {
-            validateTimeoutValues();
-        }
-    };
-
-    taskRunDaysInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
-        validateTimeoutValues();
-    };
-
-    taskRunHoursInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
-        validateTimeoutValues();
-    };
-
-    taskRunMinutesInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
-        validateTimeoutValues();
-    };
-
-    // If an image sequence was selected, enable frames per task textbox. Otherwise disable it.
-    function isFramesPerTaskEnabled(selection) {
-        if (selection == null) {
-            return false;
+            names.push(compName);
         }
         if (duplicateNames.length !== 0) {
             var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
@@ -3199,10 +3157,13 @@ function buildUI(thisObj) {
             if (mfrCheckBox.value) {
                 maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
             }
+            if (checkForInvalidCompositionNames(list.selection)) {
+                return
+            }
             if (taskRunCheckbox.value) {
-                SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
+                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
             } else {
-                SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
+                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
             }
             list.selection = null;
         }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2833,7 +2833,6 @@ function populateListBoxItem(item, renderQueueItem, index) {
     item.compId = renderQueueItem.comp.id;
     item.subItems[0].text = renderQueueItem.comp.name;
 
-    const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
     var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
     var startFrame = frameRange.startFrame;
     var endFrame = frameRange.endFrame;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1330,7 +1330,7 @@ var jobTemplateHelperFile = "JobTemplateHelper.json";
 /**
  * Generates the basic parameterValue file for the job template
  **/
-function parameterValues(
+function generateParameterValues(
     renderQueueIndex,
     projectFile,
     outputDir,
@@ -1851,34 +1851,6 @@ function validateRenderQueueItemOutputModule(renderQueueItem) {
     return true;
 }
 
-// Generate our prefixed Parameter Values for the provided comp
-function generateParameterValuesForStep(
-    prefix,
-    renderQueueIndex,
-    outputFolder,
-    outputFileName,
-    isImageSeq,
-    startFrame,
-    endFrame,
-    chunkSize,
-    multiFrameRendering,
-    maxCpuUsagePercentage,
-) {
-    return parameterValues(
-        renderQueueIndex,
-        app.project.file.fsName,
-        outputFolder,
-        outputFileName,
-        isImageSeq,
-        startFrame,
-        endFrame,
-        chunkSize,
-        multiFrameRendering,
-        maxCpuUsagePercentage,
-        prefix,
-    );
-}
-
 // Loading our default template from disk
 function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
     const path = bundlePath + "/template.json";
@@ -2239,9 +2211,9 @@ function SubmitSelection(selection, selectionSettings) {
         }
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
-        var parameterValues = generateParameterValuesForStep(
-            generateParameterName(renderQueueIndex, compName, ""),
+        var parameterValues = generateParameterValues(
             renderQueueIndex,
+            app.project.file.fsName,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
             isImageSeq,
@@ -2249,9 +2221,9 @@ function SubmitSelection(selection, selectionSettings) {
             endFrame,
             stepFramesPerTask,
             stepMultiFrameRendering,
-            stepMaxCpuUsagePercentage
+            stepMaxCpuUsagePercentage,
+            generateParameterName(renderQueueIndex, compName, "")
         );
-
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
                 jobParameterValues.parameterValues.push(parameterValues.parameterValues[p]);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -955,7 +955,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
             if (!rolloverFile.exists) {
                 continue;
             }
-            const j = i + 1;
+            var j = i + 1;
             const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
             rolloverFile.copy(rolloverTargetPath);
         }
@@ -1055,7 +1055,7 @@ function UiSettingsState() {
 function UiSettingsStore(name) {
     this.name = name;
     // _framesPerTask: string
-    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
     // _multiFrameRendering: bool
     this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
     // _maxCpuUsagePercentage: string

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2881,6 +2881,10 @@ function buildUI(thisObj) {
         framesPerTaskTextBox.enabled = false
         mfrCheckBox.enabled = false
         maxCpuUsagePercentageTextBox.enabled = false
+        taskRunCheckbox.enabled = false
+        taskRunDaysInput.enabled = false
+        taskRunHoursInput.enabled = false
+        taskRunMinutesInput.enabled = false
 
         if (selection.length !== 1) {
             return
@@ -2891,6 +2895,10 @@ function buildUI(thisObj) {
         framesPerTaskTextBox.enabled = imageOutput
         mfrCheckBox.enabled = true
         maxCpuUsagePercentageTextBox.enabled = true
+        taskRunCheckbox.enabled = true
+        taskRunDaysInput.enabled = true
+        taskRunHoursInput.enabled = true
+        taskRunMinutesInput.enabled = true
 
         logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
         framesPerTaskTextBox.text = selectionItem.subItems[1].text
@@ -2911,6 +2919,14 @@ function buildUI(thisObj) {
         maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
 
         maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+
+        taskRunCheckbox.value = settings.taskRunTimeout()
+        taskRunDaysInput.enabled = taskRunCheckbox.value
+        taskRunDaysInput.text = settings.taskRunDays()
+        taskRunHoursInput.enabled = taskRunCheckbox.value
+        taskRunHoursInput.text = settings.taskRunHours()
+        taskRunMinutesInput.enabled = taskRunCheckbox.value
+        taskRunMinutesInput.text = settings.taskRunMinutes()
     }
 
     list.onChange = onSelectionChange;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2230,6 +2230,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
+        // Generates template and parameters for the current render queue item, then pushes them to the main template
         var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
@@ -2250,6 +2251,8 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
     }
+
+    // Writes out final bundle files
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","));
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments;
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3249,6 +3249,9 @@ function buildUI(thisObj) {
             if (mfrCheckBox.value) {
                 maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
             }
+            if (list.selection === null) {
+                return;
+            }
             if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -3080,7 +3080,7 @@ function buildUI(thisObj) {
         const selectionItem = dcUtil.getSelection(list)
         if (selectionItem) {
             var compId = selectionItem.compId;
-            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuPercentageTextBox.text));
+            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -3162,7 +3162,7 @@ function buildUI(thisObj) {
             } else {
                 onTaskRunDaysChanged();
                 onTaskRunHoursChanged();
-                OnTaskRunMinutesCHanged();
+                OnTaskRunMinutesChanged();
             }
         }
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
@@ -3310,31 +3310,26 @@ function buildUI(thisObj) {
 
         function onSelectionChange() {
             const selection = list.selection;
-            if (selection == null) {
-                updateList();
-                framesPerTaskTextBox.text = "";
-                return;
-            }
+            perCompSettingsGroup.enabled = false;
+            
+            framesPerTaskTextBox.text = "";
+            mfrCheckBox.value = false;
+            maxCpuUsagePercentageTextBox.text = ""
+
             submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
 
-            // Disable everything
-            framesPerTaskTextBox.enabled = false
-            mfrCheckBox.enabled = false
-            maxCpuUsagePercentageTextBox.enabled = false
-
-            if (selection.length !== 1) {
+            if (selection == null || selection.length !== 1) {
                 return
             }
             const selectionItem = selection[0]
+            perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
             const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
-            framesPerTaskTextBox.enabled = imageOutput
-            mfrCheckBox.enabled = true
-            maxCpuUsagePercentageTextBox.enabled = true
-
-            framesPerTaskTextBox.text = selectionItem.subItems[1].text
+            framesPerTaskTextBox.enabled = imageOutput;
+            mfrCheckBox.enabled = true;
+            maxCpuUsagePercentageTextBox.enabled = true;
 
             const settings = uiSettingsState.get(selectionItem.compId)
             if (settings === undefined) {
@@ -3342,13 +3337,14 @@ function buildUI(thisObj) {
                 return
             }
 
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
-            mfrCheckBox.value = settings.multiFrameRendering()
-            maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
-
-            maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+            framesPerTaskTextBox.text = settings.framesPerTask();
+            framesPerTaskTextBox.onChange();
+            maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
+            maxCpuUsagePercentageTextBox.onChange();
+            mfrCheckBox.value = settings.multiFrameRendering();
+            mfrCheckBox.onClick();
         }
-
+        onSelectionChange();
         list.onChange = onSelectionChange;
         list.selection = null;
     }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1675,6 +1675,9 @@ for (var p = 0; p < JobParams.length; p++) {
 }
 var paramPatternRegex = new RegExp(paramPattern, 'g')
 
+if (typeof submitBundleFile == 'undefined') {
+    const submitBundleFile = "SubmitButton.jsx";
+}
 
 // Validate that the RenderQueueIndex for each selectionItem is still valid
 function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
@@ -1834,8 +1837,8 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
-    if (templateObject.steps[0].script.actions.onRun) {
-        templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+    if (stepTemplateObject.steps[0].script.actions.onRun) {
+        stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
         logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
     }
 
@@ -1863,7 +1866,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 /**
  * Submit the selected render queue item
  **/
-function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
+function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
     // Calculate task run timeout in seconds
     var taskTimeoutSeconds = 0;
     // Validate timeout values during job submission
@@ -1873,7 +1876,6 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     }
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
-    const submitBundleFile = "SubmitButton.jsx";
     const renderQueueItems = []
 
     // Check to make sure that all of our selection indices are correct
@@ -3069,7 +3071,6 @@ function buildUI(thisObj) {
     taskRunGroup.orientation = "row";
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
-
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
     taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -5,16 +5,16 @@
 var scriptFolder = Folder.current.fsName;
 
 function readFile(filePath) {
-    var f = new File(filePath);
+    const f = new File(filePath);
     f.encoding = "UTF-8";
     f.open("r");
-    var fileContents = f.read();
+    const fileContents = f.read();
     f.close();
     return fileContents;
 }
 
 function writeFile(filePath, fileContents) {
-    var f = new File(filePath);
+    const f = new File(filePath);
     f.encoding = "UTF-8";
     f.open("w");
     f.write(fileContents);
@@ -23,7 +23,7 @@ function writeFile(filePath, fileContents) {
 }
 
 function sanitizeOutputs(outputPaths) {
-    var sanitized = [];
+    const sanitized = [];
     var sanitizedPath = "";
     for (var i = 0; i < outputPaths.length; i++) {
         sanitizedPath = sanitizeFilePath(outputPaths[i]);
@@ -113,7 +113,7 @@ function adcAlert(message, errorIcon) {
 
 function __generateUtil() {
 
-    var scriptFileUtilName = "Util.jsx";
+    const scriptFileUtilName = "Util.jsx";
 
 
     function toBooleanString(value) {
@@ -160,7 +160,7 @@ function __generateUtil() {
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
         textObj.onChange = function() {
-            var newValue = parseFloat(textObj.text);
+            const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
                 logger.log("Changed editText(" + textObj.name + ") value to: " + newValue, scriptFileUtilName, LOG_LEVEL.DEBUG);
@@ -182,7 +182,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        var sliderValue = Math.round(sliderObj.value);
+        const sliderValue = Math.round(sliderObj.value);
         if (!isNaN(sliderValue) && sliderValue >= minValue && sliderValue <= maxValue) {
             textObj.text = sliderValue;
         }
@@ -198,7 +198,7 @@ function __generateUtil() {
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
 
-        var newValue = parseFloat(textObj.text);
+        const newValue = parseFloat(textObj.text);
         if (newValue < minValue) {
             textObj.text = minValue;
             sliderObj.value = minValue;
@@ -255,7 +255,7 @@ function __generateUtil() {
          * @param {Object} listBox - Source object to retrieve data from.
          * Returns array with assets available in the scene.
          */
-        var _assetsList = []
+        const _assetsList = []
         for (var i = 0; i < listBox.items.length; i++) {
             _assetsList.push(listBox.items[i].text);
         }
@@ -304,7 +304,7 @@ function __generateUtil() {
          * Inverts a given JavaScript object.
          * Only inverts the first level, does not handle nested objects properly.
          */
-        var ret = {};
+        const ret = {};
         for (var key in jsObject) {
             ret[jsObject[key]] = key;
         }
@@ -315,8 +315,8 @@ function __generateUtil() {
         /**
          * Return File instance from temporary directory with the given name.
          */
-        var _tempFilePath = normalizePath(getTempFolder() + "/" + fileName);
-        var _tempFile = File(_tempFilePath);
+        const _tempFilePath = normalizePath(getTempFolder() + "/" + fileName);
+        const _tempFile = File(_tempFilePath);
         return _tempFile;
     }
 
@@ -346,7 +346,7 @@ function __generateUtil() {
 
         // Test every path in our list by creating a test file
         for (var i = 0; i < altPaths.length; i++) {
-            var folder = new Folder(altPaths[i]);
+            const folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();
@@ -403,9 +403,9 @@ function __generateUtil() {
 
     function _wrappedCallSystemWindows(cmd) {
 
-        var tempOutputFile = getTempFile("deadline_cloud_ae_pipe.txt");
-        var tempBootstrapBatFile = getTempFile("aeCallSystemBootstrap.bat");
-        var tempBatFile = getTempFile("aeCallSystem.bat");
+        const tempOutputFile = getTempFile("deadline_cloud_ae_pipe.txt");
+        const tempBootstrapBatFile = getTempFile("aeCallSystemBootstrap.bat");
+        const tempBatFile = getTempFile("aeCallSystem.bat");
         logger.debug("Command output path: " + tempOutputFile.fsName, scriptFileUtilName);
         _makeBootstrapBatFile(tempBootstrapBatFile, tempBatFile);
         // Wrapped command with error code output
@@ -424,12 +424,12 @@ function __generateUtil() {
         logger.debug(cmd, scriptFileUtilName);
         // Call bootstrap script and return result via intermediary file.
         system.callSystem(tempBootstrapBatFile.fsName);
-        var output = system.callSystem("cmd /c \"type " + tempOutputFile.fsName + "\"");
+        const output = system.callSystem("cmd /c \"type " + tempOutputFile.fsName + "\"");
         return output;
     }
 
     function _makeBootstrapBatFile(bootstrapFile, tempFile) {
-        var _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
+        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
         bootstrapFile.open("w");
         bootstrapFile.writeln(_cmd);
         bootstrapFile.close();
@@ -452,12 +452,12 @@ function __generateUtil() {
         var result = "";
         var message = "";
         var return_code = 0;
-        var errorIndex = output.indexOf("ERROR CODE:");
+        const errorIndex = output.indexOf("ERROR CODE:");
         if (errorIndex !== -1) {
             // Extract the word and everything behind it
             result = output.substring(errorIndex);
             message = cmd + " Failed. Error has occurred.";
-            var regex = /ERROR CODE:(.*)/;
+            const regex = /ERROR CODE:(.*)/;
             return_code = regex.exec(result);
             return {
                 "return_code": return_code,
@@ -481,14 +481,14 @@ function __generateUtil() {
          * [MAJOR, MINOR, PATCH]
          */
         // Regular expression to match "version " followed by version number
-        var regex = /version\s+(\d+)\.(\d+)\.(\d+)/i;
+        const regex = /version\s+(\d+)\.(\d+)\.(\d+)/i;
 
         // Test if the inputString matches the pattern
-        var parsedVersionNumberOutput = output.match(regex);
+        const parsedVersionNumberOutput = output.match(regex);
 
         // Output the result
         if (parsedVersionNumberOutput) {
-            var versionNumbers = [
+            const versionNumbers = [
                 parseInt(parsedVersionNumberOutput[1]), // Major
                 parseInt(parsedVersionNumberOutput[2]), // Minor
                 parseInt(parsedVersionNumberOutput[3]) // Path
@@ -507,8 +507,8 @@ function __generateUtil() {
          * @param {string} fileName: Job name
          * Returns export directory
          */
-        var partialDir = getPartialExportDir(exportBundleDir);
-        var dir = getPath(partialDir, fileName, exportBundleDir);
+        const partialDir = getPartialExportDir(exportBundleDir);
+        const dir = getPath(partialDir, fileName, exportBundleDir);
         return dir.fsName;
     }
 
@@ -544,21 +544,21 @@ function __generateUtil() {
 
     function getPath(toCheckDir, fileName, rootDir) {
         // 1. Find highest sequence number used for today.
-        var splitDir = toCheckDir.split("//");
-        var toCheckFolderName = splitDir[splitDir.length - 1];
-        var parentDir = toCheckDir.replace(toCheckFolderName, "");
-        var mainDir = new Folder(parentDir);
-        var subFolders = mainDir.getFiles();
-        var regex = new RegExp(toCheckFolderName + "(\\d+)-.*");
+        const splitDir = toCheckDir.split("//");
+        const toCheckFolderName = splitDir[splitDir.length - 1];
+        const parentDir = toCheckDir.replace(toCheckFolderName, "");
+        const mainDir = new Folder(parentDir);
+        const subFolders = mainDir.getFiles();
+        const regex = new RegExp(toCheckFolderName + "(\\d+)-.*");
         var maxSeqNumber = 0;
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
             folderName = subFolders[idx].fullName
-            var match = folderName.match(regex)
+            const match = folderName.match(regex)
             if (!match) {
                 continue;
             }
-            var seqNr = parseInt(match[1]) // Convert first capture group to int
+            const seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
                 maxSeqNumber = seqNr
             }
@@ -569,7 +569,7 @@ function __generateUtil() {
         if (nextSeqNumber < 10) {
             nextSeqNumber = "0" + nextSeqNumber;
         }
-        var folder = new Folder(toCheckDir + nextSeqNumber + "-AfterEffects-" + fileName);
+        const folder = new Folder(toCheckDir + nextSeqNumber + "-AfterEffects-" + fileName);
         if (!folder.exists) {
             folder.create();
         }
@@ -582,15 +582,15 @@ function __generateUtil() {
          * @param {string} job_history_dir: Directory where job bundles is written to on submission.
          * Returns partial job history directory.
          */
-        var currentDate = new Date();
-        var year = currentDate.getFullYear();
+        const currentDate = new Date();
+        const year = currentDate.getFullYear();
         // Zero pad all integers to a length of 2
-        var month = ("0" + (currentDate.getMonth() + 1)).slice(-2); // Months are zero-based
-        var day = ("0" + currentDate.getDate()).slice(-2);
+        const month = ("0" + (currentDate.getMonth() + 1)).slice(-2); // Months are zero-based
+        const day = ("0" + currentDate.getDate()).slice(-2);
         // Create the formatted string
-        var formattedYearMonth = year + '-' + month;
-        var formattedDate = year + '-' + month + '-' + day;
-        var dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
+        const formattedYearMonth = year + '-' + month;
+        const formattedDate = year + '-' + month + '-' + day;
+        const dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
         return dir;
     }
 
@@ -598,7 +598,7 @@ function __generateUtil() {
         // Remark: gpu memory and worker memory need to be scaled with *1024, for some of the amount capabilities, the unit displayed on the UI is different
         // then the unit used within template, so use this factor to scale the input values.
 
-        var hostRequirements = {
+        const hostRequirements = {
             "attributes": [{
                 "name": "attr.worker.os.family",
                 "anyOf": [
@@ -662,7 +662,7 @@ function __generateUtil() {
         }
 
         if (obj instanceof Array) {
-            var copyArray = [];
+            const copyArray = [];
             for (var i = 0; i < obj.length; i++) {
                 copyArray[i] = deepCopy(obj[i]);
             }
@@ -670,7 +670,7 @@ function __generateUtil() {
         }
 
         if (obj instanceof Object) {
-            var copyObject = {};
+            const copyObject = {};
             for (var key in obj) {
                 if (obj.hasOwnProperty(key)) {
                     copyObject[key] = deepCopy(obj[key]);
@@ -688,10 +688,10 @@ function __generateUtil() {
          */
         // If submit layers pressed -> itemName is not comp name and therefore comp will not be found with render command
         // Check if itemName is an available comp in the project, if not, it is a layer submission
-        var comp = itemName;
-        var compList = [];
+        const comp = itemName;
+        const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
-            var item = app.project.rootFolder.items[i];
+            const item = app.project.rootFolder.items[i];
 
             if (item instanceof CompItem) {
                 compList.push(app.project.activeItem.name);
@@ -704,7 +704,7 @@ function __generateUtil() {
     }
 
     function normalizePath(path) {
-        var _file = new File(path);
+        const _file = new File(path);
         if (system.osName == "MacOS") {
             _file.changePath(_file.fsName.replace(/\\/g, "/"));
             return _file.fsName;
@@ -719,7 +719,7 @@ function __generateUtil() {
     }
 
     function removeIllegalCharacters(inputString) {
-        var outputString = inputString.replace(/[.\-\s]/g, "_");
+        const outputString = inputString.replace(/[.\-\s]/g, "_");
 
         return outputString;
     }
@@ -728,8 +728,7 @@ function __generateUtil() {
      * Replace %20 percentage back to space from the file name for Windows os.
      */
     function removePercentageFromFileName(fileName) {
-        var fileName = fileName.replace(/%20/g, " ");
-        return fileName;
+        return fileName.replace(/%20/g, " ");
     }
 
     function getUserDirectory() {
@@ -918,7 +917,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
         backupCount = backupCount || _DC_LOGGER_DEFAULT_BACKUP_COUNT;
         logDirectoryPath = logDirectoryPath || dcUtil.getUserDirectory() + "/.deadline/logs/submitters";
         logDirectoryPath = dcUtil.normPath(logDirectoryPath);
-        var folderObject = new Folder(logDirectoryPath);
+        const folderObject = new Folder(logDirectoryPath);
         if (!folderObject.exists) {
             folderObject.create();
         }
@@ -956,8 +955,8 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
             if (!rolloverFile.exists) {
                 continue;
             }
-            var j = i + 1;
-            var rolloverTargetPath = logDirectoryPath + logFileName + "." + j
+            const j = i + 1;
+            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file
@@ -978,16 +977,16 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
 
             var levelName = LOG_LEVEL_MAP[level];
             // Check the length of the string
-            var currentLength = levelName.length;
+            const currentLength = levelName.length;
 
             // If the length is less than the target length, pad with spaces
             if (currentLength < 8) {
-                var spacesToAdd = 8 - currentLength;
+                const spacesToAdd = 8 - currentLength;
                 for (var i = 0; i < spacesToAdd; i++) {
                     levelName += " ";
                 }
             }
-            var logMessage = getCurrentTimeAsStr() + " - " + "[" + levelName + "] " + " " + src_module + ": " + msg;
+            const logMessage = getCurrentTimeAsStr() + " - " + "[" + levelName + "] " + " " + src_module + ": " + msg;
 
             logFile.open("a");
             logFile.writeln(logMessage);
@@ -1025,18 +1024,18 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
 }
 
 function getCurrentTimeAsStr() {
-    var date = new Date();
-    var year = date.getFullYear();
+    const date = new Date();
+    const year = date.getFullYear();
     // Zero pad all integers to a length of 2
-    var month = ("0" + (date.getMonth() + 1)).slice(-2); // Months are zero-based
-    var day = ("0" + date.getDate()).slice(-2);
+    const month = ("0" + (date.getMonth() + 1)).slice(-2); // Months are zero-based
+    const day = ("0" + date.getDate()).slice(-2);
 
-    var currentDate = year + "-" + month + "-" + day;
-    var hours = ("0" + date.getHours()).slice(-2);
-    var minutes = ("0" + date.getMinutes()).slice(-2);
-    var seconds = ("0" + date.getSeconds()).slice(-2);
-    var currentTime = hours + ":" + minutes + ":" + seconds;
-    var logDateTime = currentDate + " " + currentTime;
+    const currentDate = year + "-" + month + "-" + day;
+    const hours = ("0" + date.getHours()).slice(-2);
+    const minutes = ("0" + date.getMinutes()).slice(-2);
+    const seconds = ("0" + date.getSeconds()).slice(-2);
+    const currentTime = hours + ":" + minutes + ":" + seconds;
+    const logDateTime = currentDate + " " + currentTime;
     return logDateTime;
 }
 
@@ -1110,7 +1109,7 @@ function parameterValues(
     maxCpuUsagePercentage,
     prefix
 ) {
-    var parameterValuesList = [{
+    const parameterValuesList = [{
             name: prefix + "_RenderQueueIndex",
             value: renderQueueIndex,
         },
@@ -1175,13 +1174,13 @@ function findJobAttachments(rootComp) {
     if (rootComp == null) {
         return [];
     }
-    var attachments = [];
-    var exploredItems = {}; // using this object as a set because AE doesn't support sets
+    const attachments = [];
+    const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
-    var queue = [rootComp];
+    const queue = [rootComp];
     while (queue.length > 0) {
-        var comp = queue.pop();
+        const comp = queue.pop();
         var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
         for (var i = 1; i <= comp.numLayers; i++) {
             var layer = comp.layer(i);
@@ -1221,7 +1220,7 @@ function findJobAttachments(rootComp) {
         }
     }
 
-    var fontsInProject = getFontsFromFile();
+    const fontsInProject = getFontsFromFile();
 
     if (fontsInProject.length > 0) {
         // Notify the user if any fonts are missing or are substituted during the session.
@@ -1231,7 +1230,7 @@ function findJobAttachments(rootComp) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }
         // Formatting collected fonts
-        var fontReferences = generateFontReferences(fontsInProject);
+        const fontReferences = generateFontReferences(fontsInProject);
         for (var i = 0; i < fontReferences.length; i++) {
             attachments.push(fontReferences[i]);
         }
@@ -1248,11 +1247,11 @@ function getFontsFromFile() {
     var fontLocations = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
-        var usedList = app.project.usedFonts;
+        const usedList = app.project.usedFonts;
         for (var i = 0; i < usedList.length; i++) {
-            var font = usedList[i].font;
-            var fontPostScriptName = font.postScriptName;
-            var fontLocation = font.location || getLocationForFont(fontPostScriptName);
+            const font = usedList[i].font;
+            const fontPostScriptName = font.postScriptName;
+            const fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
                 adcAlert(
                     "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
@@ -1260,7 +1259,7 @@ function getFontsFromFile() {
                 );
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
+            const fontName = createFontFilename(fontLocation, fontPostScriptName);
             if (fontName) {
                 fontLocations.push([fontName, fontLocation]);
             }
@@ -1277,7 +1276,7 @@ function getFontsFromFile() {
  * @return String with executable name corresponding to Python 3, or an empty string if not found
  **/
 function getPythonExecutable() {
-    var pythonExecutables = ["python3", "python", "py"];
+    const pythonExecutables = ["python3", "python", "py"];
 
     for (var i = 0; i < pythonExecutables.length; i++) {
         // Search for python executable
@@ -1306,7 +1305,7 @@ function getPythonExecutable() {
         try {
             output = system.callSystem(pythonExecutable + " --version");
             if (output && output.indexOf("Python ") !== -1) {
-                var pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
+                const pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
                 if (pythonVersion >= 3) {
                     return pythonExecutable;
                 }
@@ -1318,7 +1317,7 @@ function getPythonExecutable() {
     }
 
     // If reaching here, this means python version was too low or executable was not found
-    var errorMessage =
+    const errorMessage =
         "Error: Couldn't find Python 3 or higher on your PATH.\n" +
         "\n" +
         "Please ensure that Python 3 or higher is installed correctly and added to your PATH.";
@@ -1334,12 +1333,12 @@ function getPythonExecutable() {
 function getFontPaths() {
     var errorMessage = "";
     // Ensure Python exists and is at least version 3
-    var pythonExecutable = getPythonExecutable();
+    const pythonExecutable = getPythonExecutable();
     if (!pythonExecutable) {
         return null;
     }
-    var scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-    var scriptFile = new File(scriptPath);
+    const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
+    const scriptFile = new File(scriptPath);
     if (!scriptFile.exists) {
         errorMessage =
             "Error: Missing font script at " + scriptFile.fsName + "\n" +
@@ -1351,7 +1350,7 @@ function getFontPaths() {
 
     var output = {};
     try {
-        var outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
         output = JSON.parse(outputRaw);
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -1381,7 +1380,7 @@ function getLocationForFont(fontPostScriptName) {
     var fontPath = null;
     try {
         // Get user-installed fonts
-        var fontPaths = getFontPaths();
+        const fontPaths = getFontPaths();
         if (!fontPaths) {
             return null;
         }
@@ -1404,16 +1403,16 @@ function getLocationForFont(fontPostScriptName) {
  **/
 function createFontFilename(fontLocation, fontPostScriptName) {
     var fileExtension = "";
-    var lastDotIndex = fontLocation.lastIndexOf('.');
-    var extensionRegex = /\.[a-zA-Z]+$/;
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
 
     var fontName = "";
 
     var validExtension = true;
-    var fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf"];
 
     // Windows also supports .fon files
-    var os = $.os.toLowerCase();
+    const os = $.os.toLowerCase();
     if (os.indexOf("windows") !== -1) {
         fontExtensions.push(".fon");
     }
@@ -1421,7 +1420,7 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
     if (extensionRegex.test(fontLocation)) {
         fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
-        var fontExtensionsAsString = fontExtensions.toString();
+        const fontExtensionsAsString = fontExtensions.toString();
         if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
             adcAlert(
                 "font with an unsupported extension '" + fileExtension +
@@ -1444,21 +1443,21 @@ function createFontFilename(fontLocation, fontPostScriptName) {
  * @return an array of font metadata, each item containing the font's temp copy name and the actual location of that font file
  **/
 function getFontsFromFileLegacy() {
-    var fontLocations = [];
-    var items = app.project.items;
+    const fontLocations = [];
+    const items = app.project.items;
     for (var i = items.length; i >= 1; i--) {
-        var item = app.project.item(i);
+        const item = app.project.item(i);
         // Only look at CompItems
         if (!(item instanceof CompItem)) {
             continue;
         }
         for (var j = item.layers.length; j >= 1; j--) {
-            var layer = item.layers[j];
+            const layer = item.layers[j];
             // Only look at TextLayers
             if (!(layer instanceof TextLayer)) {
                 continue;
             }
-            var sourceText = layer.text.sourceText;
+            const sourceText = layer.text.sourceText;
             // Check if the sourceText property has keys.
             // If it has keys, the font can change over time and we need to check all keys for their font
             if (sourceText.numKeys) {
@@ -1521,21 +1520,21 @@ function getFontsFromFileLegacy() {
  **/
 function generateFontReferences(fontPaths) {
     // Create a temp folder where all used fonts get gathered
-    var _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
-    var formattedFontsPaths = [];
-    var tempFontPath = new Folder(_tempFontsFolder);
+    const _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
+    const formattedFontsPaths = [];
+    const tempFontPath = new Folder(_tempFontsFolder);
     if (!tempFontPath.exists) {
         tempFontPath.create();
     }
 
     // Copy the font files to the temp folder
     for (var i = 0; i < fontPaths.length; i++) {
-        var fontName = fontPaths[i][0];
-        var fontLocation = fontPaths[i][1];
+        const fontName = fontPaths[i][0];
+        const fontLocation = fontPaths[i][1];
 
-        var fontFile = File(fontLocation);
-        var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        var fontCopied = fontFile.copy(_tempFontPath);
+        const fontFile = File(fontLocation);
+        const _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        const fontCopied = fontFile.copy(_tempFontPath);
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);
@@ -1562,25 +1561,17 @@ function isImageOutput(extension) {
 
 
 
-/**
- * Submit the selected render queue item
- **/
-function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
-    // Calculate task run timeout in seconds
-    var taskTimeoutSeconds = 0;
-    // Validate timeout values during job submission
-    if (taskTimeoutDays === 0 && taskTimeoutHours === 0 && taskTimeoutMinutes === 0) {
-        adcAlert("The following timeout value must be greater than 0: TaskRun", true);
-        throw new Error("Task run timeout must be greater than zero");
-    }
-    taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
+var JobParams = [
+    "JobScriptDir",
+    "CondaPackages",
+    "ProjectFile"
+]
 
-    const submitBundleFile = "SubmitButton.jsx";
-    // first we must verify that our selection is valid
-    if (selection == null) {
-        adcAlert("Error: No selection", true);
-        return;
-    }
+var paramPattern = "Param\."
+for (var p=0;p<JobParams.length;p++) {
+    paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
+}
+var paramPatternRegex = new RegExp(paramPattern, 'g')
 
 
 // Validate that the RenderQueueIndex for each selectionItem is still valid
@@ -1596,7 +1587,7 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
         return false;
     }
 
-    var renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+    const renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
     if (renderQueueItem == null || renderQueueItem.comp.id != selectionItem.compId) {
         adcAlert(
             "Error: Render Queue has changed since last refresh. Refreshing panel now. Please try again.", true
@@ -1616,10 +1607,194 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
 // Validate that our outputModule is set
 function validateRenderQueueItemOutputModule(renderQueueItem) {
     // We have already validated that we don't have more than 1 `numOutputModels`
-    var outputModule = renderQueueItem.outputModule(1).file;
+    const outputModule = renderQueueItem.outputModule(1).file;
     if (outputModule == null) {
         adcAlert("Error: Render Queue Item " + renderQueueItem.comp.name + " does not have its output file set", true);
         return false;
+    }
+    return true;
+}
+
+// Generate our prefixed Parameter Values for the provided comp
+function generateParameterValuesForStep(
+    prefix,
+    renderQueueIndex,
+    outputFolder,
+    outputFileName,
+    isImageSeq,
+    startFrame,
+    endFrame,
+    chunkSize,
+    multiFrameRendering,
+    maxCpuUsagePercentage,
+) {
+    return parameterValues(
+        renderQueueIndex,
+        app.project.file.fsName,
+        outputFolder,
+        outputFileName,
+        isImageSeq,
+        startFrame,
+        endFrame,
+        chunkSize,
+        multiFrameRendering,
+        maxCpuUsagePercentage,
+        prefix,
+    )
+}
+
+// Loading our default template from disk
+function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
+    const path = bundlePath + "/template.json";
+    const templateContents = readFile(path);
+    // Parse the template string to a JSON object
+    const templateObject = JSON.parse(templateContents);
+    templateObject.name = File.decode(app.project.file.name);
+    logger.debug("The template name is " + templateObject.name, submitBundleFile);
+
+    return templateObject
+}
+
+// Generates the job bundle and copies files from our template source folder into it
+function generateBundle() {
+    // create the job bundle folder
+    const bundleRoot = new Folder(
+        dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
+    ); //forward slash works on all operating systems
+    recursiveDelete(bundleRoot);
+    bundleRoot.create();
+
+    const jobTemplateSourceFolder = new Folder(
+        scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
+    );
+    if (!jobTemplateSourceFolder.exists) {
+        adcAlert(
+            "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
+        );
+        return null;
+    }
+    recursiveCopy(jobTemplateSourceFolder, bundleRoot);
+    return bundleRoot;
+}
+
+// Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
+//      Adding our `( <CompName> )` to the label and changing the name to prefixed by `<CompName>_`
+function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
+    var path = bundlePath + "/parameter_definitions_video_fragment.json";
+    if (isImageSeq) {
+        path = bundlePath + "/parameter_definitions_image_fragment.json";
+    }
+    const stepParametersContents = readFile(path);
+    // Parse the template string to a JSON object
+    const stepParametersObject = JSON.parse(stepParametersContents);
+
+    const updatedParameterDefinitions = []
+    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
+        if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
+            // Don't modify these values
+            continue
+        }
+        var replacedDefinition = stepParametersObject.parameterDefinitions[i]
+        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name
+        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label
+
+        updatedParameterDefinitions.push(replacedDefinition)
+    }
+    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
+    return stepParametersObject
+}
+
+// Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
+//      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
+function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
+    var path = bundlePath + "/step_video_fragment.json";
+    if (isImageSeq) {
+        path = bundlePath + "/step_image_fragment.json";
+    }
+    const stepTemplateContents = readFile(path);
+    // Parse the template string to a JSON object
+    const stepTemplateObject = JSON.parse(stepTemplateContents);
+
+    if (isImageSeq) {
+        // Replace parameter names in the creation of `Index`
+        const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_")
+        taskParameters.name = compName + "_" + taskParameters.name
+        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters
+    }
+
+    stepTemplateObject.steps[0].name = compName;
+    // Replace any parameter names in onRun script
+    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
+    const replacedArgs = []
+    for (var i=0;i<scriptArgs.length;i++) {
+        // JobParams
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
+    }
+    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+
+    return stepTemplateObject
+}
+
+// Modifies the `Create Output Directories` job environment by adding all of our output folder parameters
+function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
+    const path = bundlePath + "/job_environments_fragment.json";
+    const jobEnvironmentsContents = readFile(path);
+    // Parse the template string to a JSON object
+    const jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
+
+    for (var j=0;j<jobEnvironmentsObject.jobEnvironments.length;j++) {
+        if (jobEnvironmentsObject.jobEnvironments[j].name === "Create Output Directories") {
+            jobEnvironmentsObject.jobEnvironments[j].script.actions.onEnter.args = [
+                "{{Param.JobScriptDir}}/create_output_directory.py",
+                outputFoldersStr
+            ]
+        }
+    }
+    return jobEnvironmentsObject
+}
+
+/**
+ * Submit the selected render queue item
+ **/
+function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
+    // Calculate task run timeout in seconds
+    var taskTimeoutSeconds = 0;
+    // Validate timeout values during job submission
+    if (taskTimeoutDays === 0 && taskTimeoutHours === 0 && taskTimeoutMinutes === 0) {
+        adcAlert("The following timeout value must be greater than 0: TaskRun", true);
+        throw new Error("Task run timeout must be greater than zero");
+    }
+    taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
+
+    const submitBundleFile = "SubmitButton.jsx";
+    const renderQueueItems = []
+
+    // Check to make sure that all of our selection indices are correct
+    for (var i=0;i<selection.length;i++) {
+        var selectionItem = selection[i];
+        var initialRenderQueueIndex = selectionItem.renderQueueIndex;
+
+        // because our panel is updated independently of the render queue, the two may become out of sync
+        // we need to verify that the selection made actually matches what is in the render queue
+        if (!UpdateRenderQueueIndices(initialRenderQueueIndex, selectionItem)) {
+            return;
+        }
+        var initialRenderQueueItem = app.project.renderQueue.item(initialRenderQueueIndex);
+        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
+    }
+
+    //We have a valid selection
+    var confirmation = confirm("Project must be saved before submitting. Continue?");
+    if (!confirmation) {
+        return;
+    } else {
+        app.project.save();
+    }
+    if (app.project.file == null) {
+        // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
+        // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
+        return;
     }
 
     // Check if warning should be shown
@@ -1664,43 +1839,22 @@ function validateRenderQueueItemOutputModule(renderQueueItem) {
             }
             return;
         } else {
-            outputPath = outputModule.fsName;
-            outputFile = outputModule.name;
-            outputFolder = outputModule.parent.fsName;
-            logger.debug("OutputPath is: " + outputPath, submitBundleFile);
-            logger.debug("OutputFile is: " + outputFile, submitBundleFile);
-            logger.debug("outputFolder is: " + outputFolder, submitBundleFile);
+            app.project.save();
+        }
+        if (app.project.file == null) {
+            // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
+            // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
+            return;
         }
     }
+
     // Calculate frame range using the utility function
     const frameRange = dcUtil.calculateFrameRange(rqi);
     const startFrame = frameRange.startFrame;
     const endFrame = frameRange.endFrame;
 
-    return templateObject
-}
-
-// Generates the job bundle and copies files from our template source folder into it
-function generateBundle() {
-    // create the job bundle folder
-    var bundleRoot = new Folder(
-        dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
-    ); //forward slash works on all operating systems
-    recursiveDelete(bundleRoot);
-    bundleRoot.create();
-
-    var jobTemplateSourceFolder = new Folder(
-        scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
-    );
-    if (!jobTemplateSourceFolder.exists) {
-        adcAlert(
-            "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
-        );
-        return null;
-    }
-    recursiveCopy(jobTemplateSourceFolder, bundleRoot);
-    return bundleRoot;
-}
+    const aftereffectsVersion = app.version[0] + app.version[1];
+    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
 
     /**
      * Generates parameter_values json file
@@ -1727,15 +1881,29 @@ function generateBundle() {
             )
         );
     }
-    var stepParametersContents = readFile(path);
-    // Parse the template string to a JSON object
-    var stepParametersObject = JSON.parse(stepParametersContents);
 
-    var updatedParameterDefinitions = []
-    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
-        if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
-            // Don't modify these values
-            continue
+    /**
+     * Generates job template json file
+     **/
+    function generateTemplate(bundlePath, isImageSeq) {
+        // Open the template depending on the output type
+        var path = bundlePath + "/video_template.json";
+        if (isImageSeq) {
+            path = bundlePath + "/image_template.json";
+        }
+        var templateContents = readFile(path);
+        // Parse the template string to a JSON object
+        var templateObject = JSON.parse(templateContents);
+        templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
+        logger.debug("The template name is " + templateObject.name, submitBundleFile);
+        try {
+            if (templateObject.steps[0].name) {
+                templateObject.steps[0].name = compName;
+                logger.debug("The step name is " + templateObject.steps[0].name, submitBundleFile);
+            }
+        } catch (e) {
+            adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
+            logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
         }
         try {
             if (templateObject.steps[0].script && templateObject.steps[0].script.actions) {
@@ -1756,169 +1924,18 @@ function generateBundle() {
         }
         logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
-        updatedParameterDefinitions.push(replacedDefinition)
-    }
-    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
-    return stepParametersObject
-}
+    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
+    const stepOutputFolderParameters = [];
 
         for (var i = paramDefCopy.length - 1; i >= 0; i--) {
             if (paramDefCopy[i].name == "CondaPackages") {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsCondaVersion;
             }
         }
-    }
-    return jobEnvironmentsObject
-}
 
-/**
- * Submit the selected render queue item
- **/
-function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
-    const submitBundleFile = "SubmitButton.jsx";
-    var renderQueueItems = []
-
-    // Check to make sure that all of our selection indices are correct
-    for (var i=0;i<selection.length;i++) {
-        var selectionItem = selection[i];
-        var renderQueueIndex = selectionItem.renderQueueIndex;
-        var renderQueueItem;
-
-        // because our panel is updated independently of the render queue, the two may become out of sync
-        // we need to verify that the selection made actually matches what is in the render queue
-        if (!UpdateRenderQueueIndices(renderQueueIndex, selectionItem)) {
-            return;
-        }
-        renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
-        renderQueueItems.push([renderQueueItem, renderQueueIndex])
-    }
-
-    // We have valid selections check for saving
-    if (app.project.dirty) {
-        var confirmation = confirm("Project must be saved before submitting. Continue?");
-        if (!confirmation) {
-            return;
-        } else {
-            app.project.save();
-        }
-        if (app.project.file == null) {
-            // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
-            // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
-            return;
-        }
-    }
-
-
-    const aftereffectsVersion = app.version[0] + app.version[1];
-    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
-
-    var bundle = generateBundle();
-    var jobAssetReferences = {
-        assetReferences: {
-            inputs: {
-                directories: [],
-                filenames: [],
-            },
-            outputs: {
-                directories: [],
-            },
-            referencedPaths: [],
-        },
-    };
-    var jobParameterDefinitions = {
-      "parameterDefinitions": [
-        {
-          "name": "ProjectFile",
-          "type": "PATH",
-          "objectType": "FILE",
-          "dataFlow": "IN",
-          "userInterface": {
-            "control": "CHOOSE_INPUT_FILE",
-            "label": "Project file",
-            "groupLabel": "Source",
-            "fileFilters": [
-              {
-                "label": "After Effects project files",
-                "patterns": [
-                  "*.aep",
-                  "*.aepx"
-                ]
-              },
-              {
-                "label": "All Files",
-                "patterns": [
-                  "*"
-                ]
-              }
-            ]
-          },
-          "description": "The After Effects project file to render."
-        },
-        {
-          "name": "JobScriptDir",
-          "description": "Directory containing embedded scripts.",
-          "userInterface": {
-            "control": "HIDDEN"
-          },
-          "type": "PATH",
-          "objectType": "DIRECTORY",
-          "dataFlow": "IN",
-          "default": "scripts"
-        },
-        {
-          "name": "CondaPackages",
-          "type": "STRING",
-          "userInterface": {
-            "control": "HIDDEN"
-          },
-          "default": "aftereffects=" + aftereffectsVersion,
-          "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
-        }
-      ]
-    }
-    var jobParameterValues = {
-        parameterValues: [
-            {
-                name: "deadline:targetTaskRunStatus",
-                value: "READY",
-            },
-            {
-                name: "deadline:maxFailedTasksCount",
-                value: 20,
-            },
-            {
-                name: "deadline:maxRetriesPerTask",
-                value: 5,
-            },
-            {
-                name: "deadline:priority",
-                value: 50,
-            },
-            {
-                name: "ProjectFile",
-                value: app.project.file.fsName,
-            },
-        ]
-    }
-
-    var template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
-    template.steps = []
-    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
-
-    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
-    var stepOutputFolderParameters = [];
-
-    for (var i=0;i<renderQueueItems.length;i++) {
-        var renderQueueItem = renderQueueItems[i][0];
-        var renderQueueIndex = renderQueueItems[i][1];
-
-        if (!validateRenderQueueItemOutputModule(renderQueueItem)) {
-            return;
-        }
-
-        var stepFramesPerTask = parseInt(selectionSettings.get(selectionItem.compId).framesPerTask() || framesPerTask)
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(selectionItem.compId).maxCpuUsagePercentage() || maxCpuUsagePercentage)
-        var stepMultiFrameRendering = selectionSettings.get(selectionItem.compId).multiFrameRendering() || multiFrameRendering
+        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage)
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -2004,7 +2021,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             }
         }
     }
-    var generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
+    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
     writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
@@ -2013,14 +2030,14 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
-    var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
+    const logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
     logFile.open("w"); // Erase contents of active log file
     logFile.close();
     var submitScriptContents = "";
     var output = "";
     var cmd = "";
     if ($.os.toString().slice(0, 7) === "Windows") {
-        var tempBatFile = new File(
+        const tempBatFile = new File(
             dcUtil.getTempFolder() + "/DeadlineCloudAESubmission.bat"
         );
         cmd =
@@ -2043,7 +2060,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     } else {
         // Execute the command using a bash in the interactive mode so it loads the bash profile to set
         // the PATH correctly.
-        var shellPath = $.getenv("SHELL") || "/bin/bash";
+        const shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
         submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
@@ -2641,32 +2658,32 @@ if (typeof JSON !== "object") {
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
 function buildUI(thisObj) {
-    var submitterPanel = (thisObj instanceof Panel) ? thisObj : new Window("palette", "Submit to AWS Deadline Cloud", undefined, {
+    const submitterPanel = (thisObj instanceof Panel) ? thisObj : new Window("palette", "Submit to AWS Deadline Cloud", undefined, {
         resizable: true
     });
 
-    var uiSettingsState = new UiSettingsState();
+    const uiSettingsState = new UiSettingsState();
 
-    var root = submitterPanel.add("group");
+    const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
     root.alignChildren = ['fill', 'top']
-    var logoGroup = root.add("group");
+    const logoGroup = root.add("group");
     logoGroup.alignment = 'left';
     logoGroup.add("image", undefined, logoData());
-    var logoText = logoGroup.add("statictext", undefined, "AWS Deadline Cloud");
-    var arialBold24Font = ScriptUI.newFont("Arial", ScriptUI.FontStyle.BOLD, 64);
+    const logoText = logoGroup.add("statictext", undefined, "AWS Deadline Cloud");
+    const arialBold24Font = ScriptUI.newFont("Arial", ScriptUI.FontStyle.BOLD, 64);
     logoText.graphics.font = arialBold24Font;
-    var headerButtonGroup = root.add("group");
-    var focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
+    const headerButtonGroup = root.add("group");
+    const focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
     focusRenderQueueButton.onClick = function() {
         // we quickly toggle the window to make sure it gains focus
         // sometimes this causes a flicker
         app.project.renderQueue.showWindow(false);
         app.project.renderQueue.showWindow(true);
     }
-    var refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
-    var listGroup = root.add("panel", undefined, "");
+    const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
+    const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
     var list = null;
@@ -2696,6 +2713,7 @@ function buildUI(thisObj) {
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
+
     function onFramesPerTaskChanged() {
         const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
         if (isNaN(newFramesPerTaskValue)) {
@@ -2708,8 +2726,8 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -2739,6 +2757,7 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
     maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
+
     function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
@@ -2749,8 +2768,8 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
         }
     }
@@ -2771,12 +2790,24 @@ function buildUI(thisObj) {
         }
 
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
         }
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
+
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem.numOutputModules === 1) {
+            const outputModule = renderQueueItem.outputModule(1).file;
+            if (outputModule != null) {
+                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                const extension = getFileExtension(outputFileNameNoRegex);
+                return isImageOutput(extension);
+            }
+        }
+        return false
+    }
 
     // Add Timeouts settings group
     const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
@@ -2862,36 +2893,9 @@ function buildUI(thisObj) {
         if (selection == null) {
             return false;
         }
-        const renderQueueIndex = selection.renderQueueIndex;
-        const rqi = app.project.renderQueue.item(renderQueueIndex);
-        // Currently we only support one output modele. We have sufficient error handling
-        // after submit button is clicked, so this is a sufficient for now
-        if (rqi.numOutputModules == 1) {
-            var outputModule = rqi.outputModule(1).file;
-            if (outputModule != null) {
-                var outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                var extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
-            }
-        }
-        return false
-    }
-
-    // Check for duplicate names
-    function checkForInvalidCompositionNames(selection) {
-        var names = [];
-        var duplicateNames = [];
-        for (var i=0;i<selection.length;i++) {
-            var selectionItem = selection[i];
-            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
-            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-            if (names.indexOf(compName) !== -1) {
-                duplicateNames.push(renderQueueItem.comp.name);
-            }
-        }
         if (duplicateNames.length !== 0) {
             var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
-            for (var i=0;i<duplicateNames.length;i++) {
+            for (var i = 0; i < duplicateNames.length; i++) {
                 message = message + "\n\t" + duplicateNames[i];
             }
             adcAlert(message, true)
@@ -2900,7 +2904,7 @@ function buildUI(thisObj) {
         return false
     }
 
-    var submitButton = controlsGroup.add("button", undefined, "Submit");
+    const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
             const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
@@ -2910,8 +2914,7 @@ function buildUI(thisObj) {
             }
             if (taskRunCheckbox.value) {
                 SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
-            }
-            else {
+            } else {
                 SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
             }
             list.selection = null;
@@ -2921,8 +2924,8 @@ function buildUI(thisObj) {
     submitButton.enabled = false;
 
     function updateList() {
-        var bounds = list == null ? undefined : list.bounds;
-        var newList = listGroup.add("listbox", bounds, "", {
+        const bounds = list == null ? undefined : list.bounds;
+        const newList = listGroup.add("listbox", bounds, "", {
             multiselect: true,
             numberOfColumns: 4,
             showHeaders: true,
@@ -2932,28 +2935,30 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            var rqi = app.project.renderQueue.item(i);
+            const rqi = app.project.renderQueue.item(i);
             if (rqi == null) {
                 continue;
             }
             if (rqi.status == RQItemStatus.RENDERING || rqi.status == RQItemStatus.WILL_CONTINUE || rqi.status == RQItemStatus.USER_STOPPED || rqi.status == RQItemStatus.ERR_STOPPED || rqi.status == RQItemStatus.DONE) {
                 continue;
             }
-            var item = newList.add('item', i.toString());
+            const item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
             uiSettingsState.get(item.compId)
             item.subItems[0].text = rqi.comp.name;
+
             // Calculate frame range using the utility function
             var frameRange = dcUtil.calculateFrameRange(rqi);
             var startFrame = frameRange.startFrame;
             var endFrame = frameRange.endFrame;
+
             item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";
             } else if (rqi.numOutputModules == 1) {
-                var outputFile = rqi.outputModule(1).file;
+                const outputFile = rqi.outputModule(1).file;
                 item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
             } else {
                 item.subItems[2].text = "<multiple output modules>";
@@ -2966,7 +2971,7 @@ function buildUI(thisObj) {
         list = newList;
 
         function onSelectionChange() {
-            var selection = list.selection;
+            const selection = list.selection;
             if (selection == null) {
                 updateList();
                 framesPerTaskTextBox.text = "";
@@ -2984,16 +2989,16 @@ function buildUI(thisObj) {
             if (selection.length !== 1) {
                 return
             }
-            var selectionItem = selection[0]
+            const selectionItem = selection[0]
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            var imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
             framesPerTaskTextBox.enabled = imageOutput
             mfrCheckBox.enabled = true
             maxCpuUsagePercentageTextBox.enabled = true
 
             framesPerTaskTextBox.text = selectionItem.subItems[1].text
 
-            var settings = uiSettingsState.get(selectionItem.compId)
+            const settings = uiSettingsState.get(selectionItem.compId)
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return
@@ -3012,8 +3017,8 @@ function buildUI(thisObj) {
 
     updateList();
     if (list.selection != null && list.selection.length === 1) {
-        var selectionItem = list.selection[0]
-        var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
+        const selectionItem = list.selection[0]
+        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
     refreshButton.onClick = updateList;
@@ -3034,7 +3039,7 @@ function buildUI(thisObj) {
 
 
 function isSecurityPrefSet() {
-    var securitySetting = app.preferences.getPrefAsLong(
+    const securitySetting = app.preferences.getPrefAsLong(
         "Main Pref Section",
         "Pref_SCRIPTING_FILE_NETWORK_SECURITY"
     );
@@ -3045,7 +3050,7 @@ if (isSecurityPrefSet()) {
     buildUI(this);
 } else {
     //Print an error message and instructions for changing security preferences
-    var submitterPanel =
+    const submitterPanel =
         this instanceof Panel ?
         this :
         new Window(
@@ -3056,11 +3061,11 @@ if (isSecurityPrefSet()) {
                 closeButton: true,
             }
         );
-    var root = submitterPanel.add("group");
+    const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ["fill", "fill"];
     root.alignChildren = ["fill", "top"];
-    var errorText = root.add("statictext", undefined, "", {
+    const errorText = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText.graphics.foregroundColor = errorText.graphics.newPen(
@@ -3069,7 +3074,7 @@ if (isSecurityPrefSet()) {
         1
     );
     errorText.text = "Update Script Permissions";
-    var errorText2 = root.add("statictext", undefined, "", {
+    const errorText2 = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText2.text = [

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2854,7 +2854,7 @@ function populateListBoxItem(item, renderQueueItem, index) {
 
 function refreshList(listBox, uiSettingsState) {
     listBox.removeAll();
-   
+
     const InvalidRenderQueueItemStatuses = [
         RQItemStatus.RENDERING,
         RQItemStatus.WILL_CONTINUE,
@@ -3030,14 +3030,15 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            if (isNaN(newFramesPerTaskValue)){
-                framesPerTaskTextBox.text = uiSettingsState.get(selectionItem.compId).framesPerTask;
-            } else if (newFramesPerTaskValue > 9999) {
-                framesPerTaskTextBox.text = "9999"
-            } else {
-                framesPerTaskTextBox.text = newFramesPerTaskValue
+            var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
+            if (isNaN(newFramesPerTaskValue)) {
+                newFramesPerTaskValue = uiSettingsState.get(selectionItem.compId).framesPerTask();
             }
-            uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
+            if (newFramesPerTaskValue > 9999) {
+                newFramesPerTaskValue = 9999;
+            }
+            framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
+            uiSettingsState.get(selectionItem.compId).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -3150,65 +3151,69 @@ function buildUI(thisObj) {
 
     // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
-        uiSettingsState.setTaskRunTimeoutEnabled(this.value);
-        if (this.value) {
-            if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        if (taskRunCheckbox.value) {
+            if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
                 uiSettingsState.setTaskRunDays(DEFAULT_TASK_RUN_TIMEOUT_DAYS);
                 taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS;
                 uiSettingsState.setTaskRunHours(DEFAULT_TASK_RUN_TIMEOUT_HOURS);
                 taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_HOURS;
                 uiSettingsState.setTaskRunMinutes(DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
                 taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_MINUTES;
+            } else {
+                onTaskRunDaysChanged();
+                onTaskRunHoursChanged();
+                OnTaskRunMinutesCHanged();
             }
         }
-        uiSettingsState.setTaskRunTimeoutEnabled(this.value)
+        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunDaysInput.text;
+        taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
+        if (taskRunDaysInput.text === "") taskRunDaysInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunDaysInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunDays(parseInt(this.text))
+        uiSettingsState.setTaskRunDays(parseInt(taskRunDaysInput.text))
     }
     taskRunDaysInput.onChange = onTaskRunDaysChanged
 
     function onTaskRunHoursChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunHoursInput.text;
+        taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
+        if (taskRunHoursInput.text === "") taskRunHoursInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunHoursInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunHours(parseInt(this.text))
+        uiSettingsState.setTaskRunHours(parseInt(taskRunHoursInput.text))
     }
     taskRunHoursInput.onChange = onTaskRunHoursChanged
 
     function onTaskRunMinutesChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunMinutesInput.text;
+        taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
+        if (taskRunMinutesInput.text === "") taskRunMinutesInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunMinutesInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunMinutes(parseInt(this.text))
+        uiSettingsState.setTaskRunMinutes(parseInt(taskRunMinutesInput.text))
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
+
 
     // Check for duplicate names
     function checkForInvalidCompositionNames(selection) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1865,8 +1865,8 @@ function generateBundle() {
 }
 
 // Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
-//      Adding our `( <CompName> )` to the label and changing the name to prefixed by `<CompName>_`
-function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
+//      Adding our `( <RenderQueueItemID> )` to the label and changing the name to prefixed by `<RenderQueueItemID>_`
+function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID) {
     var path = bundlePath + "/parameter_definitions_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/parameter_definitions_image_fragment.json";
@@ -1882,8 +1882,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
             continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name;
-        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label;
+        replacedDefinition.name = renderQueueItemID + "_" + stepParametersObject.parameterDefinitions[i].name;
+        replacedDefinition.userInterface.label = "(" + renderQueueItemID + ") " + replacedDefinition.userInterface.label;
 
         updatedParameterDefinitions.push(replacedDefinition);
     }
@@ -1892,8 +1892,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
-//      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTimeoutSeconds) {
+//      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -1905,18 +1905,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_");
-        taskParameters.name = compName + "_" + taskParameters.name;
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + renderQueueItemID + "_");
+        taskParameters.name = renderQueueItemID + "_" + taskParameters.name;
         stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
-    stepTemplateObject.steps[0].name = compName;
+    stepTemplateObject.steps[0].name = renderQueueItemID;
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"));
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + renderQueueItemID + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
@@ -2143,7 +2143,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-
+        var renderQueueItemID = renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
@@ -2161,7 +2161,7 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
-            compName + "_" + renderQueueIndex,
+            renderQueueItemID,
             renderQueueIndex,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
@@ -2179,13 +2179,13 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}");
+        stepOutputFolderParameters.push("{{Param." + renderQueueItemID + "_OutputDir}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueItemID, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName);
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueItemID);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2143,7 +2143,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-        var renderQueueItemID = renderQueueIndex + "_" + compName;
+        var renderQueueItemID = "_" + renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2045,6 +2045,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
+    writeFile(bundle.fsName + "/asset_references.json",JSON.stringify(jobAssetReferences, null, 4));
+
     writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
 
     writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2,7 +2,71 @@
 // Manual changes in this file may be overwritten by a new installation.
 // Please change the source files and regenerate this file instead.
 
+if ( ExternalObject.AdobeXMPScript == undefined ) {
+    ExternalObject.AdobeXMPScript = new ExternalObject( "lib:AdobeXMPScript");
+}
+
 var scriptFolder = Folder.current.fsName;
+
+// Global constants, wrapped with if-blocks to ensure they are only defined once
+// to avoid errors due to redeclaration
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+}
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+}
+if (typeof SUPPORTED_VERSIONS === "undefined") {
+    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+}
+if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+    const DEADLINECLOUD_SUBMITTER_SETTINGS = "DeadlineCloudSubmitter";
+}
+if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+}
+if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+}
+if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+}
+if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
+}
+if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
+    const DEFAULT_FRAMESPERTASK = 10;
+}
+if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
+    const DEFAULT_MULTI_FRAME_RENDERING = false;
+}
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -148,12 +212,66 @@ function __generateUtil() {
         return false;
     }
 
+    /**
+     * Combines prefix and key to construct a key for accessing a value in XMPMetadata 
+     * @param {String} prefix 
+     * @param {String} key 
+     * @returns {String}
+     */
+    function buildMetadataKey(prefix, key) {
+        return "xmp:" + prefix + "__" + key;
+    }
+
+    /**
+     * Saves item to project's XMP Metadata
+     * @param {String} prefix 
+     * @param {String} key 
+     * @param {*} value 
+     * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
+     */
+    function saveToMetadata(prefix, key, value, type) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        metadata.setProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), value, type);
+        app.project.xmpPacket = metadata.serialize();
+    }
+
+    /**
+     * Checks if item with given key exists in project's XMPMetadata
+     * @param {String} prefix 
+     * @param {String} key 
+     * @returns {boolean}
+     */
+    function metadataKeyExists(prefix, key) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key)) !== undefined;
+    }
+
+    /**
+     * Loads value from project's XMP metadata 
+     * @param {String} prefix 
+     * @param {String} key 
+     * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
+     * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
+     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
+     */
+    function loadFromMetadata(prefix, key, defaultValue, type) {
+        if (!metadataKeyExists(prefix, key)) {
+            if (defaultValue !== undefined) {
+                saveToMetadata(prefix, key, defaultValue, type);
+            } else {
+                throw Error("Key '" + buildMetadataKey(prefix, key) + "' does not exist in project XMP Metadata, and no default value is set.")
+            }
+        }
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), type).value;
+    }
+
     function saveBoolSetting(sectionName, keyName, value) {
         /**
          * Sets boolean value in app settings
          */
         validateType(value, "boolean");
-        app.settings.saveSetting(sectionName, keyName, value.toString());
+        saveToMetadata(sectionName, keyName, value, XMPConst.BOOLEAN);
     }
 
     function getBoolSetting(sectionName, keyName, defaultValue) {
@@ -161,14 +279,7 @@ function __generateUtil() {
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
-            }
-            saveBoolSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "defaultValue");
-        }
-        return parseBool(app.settings.getSetting(sectionName, keyName));
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
     function saveNumberSetting(sectionName, keyName, value) {
@@ -176,7 +287,7 @@ function __generateUtil() {
          * Sets integer value in app settings
          */
         validateType(value, "number");
-        app.settings.saveSetting(sectionName, keyName, value.toString());
+        saveToMetadata(sectionName, keyName, value, XMPConst.NUMBER);
     }
 
     function getNumberSetting(sectionName, keyName, defaultValue) {
@@ -184,21 +295,7 @@ function __generateUtil() {
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
-            }
-            saveNumberSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
-        }
-        if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
-            }
-            saveNumberSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + defaultValue);
-        }
-        return Number(app.settings.getSetting(sectionName, keyName));
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.NUMBER);
     }
 
     function saveStringSetting(sectionName, keyName, value) {
@@ -206,7 +303,7 @@ function __generateUtil() {
          * Sets string in app settings
          */
         validateType(value, "string");
-        app.settings.saveSetting(sectionName, keyName, value);
+        saveToMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
     }
 
     function getStringSetting(sectionName, keyName, defaultValue) {
@@ -214,14 +311,7 @@ function __generateUtil() {
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
-            }
-            setStringSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
-        }
-        return app.settings.getSetting(sectionName, keyName)
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -242,7 +332,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function() {
+        textObj.onChange = function () {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -251,7 +341,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function() {
+        sliderObj.onChange = function () {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -683,43 +773,43 @@ function __generateUtil() {
 
         const hostRequirements = {
             "attributes": [{
-                    "name": "attr.worker.os.family",
-                    "anyOf": [
-                        osGroup.OSDropdownList.selection.text.toLowerCase()
-                    ]
-                },
-                {
-                    "name": "attr.worker.cpu.arch",
-                    "anyOf": [
-                        cpuArchGroup.cpuDropdownList.selection.text
-                    ]
-                }
+                "name": "attr.worker.os.family",
+                "anyOf": [
+                    osGroup.OSDropdownList.selection.text.toLowerCase()
+                ]
+            },
+            {
+                "name": "attr.worker.cpu.arch",
+                "anyOf": [
+                    cpuArchGroup.cpuDropdownList.selection.text
+                ]
+            }
             ],
             "amounts": [{
-                    "name": "amount.worker.vcpu",
-                    "min": parseInt(cpuGroup.cpuMinText.text),
-                    "max": parseInt(cpuGroup.cpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.memory",
-                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.gpu",
-                    "min": parseInt(gpuGroup.gpuMinText.text),
-                    "max": parseInt(gpuGroup.gpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.gpu.memory",
-                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.disk.scratch",
-                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-                }
+                "name": "amount.worker.vcpu",
+                "min": parseInt(cpuGroup.cpuMinText.text),
+                "max": parseInt(cpuGroup.cpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.memory",
+                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.gpu",
+                "min": parseInt(gpuGroup.gpuMinText.text),
+                "max": parseInt(gpuGroup.gpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.gpu.memory",
+                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.disk.scratch",
+                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+            }
             ]
         }
 
@@ -872,9 +962,9 @@ function __generateUtil() {
 
     function getRQIID(renderQueueIndex) {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
-         * Not guaranteed to be unique
+         * Not guaranteed to be unique if render queue items are reordered
          */
-        return app.project.file.name + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+        return app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
     }
 
     return {
@@ -925,75 +1015,11 @@ function __generateUtil() {
     }
 }
 
-dcUtil = __generateUtil();
+var dcUtil = __generateUtil();
 
-
-// Global constants, wrapped with if-blocks to ensure they are only defined once
-// to avoid errors due to redeclaration
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-}
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-}
-if (typeof SUPPORTED_VERSIONS === "undefined") {
-    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-}
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-}
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
-if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-}
-if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-}
-if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
-}
-if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
-    const DEFAULT_FRAMESPERTASK = 10;
-}
-if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
-    const DEFAULT_MULTI_FRAME_RENDERING = false;
-}
-if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
-}
-
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
+// Getting a setting that doesn't already exist will set it to its default value
+dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
+dcUtil.getStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
 
 
 var LOG_LEVEL = {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -853,7 +853,7 @@ function __generateUtil() {
         if (enabled) {
             var days = parseInt(daysInput) || 0;
             var hours = parseInt(hoursInput) || 0;
-            var minutes = parseInt(minutesInput.text) || 0;
+            var minutes = parseInt(minutesInput) || 0;
 
             if (days === 0 && hours === 0 && minutes === 0) {
                 adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
@@ -3162,7 +3162,7 @@ function buildUI(thisObj) {
             } else {
                 onTaskRunDaysChanged();
                 onTaskRunHoursChanged();
-                OnTaskRunMinutesChanged();
+                onTaskRunMinutesChanged();
             }
         }
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
@@ -3170,49 +3170,46 @@ function buildUI(thisObj) {
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
-        var old_text = taskRunDaysInput.text;
+        var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        if (taskRunDaysInput.text === "") taskRunDaysInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunDaysInput.text = old_text
+        var new_value = parseInt(taskRunDaysInput.text)
+        if (taskRunDaysInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunDays(new_value)
             }
         }
-        uiSettingsState.setTaskRunDays(parseInt(taskRunDaysInput.text))
+        taskRunDaysInput.text = uiSettingsState.taskRunDays();
     }
-    taskRunDaysInput.onChange = onTaskRunDaysChanged
+    taskRunDaysInput.onChange = onTaskRunDaysChanged;
 
     function onTaskRunHoursChanged() {
-        var old_text = taskRunHoursInput.text;
+        var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        if (taskRunHoursInput.text === "") taskRunHoursInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunHoursInput.text = old_text
+        var new_value = parseInt(taskRunHoursInput.text)
+        if (taskRunHoursInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunHours(new_value)
             }
         }
-        uiSettingsState.setTaskRunHours(parseInt(taskRunHoursInput.text))
+        taskRunHoursInput.text = uiSettingsState.taskRunHours();
     }
-    taskRunHoursInput.onChange = onTaskRunHoursChanged
+    taskRunHoursInput.onChange = onTaskRunHoursChanged;
 
     function onTaskRunMinutesChanged() {
-        var old_text = taskRunMinutesInput.text;
+        var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        if (taskRunMinutesInput.text === "") taskRunMinutesInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunMinutesInput.text = old_text
+        var new_value = parseInt(taskRunMinutesInput.text)
+        if (taskRunMinutesInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunMinutes(new_value)
             }
         }
-        uiSettingsState.setTaskRunMinutes(parseInt(taskRunMinutesInput.text))
+        taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
     }
-    taskRunMinutesInput.onChange = onTaskRunMinutesChanged
+    taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
 
     // Check for duplicate names
@@ -3311,7 +3308,7 @@ function buildUI(thisObj) {
         function onSelectionChange() {
             const selection = list.selection;
             perCompSettingsGroup.enabled = false;
-            
+
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = ""

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -600,43 +600,43 @@ function __generateUtil() {
 
         const hostRequirements = {
             "attributes": [{
-                "name": "attr.worker.os.family",
-                "anyOf": [
-                    osGroup.OSDropdownList.selection.text.toLowerCase()
-                ]
-            },
-            {
-                "name": "attr.worker.cpu.arch",
-                "anyOf": [
-                    cpuArchGroup.cpuDropdownList.selection.text
-                ]
-            }
+                    "name": "attr.worker.os.family",
+                    "anyOf": [
+                        osGroup.OSDropdownList.selection.text.toLowerCase()
+                    ]
+                },
+                {
+                    "name": "attr.worker.cpu.arch",
+                    "anyOf": [
+                        cpuArchGroup.cpuDropdownList.selection.text
+                    ]
+                }
             ],
             "amounts": [{
-                "name": "amount.worker.vcpu",
-                "min": parseInt(cpuGroup.cpuMinText.text),
-                "max": parseInt(cpuGroup.cpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.memory",
-                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.gpu",
-                "min": parseInt(gpuGroup.gpuMinText.text),
-                "max": parseInt(gpuGroup.gpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.gpu.memory",
-                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.disk.scratch",
-                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-            }
+                    "name": "amount.worker.vcpu",
+                    "min": parseInt(cpuGroup.cpuMinText.text),
+                    "max": parseInt(cpuGroup.cpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.memory",
+                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.gpu",
+                    "min": parseInt(gpuGroup.gpuMinText.text),
+                    "max": parseInt(gpuGroup.gpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.gpu.memory",
+                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.disk.scratch",
+                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+                }
             ]
         }
 
@@ -753,7 +753,7 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-         // NOTE: we're not using displayStartFrame since it is rounded up
+        // NOTE: we're not using displayStartFrame since it is rounded up
         const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
@@ -764,112 +764,139 @@ function __generateUtil() {
         };
     }
 
-    return {
-        "invertObject": invertObject,
-        "toBooleanString": toBooleanString,
-        "parseBool": parseBool,
-        "trimIllegalChars": trimIllegalChars,
-        "sliderTextSync": sliderTextSync,
-        "changeTextValue": changeTextValue,
-        "changeSliderValue": changeSliderValue,
-        "checkGPUAccelType": checkGPUAccelType,
-        "spinBoxLimiterMin": spinBoxLimiterMin,
-        "spinBoxLimiterMax": spinBoxLimiterMax,
-        "getAssetsInScene": getAssetsInScene,
-        "editTextIntValidation": editTextIntValidation,
-        "getDescription": getDescription,
-        "wrappedCallSystem": wrappedCallSystem,
-        "parseErrorData": parseErrorData,
-        "parseVersionData": parseVersionData,
-        "createExportBundleDir": createExportBundleDir,
-        "removeLineBreak": removeLineBreak,
-        "setListBoxSelection": setListBoxSelection,
-        "getPath": getPath,
-        "getPartialExportDir": getPartialExportDir,
-        "collectHostRequirements": collectHostRequirements,
-        "deepCopy": deepCopy,
-        "getActiveComp": getActiveComp,
-        "normalizePath": normalizePath,
-        "normPath": normalizePath,
-        "enforceForwardSlashes": enforceForwardSlashes,
-        "removeIllegalCharacters": removeIllegalCharacters,
-        "removePercentageFromFileName": removePercentageFromFileName,
-        "getTempFile": getTempFile,
-        "getUserDirectory": getUserDirectory,
-        "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder,
-        "calculateFrameRange": calculateFrameRange
+        function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+            if (enabled) {
+                var days = parseInt(daysInput.text) || 0;
+                var hours = parseInt(hoursInput.text) || 0;
+                var minutes = parseInt(minutesInput.text) || 0;
+
+                if (days === 0 && hours === 0 && minutes === 0) {
+                    adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
+                    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        function getSelection(list) {
+            for (var s = 0; s < list.selection.length; s++) {
+                return list.selection[s];
+            }
+        }
+
+        return {
+            "invertObject": invertObject,
+            "toBooleanString": toBooleanString,
+            "parseBool": parseBool,
+            "trimIllegalChars": trimIllegalChars,
+            "sliderTextSync": sliderTextSync,
+            "changeTextValue": changeTextValue,
+            "changeSliderValue": changeSliderValue,
+            "checkGPUAccelType": checkGPUAccelType,
+            "spinBoxLimiterMin": spinBoxLimiterMin,
+            "spinBoxLimiterMax": spinBoxLimiterMax,
+            "getAssetsInScene": getAssetsInScene,
+            "editTextIntValidation": editTextIntValidation,
+            "getDescription": getDescription,
+            "wrappedCallSystem": wrappedCallSystem,
+            "parseErrorData": parseErrorData,
+            "parseVersionData": parseVersionData,
+            "createExportBundleDir": createExportBundleDir,
+            "removeLineBreak": removeLineBreak,
+            "setListBoxSelection": setListBoxSelection,
+            "getPath": getPath,
+            "getPartialExportDir": getPartialExportDir,
+            "collectHostRequirements": collectHostRequirements,
+            "deepCopy": deepCopy,
+            "getActiveComp": getActiveComp,
+            "normalizePath": normalizePath,
+            "normPath": normalizePath,
+            "enforceForwardSlashes": enforceForwardSlashes,
+            "removeIllegalCharacters": removeIllegalCharacters,
+            "removePercentageFromFileName": removePercentageFromFileName,
+            "getTempFile": getTempFile,
+            "getUserDirectory": getUserDirectory,
+            "getAEVersion": getAEVersion,
+            "getTempFolder": getTempFolder,
+            "calculateFrameRange": calculateFrameRange
+            "validateTimeoutValues": validateTimeoutValues,
+            "getSelection": getSelection,
+            "getTempFolder": getTempFolder
     }
+
 }
+
+
 
 dcUtil = __generateUtil();
 
 
-// Global constants, wrapped with if-blocks to ensure they are only defined once
-// to avoid errors due to redeclaration
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-}
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-}
-if (typeof SUPPORTED_VERSIONS === "undefined") {
-    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-}
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-}
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
-if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-}
-if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-}
-if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-}
+                        // Global constants, wrapped with if-blocks to ensure they are only defined once
+                        // to avoid errors due to redeclaration
+                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+                            const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+                        }
+                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+                            const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+                        }
+                        if (typeof SUPPORTED_VERSIONS === "undefined") {
+                            const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+                        }
+                        if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+                            const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+                        }
+                        if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+                            const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+                        }
+                        if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+                            const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+                        }
+                        if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+                            const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+                        }
+                        if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+                            const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+                        }
 
 
 var LOG_LEVEL = {
@@ -1061,6 +1088,15 @@ function UiSettingsStore(name) {
     // _maxCpuUsagePercentage: string
     this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
 
+    // _taskRunTimeout: bool
+    this._taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    // _taskRunDays: string
+    this._taskRunDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
+    // _taskRunHours: string
+    this._taskRunHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
+    // _taskRunMinutes: string
+    this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
+
     this.framesPerTask = function () {
         return this._framesPerTask
     }
@@ -1084,9 +1120,41 @@ function UiSettingsStore(name) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
         this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
+
+    this.taskRunTimeout = function () {
+        return this._taskRunTimeout
+    }
+    this.setTaskRunTimeout = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
+        this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunDays = function () {
+        return this._taskRunDays
+    }
+    this.setTaskRunDays = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
+        this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunHours = function () {
+        return this._taskRunHours
+    }
+    this.setTaskRunHours = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
+        this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunMinutes = function () {
+        return this._taskRunMinutes
+    }
+    this.setTaskRunMinutes = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
+        this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
+    }
 }
 
-UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId)
     }
@@ -1099,9 +1167,26 @@ UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRe
     if (maxCpuUsagePercentage === undefined) {
         maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
     }
+    if (taskRunTimeout === undefined) {
+        taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    }
+    if (taskRunTimeoutDays === undefined) {
+        taskRunTimeoutDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
+    }
+    if (taskRunTimeoutHours === undefined) {
+        taskRunTimeoutHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
+    }
+    if (taskRunTimeoutMinutes === undefined) {
+        taskRunTimeoutMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
+    }
+
     this.settings[compId].setFramesPerTask(framesPerTask);
     this.settings[compId].setMultiFrameRendering(multiFrameRendering);
     this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+    this.settings[compId].setTaskRunTimeout(taskRunTimeout);
+    this.settings[compId].setTaskRunDays(taskRunTimeoutDays);
+    this.settings[compId].setTaskRunHours(taskRunTimeoutHours);
+    this.settings[compId].setTaskRunMinutes(taskRunTimeoutMinutes);
 }
 
 UiSettingsState.prototype.get = function(compId) {
@@ -1727,7 +1812,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -1753,6 +1838,10 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+    if (templateObject.steps[0].script.actions.onRun) {
+        templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+        logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
+    }
 
     return stepTemplateObject
 }
@@ -2052,7 +2141,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
 
         stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName)
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
         for (var s=0;s<stepTemplate.steps.length;s++) {
             template.steps.push(stepTemplate.steps[s])
         }
@@ -2838,11 +2927,11 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
-        for (var s = 0; s < list.selection.length; s++) {
-            if (list.selection == null) {
-                return;
-            }
-            const selectionItem = list.selection[s];
+        if (list.selection == null) {
+            return;
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -2883,12 +2972,95 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        for (var s = 0; s < list.selection.length; s++) {
-            const selectionItem = list.selection[s];
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
+
+    // Add Timeouts settings group
+    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
+    timeoutsPanel.orientation = "column";
+    timeoutsPanel.alignment = ['fill', 'top'];
+    timeoutsPanel.alignChildren = ['left', 'center'];
+    timeoutsPanel.margins = 5;
+
+    // Task run timeout
+    const taskRunGroup = timeoutsPanel.add("group");
+    taskRunGroup.orientation = "row";
+    taskRunGroup.alignment = ['fill', 'top'];
+    taskRunGroup.alignChildren = ['left', 'center'];
+
+    const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
+    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+
+    const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
+    taskRunDaysInput.characters = 3;
+    taskRunDaysGroup.add("statictext", undefined, "days");
+
+    const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
+    taskRunHoursInput.characters = 3;
+    taskRunHoursGroup.add("statictext", undefined, "hours");
+
+    const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
+    taskRunMinutesInput.characters = 3;
+    taskRunMinutesGroup.add("statictext", undefined, "minutes");
+
+    // Add input validation and save values to settings
+    function onTaskRunCheckboxClicked() {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
+        if (this.value) {
+            dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunTimeout(this.value)
+        }
+    }
+    taskRunCheckbox.onClick = onTaskRunCheckboxClicked
+
+    function onTaskRunDaysChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunDays(this.text)
+        }
+    }
+    taskRunDaysInput.onChange = onTaskRunDaysChanged
+
+    function onTaskRunHoursChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunHours(this.text)
+        }
+    }
+    taskRunHoursInput.onChange = onTaskRunHoursChanged
+
+    function onTaskRunMinutesChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunMinutes(this.text)
+        }
+    }
+    taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
@@ -2905,8 +3077,8 @@ function buildUI(thisObj) {
         }
 
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        for (var s = 0; s < list.selection.length; s++) {
-            const selectionItem = list.selection[s];
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
         }
     }

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/job_environments_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/job_environments_fragment.json
@@ -1,0 +1,43 @@
+{
+  "jobEnvironments": [
+    {
+      "name": "Create Output Directories",
+      "description": "Create Output Directories",
+      "script": {
+        "actions": {
+          "onEnter": {
+            "command": "python",
+            "args": [
+              "{{Param.JobScriptDir}}/create_output_directory.py",
+              "{{Param.OutputDir}}"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "Install Fonts to Worker",
+      "description": "Install Fonts to Worker",
+      "script": {
+        "actions": {
+          "onEnter": {
+            "command": "python",
+            "args": [
+              "{{Param.JobScriptDir}}/font_manager.py",
+              "install",
+              "{{Session.WorkingDirectory}}"
+            ]
+          },
+          "onExit": {
+            "command": "python",
+            "args": [
+              "{{Param.JobScriptDir}}/font_manager.py",
+              "remove",
+              "{{Session.WorkingDirectory}}"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
@@ -1,0 +1,134 @@
+{
+  "parameterDefinitions": [
+    {
+      "name": "ProjectFile",
+      "type": "PATH",
+      "objectType": "FILE",
+      "dataFlow": "IN",
+      "userInterface": {
+        "control": "CHOOSE_INPUT_FILE",
+        "label": "Project file",
+        "groupLabel": "Source",
+        "fileFilters": [
+          {
+            "label": "After Effects project files",
+            "patterns": [
+              "*.aep",
+              "*.aepx"
+            ]
+          },
+          {
+            "label": "All Files",
+            "patterns": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "description": "The After Effects project file to render."
+    },
+    {
+      "name": "RenderQueueIndex",
+      "type": "INT",
+      "userInterface": {
+        "control": "SPIN_BOX",
+        "label": "Render Queue Index",
+        "groupLabel": "Source"
+      },
+      "description": "The index of the item in the render queue to render.",
+      "default": 1
+    },
+    {
+      "name": "OutputDir",
+      "type": "PATH",
+      "objectType": "DIRECTORY",
+      "dataFlow": "OUT",
+      "userInterface": {
+        "control": "CHOOSE_DIRECTORY",
+        "label": "Output Directory",
+        "groupLabel": "Render Parameters"
+      },
+      "default": "./output",
+      "description": "Choose the render output directory."
+    },
+    {
+      "name": "OutputFileName",
+      "type": "STRING",
+      "userInterface": {
+        "control": "HIDDEN",
+        "label": "Output File Pattern",
+        "groupLabel": "Render Parameters"
+      },
+      "default": "output_####.png",
+      "description": "The file name used for aerender cmd. Not a changeable parameter."
+    },
+    {
+      "name": "Frames",
+      "type": "STRING",
+      "userInterface": {
+        "control": "LINE_EDIT",
+        "label": "Start Frame - End Frame",
+        "groupLabel": "Frame Range"
+      }
+    },
+    {
+      "name": "ChunkSize",
+      "type": "INT",
+      "userInterface": {
+        "control": "SPIN_BOX",
+        "label": "Frames Per Task",
+        "groupLabel": "Frame Range"
+      },
+      "description": "The chunk size of frames per task to render",
+      "minValue": 1
+    },
+    {
+      "name": "MultiFrameRendering",
+      "type": "STRING",
+      "default": "OFF",
+      "allowedValues": [
+        "ON",
+        "OFF"
+      ],
+      "userInterface": {
+        "control": "DROPDOWN_LIST",
+        "label": "Enable or disable multi-frame rendering",
+        "groupLabel": "Multi-Frame Rendering"
+      },
+      "description": "Multi frame rendering settings"
+    },
+    {
+      "name": "MaxCpuUsagePercentage",
+      "type": "INT",
+      "userInterface": {
+        "control": "SPIN_BOX",
+        "label": "Max CPU Usage Percentage",
+        "groupLabel": "Multi-Frame Rendering"
+      },
+      "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
+      "minValue": 1,
+      "maxValue": 100,
+      "default": 90
+    },
+    {
+      "name": "JobScriptDir",
+      "description": "Directory containing embedded scripts.",
+      "userInterface": {
+        "control": "HIDDEN"
+      },
+      "type": "PATH",
+      "objectType": "DIRECTORY",
+      "dataFlow": "IN",
+      "default": "scripts"
+    },
+    {
+      "name": "CondaPackages",
+      "type": "STRING",
+      "userInterface": {
+        "control": "HIDDEN"
+      },
+      "default": "aftereffects={{AE_VERSION}}",
+      "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+    }
+  ]
+}

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
@@ -1,0 +1,124 @@
+{
+  "parameterDefinitions": [
+    {
+      "name": "ProjectFile",
+      "type": "PATH",
+      "objectType": "FILE",
+      "dataFlow": "IN",
+      "userInterface": {
+        "control": "CHOOSE_INPUT_FILE",
+        "label": "Project file",
+        "groupLabel": "Source",
+        "fileFilters": [
+          {
+            "label": "After Effects project files",
+            "patterns": [
+              "*.aep",
+              "*.aepx"
+            ]
+          },
+          {
+            "label": "All Files",
+            "patterns": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "description": "The After Effects project file to render."
+    },
+    {
+      "name": "RenderQueueIndex",
+      "type": "INT",
+      "userInterface": {
+        "control": "SPIN_BOX",
+        "label": "Render Queue Index",
+        "groupLabel": "Source"
+      },
+      "description": "The index of the item in the render queue to render.",
+      "default": 1
+    },
+    {
+      "name": "OutputDir",
+      "type": "PATH",
+      "objectType": "DIRECTORY",
+      "dataFlow": "OUT",
+      "userInterface": {
+        "control": "CHOOSE_DIRECTORY",
+        "label": "Output Directory",
+        "groupLabel": "Render Parameters"
+      },
+      "default": "./output",
+      "description": "Choose the render output directory."
+    },
+    {
+      "name": "OutputFileName",
+      "type": "STRING",
+      "userInterface": {
+        "control": "HIDDEN",
+        "label": "Output File Pattern",
+        "groupLabel": "Render Parameters"
+      },
+      "default": "output.mp4",
+      "description": "The file name used for aerender cmd. Not a changeable parameter."
+    },
+    {
+      "name": "Frames",
+      "type": "STRING",
+      "userInterface": {
+        "control": "LINE_EDIT",
+        "label": "Start Frame - End Frame",
+        "groupLabel": "Frame Range"
+      },
+      "default": "1-10"
+    },
+    {
+      "name": "MultiFrameRendering",
+      "type": "STRING",
+      "default": "OFF",
+      "allowedValues": [
+        "ON",
+        "OFF"
+      ],
+      "userInterface": {
+        "control": "DROPDOWN_LIST",
+        "label": "Enable or disable multi-frame rendering",
+        "groupLabel": "Multi-Frame Rendering"
+      },
+      "description": "Multi frame rendering settings"
+    },
+    {
+      "name": "MaxCpuUsagePercentage",
+      "type": "INT",
+      "userInterface": {
+        "control": "SPIN_BOX",
+        "label": "Max CPU Usage Percentage",
+        "groupLabel": "Multi-Frame Rendering"
+      },
+      "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
+      "minValue": 1,
+      "maxValue": 100,
+      "default": 90
+    },
+    {
+      "name": "JobScriptDir",
+      "description": "Directory containing embedded scripts.",
+      "userInterface": {
+        "control": "HIDDEN"
+      },
+      "type": "PATH",
+      "objectType": "DIRECTORY",
+      "dataFlow": "IN",
+      "default": "scripts"
+    },
+    {
+      "name": "CondaPackages",
+      "type": "STRING",
+      "userInterface": {
+        "control": "HIDDEN"
+      },
+      "default": "aftereffects={{AE_VERSION}}",
+      "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+    }
+  ]
+}

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_image_fragment.json
@@ -1,0 +1,49 @@
+{
+  "steps": [
+    {
+      "name": "{{COMP_NAME}}",
+      "hostRequirements": {
+        "attributes": [
+          {
+            "name": "attr.worker.os.family",
+            "anyOf": [
+              "windows",
+              "macos"
+            ]
+          }
+        ]
+      },
+      "parameterSpace": {
+        "taskParameterDefinitions": [
+          {
+            "name": "Index",
+            "type": "INT",
+            "range": "{{Param.Frames}}:{{Param.ChunkSize}}"
+          }
+        ]
+      },
+      "script": {
+        "actions": {
+          "onRun": {
+            "command": "python",
+            "args": [
+              "{{Param.JobScriptDir}}/call_aerender.py",
+              "{{Param.ProjectFile}}",
+              "{{Param.RenderQueueIndex}}",
+              "{{Param.OutputDir}}/{{Param.OutputFileName}}",
+              "{{Param.Frames}}",
+              "--chunk-size",
+              "{{Param.ChunkSize}}",
+              "--index",
+              "{{Task.Param.Index}}",
+              "--multi-frame-rendering",
+              "{{Param.MultiFrameRendering}}",
+              "--max-cpu-usage-percentage",
+              "{{Param.MaxCpuUsagePercentage}}"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_video_fragment.json
@@ -1,0 +1,36 @@
+{
+  "steps": [
+    {
+      "name": "{{COMP_NAME}}",
+      "hostRequirements": {
+        "attributes": [
+          {
+            "name": "attr.worker.os.family",
+            "anyOf": [
+              "windows",
+              "macos"
+            ]
+          }
+        ]
+      },
+      "script": {
+        "actions": {
+          "onRun": {
+            "command": "python",
+            "args": [
+              "{{Param.JobScriptDir}}/call_aerender.py",
+              "{{Param.ProjectFile}}",
+              "{{Param.RenderQueueIndex}}",
+              "{{Param.OutputDir}}/{{Param.OutputFileName}}",
+              "{{Param.Frames}}",
+              "--multi-frame-rendering",
+              "{{Param.MultiFrameRendering}}",
+              "--max-cpu-usage-percentage",
+              "{{Param.MaxCpuUsagePercentage}}"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/template.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/template.json
@@ -1,0 +1,96 @@
+{
+    "specificationVersion": "jobtemplate-2023-09",
+    "name": "{{JOB_NAME}}",
+    "description": "A simple job bundle that allows a user to select a project and comp to render with aerender.",
+    "parameterDefinitions": [
+        {
+            "name": "ProjectFile",
+            "type": "PATH",
+            "objectType": "FILE",
+            "dataFlow": "IN",
+            "userInterface": {
+                "control": "CHOOSE_INPUT_FILE",
+                "label": "Project file",
+                "groupLabel": "Source",
+                "fileFilters": [
+                    {
+                        "label": "After Effects project files",
+                        "patterns": [
+                            "*.aep",
+                            "*.aepx"
+                        ]
+                    },
+                    {
+                        "label": "All Files",
+                        "patterns": [
+                            "*"
+                        ]
+                    }
+                ]
+            },
+            "description": "The After Effects project file to render."
+        },
+        {
+            "name": "JobScriptDir",
+            "description": "Directory containing embedded scripts.",
+            "userInterface": {
+                "control": "HIDDEN"
+            },
+            "type": "PATH",
+            "objectType": "DIRECTORY",
+            "dataFlow": "IN",
+            "default": "scripts"
+        },
+        {
+            "name": "CondaPackages",
+            "type": "STRING",
+            "userInterface": {
+                "control": "HIDDEN"
+            },
+            "default": "aftereffects={{AE_VERSION}}",
+            "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        }
+    ],
+    "jobEnvironments": [
+        {
+            "name": "Create Output Directories",
+            "description": "Create Output Directories",
+            "script": {
+                "actions": {
+                    "onEnter": {
+                        "command": "python",
+                        "args": [
+                            "{{Param.JobScriptDir}}/create_output_directory.py",
+                            "{{Param.OutputDir}}"
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "name": "Install Fonts to Worker",
+            "description": "Install Fonts to Worker",
+            "script": {
+                "actions": {
+                    "onEnter": {
+                        "command": "python",
+                        "args": [
+                            "{{Param.JobScriptDir}}/font_manager.py",
+                            "install",
+                            "{{Session.WorkingDirectory}}"
+                        ]
+                    },
+                    "onExit": {
+                        "command": "python",
+                        "args": [
+                            "{{Param.JobScriptDir}}/font_manager.py",
+                            "remove",
+                            "{{Session.WorkingDirectory}}"
+                        ]
+                    }
+                }
+            }
+        }
+    ],
+    "steps": []
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,0 @@
-{"include":["./**/*","c:/Users/olly/.vscode/extensions/il-harper.vscode-types-for-adobe-0.1.1/node_modules/types-for-adobe/AfterEffects/2018/**/*","c:/Users/olly/.vscode/extensions/il-harper.vscode-types-for-adobe-0.1.1/node_modules/types-for-adobe/shared/**/*"]}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"include":["./**/*","c:/Users/olly/.vscode/extensions/il-harper.vscode-types-for-adobe-0.1.1/node_modules/types-for-adobe/AfterEffects/2018/**/*","c:/Users/olly/.vscode/extensions/il-harper.vscode-types-for-adobe-0.1.1/node_modules/types-for-adobe/shared/**/*"]}

--- a/src/Imports.jsx
+++ b/src/Imports.jsx
@@ -1,5 +1,7 @@
 #include "utils/Utils.jsx"
 
+#include "utils/CompositionSettings.jsx"
+
 #include "submission/JobTemplateHelper.jsx"
 
 #include "submission/SubmitBundle.jsx"

--- a/src/OpenAESubmitter.jsx
+++ b/src/OpenAESubmitter.jsx
@@ -5,7 +5,7 @@
 #include "UI/SubmitterUI.jsx"
 
 function isSecurityPrefSet() {
-    var securitySetting = app.preferences.getPrefAsLong(
+    const securitySetting = app.preferences.getPrefAsLong(
         "Main Pref Section",
         "Pref_SCRIPTING_FILE_NETWORK_SECURITY"
     );
@@ -16,7 +16,7 @@ if (isSecurityPrefSet()) {
     buildUI(this);
 } else {
     //Print an error message and instructions for changing security preferences
-    var submitterPanel =
+    const submitterPanel =
         this instanceof Panel ?
         this :
         new Window(
@@ -27,11 +27,11 @@ if (isSecurityPrefSet()) {
                 closeButton: true,
             }
         );
-    var root = submitterPanel.add("group");
+    const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ["fill", "fill"];
     root.alignChildren = ["fill", "top"];
-    var errorText = root.add("statictext", undefined, "", {
+    const errorText = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText.graphics.foregroundColor = errorText.graphics.newPen(
@@ -40,7 +40,7 @@ if (isSecurityPrefSet()) {
         1
     );
     errorText.text = "Update Script Permissions";
-    var errorText2 = root.add("statictext", undefined, "", {
+    const errorText2 = root.add("statictext", undefined, "", {
         multiline: true,
     });
     errorText2.text = [

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -15,7 +15,7 @@ function parameterValues(
     maxCpuUsagePercentage,
     prefix
 ) {
-    var parameterValuesList = [{
+    const parameterValuesList = [{
             name: prefix + "_RenderQueueIndex",
             value: renderQueueIndex,
         },
@@ -80,13 +80,13 @@ function findJobAttachments(rootComp) {
     if (rootComp == null) {
         return [];
     }
-    var attachments = [];
-    var exploredItems = {}; // using this object as a set because AE doesn't support sets
+    const attachments = [];
+    const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
-    var queue = [rootComp];
+    const queue = [rootComp];
     while (queue.length > 0) {
-        var comp = queue.pop();
+        const comp = queue.pop();
         var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
         for (var i = 1; i <= comp.numLayers; i++) {
             var layer = comp.layer(i);
@@ -126,7 +126,7 @@ function findJobAttachments(rootComp) {
         }
     }
 
-    var fontsInProject = getFontsFromFile();
+    const fontsInProject = getFontsFromFile();
 
     if (fontsInProject.length > 0) {
         // Notify the user if any fonts are missing or are substituted during the session.
@@ -136,7 +136,7 @@ function findJobAttachments(rootComp) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }
         // Formatting collected fonts
-        var fontReferences = generateFontReferences(fontsInProject);
+        const fontReferences = generateFontReferences(fontsInProject);
         for (var i = 0; i < fontReferences.length; i++) {
             attachments.push(fontReferences[i]);
         }
@@ -153,11 +153,11 @@ function getFontsFromFile() {
     var fontLocations = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
-        var usedList = app.project.usedFonts;
+        const usedList = app.project.usedFonts;
         for (var i = 0; i < usedList.length; i++) {
-            var font = usedList[i].font;
-            var fontPostScriptName = font.postScriptName;
-            var fontLocation = font.location || getLocationForFont(fontPostScriptName);
+            const font = usedList[i].font;
+            const fontPostScriptName = font.postScriptName;
+            const fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
                 adcAlert(
                     "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
@@ -165,7 +165,7 @@ function getFontsFromFile() {
                 );
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
+            const fontName = createFontFilename(fontLocation, fontPostScriptName);
             if (fontName) {
                 fontLocations.push([fontName, fontLocation]);
             }
@@ -182,7 +182,7 @@ function getFontsFromFile() {
  * @return String with executable name corresponding to Python 3, or an empty string if not found
  **/
 function getPythonExecutable() {
-    var pythonExecutables = ["python3", "python", "py"];
+    const pythonExecutables = ["python3", "python", "py"];
 
     for (var i = 0; i < pythonExecutables.length; i++) {
         // Search for python executable
@@ -211,7 +211,7 @@ function getPythonExecutable() {
         try {
             output = system.callSystem(pythonExecutable + " --version");
             if (output && output.indexOf("Python ") !== -1) {
-                var pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
+                const pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
                 if (pythonVersion >= 3) {
                     return pythonExecutable;
                 }
@@ -223,7 +223,7 @@ function getPythonExecutable() {
     }
 
     // If reaching here, this means python version was too low or executable was not found
-    var errorMessage =
+    const errorMessage =
         "Error: Couldn't find Python 3 or higher on your PATH.\n" +
         "\n" +
         "Please ensure that Python 3 or higher is installed correctly and added to your PATH.";
@@ -239,12 +239,12 @@ function getPythonExecutable() {
 function getFontPaths() {
     var errorMessage = "";
     // Ensure Python exists and is at least version 3
-    var pythonExecutable = getPythonExecutable();
+    const pythonExecutable = getPythonExecutable();
     if (!pythonExecutable) {
         return null;
     }
-    var scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-    var scriptFile = new File(scriptPath);
+    const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
+    const scriptFile = new File(scriptPath);
     if (!scriptFile.exists) {
         errorMessage =
             "Error: Missing font script at " + scriptFile.fsName + "\n" +
@@ -256,7 +256,7 @@ function getFontPaths() {
 
     var output = {};
     try {
-        var outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
         output = JSON.parse(outputRaw);
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -286,7 +286,7 @@ function getLocationForFont(fontPostScriptName) {
     var fontPath = null;
     try {
         // Get user-installed fonts
-        var fontPaths = getFontPaths();
+        const fontPaths = getFontPaths();
         if (!fontPaths) {
             return null;
         }
@@ -309,16 +309,16 @@ function getLocationForFont(fontPostScriptName) {
  **/
 function createFontFilename(fontLocation, fontPostScriptName) {
     var fileExtension = "";
-    var lastDotIndex = fontLocation.lastIndexOf('.');
-    var extensionRegex = /\.[a-zA-Z]+$/;
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
 
     var fontName = "";
 
     var validExtension = true;
-    var fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf"];
 
     // Windows also supports .fon files
-    var os = $.os.toLowerCase();
+    const os = $.os.toLowerCase();
     if (os.indexOf("windows") !== -1) {
         fontExtensions.push(".fon");
     }
@@ -326,7 +326,7 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
     if (extensionRegex.test(fontLocation)) {
         fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
-        var fontExtensionsAsString = fontExtensions.toString();
+        const fontExtensionsAsString = fontExtensions.toString();
         if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
             adcAlert(
                 "font with an unsupported extension '" + fileExtension +
@@ -349,21 +349,21 @@ function createFontFilename(fontLocation, fontPostScriptName) {
  * @return an array of font metadata, each item containing the font's temp copy name and the actual location of that font file
  **/
 function getFontsFromFileLegacy() {
-    var fontLocations = [];
-    var items = app.project.items;
+    const fontLocations = [];
+    const items = app.project.items;
     for (var i = items.length; i >= 1; i--) {
-        var item = app.project.item(i);
+        const item = app.project.item(i);
         // Only look at CompItems
         if (!(item instanceof CompItem)) {
             continue;
         }
         for (var j = item.layers.length; j >= 1; j--) {
-            var layer = item.layers[j];
+            const layer = item.layers[j];
             // Only look at TextLayers
             if (!(layer instanceof TextLayer)) {
                 continue;
             }
-            var sourceText = layer.text.sourceText;
+            const sourceText = layer.text.sourceText;
             // Check if the sourceText property has keys.
             // If it has keys, the font can change over time and we need to check all keys for their font
             if (sourceText.numKeys) {
@@ -426,21 +426,21 @@ function getFontsFromFileLegacy() {
  **/
 function generateFontReferences(fontPaths) {
     // Create a temp folder where all used fonts get gathered
-    var _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
-    var formattedFontsPaths = [];
-    var tempFontPath = new Folder(_tempFontsFolder);
+    const _tempFontsFolder = dcUtil.normPath(dcUtil.getTempFolder() + '/' + "tempFonts");
+    const formattedFontsPaths = [];
+    const tempFontPath = new Folder(_tempFontsFolder);
     if (!tempFontPath.exists) {
         tempFontPath.create();
     }
 
     // Copy the font files to the temp folder
     for (var i = 0; i < fontPaths.length; i++) {
-        var fontName = fontPaths[i][0];
-        var fontLocation = fontPaths[i][1];
+        const fontName = fontPaths[i][0];
+        const fontLocation = fontPaths[i][1];
 
-        var fontFile = File(fontLocation);
-        var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        var fontCopied = fontFile.copy(_tempFontPath);
+        const fontFile = File(fontLocation);
+        const _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        const fontCopied = fontFile.copy(_tempFontPath);
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -12,58 +12,39 @@ function parameterValues(
     endFrame,
     chunkSize,
     multiFrameRendering,
-    maxCpuUsagePercentage
+    maxCpuUsagePercentage,
+    prefix
 ) {
     var parameterValuesList = [{
-            name: "deadline:targetTaskRunStatus",
-            value: "READY",
-        },
-        {
-            name: "deadline:maxFailedTasksCount",
-            value: 20,
-        },
-        {
-            name: "deadline:maxRetriesPerTask",
-            value: 5,
-        },
-        {
-            name: "deadline:priority",
-            value: 50,
-        },
-        {
-            name: "ProjectFile",
-            value: projectFile,
-        },
-        {
-            name: "RenderQueueIndex",
+            name: prefix + "_RenderQueueIndex",
             value: renderQueueIndex,
         },
         {
-            name: "OutputDir",
+            name: prefix + "_OutputDir",
             value: outputDir,
         },
         {
-            name: "OutputFileName",
+            name: prefix + "_OutputFileName",
             value: outputFileName,
         },
         {
-            name: "Frames",
+            name: prefix + "_Frames",
             value: startFrame.toString() + "-" + endFrame.toString(),
         },
         {
-            name: "MultiFrameRendering",
+            name: prefix + "_MultiFrameRendering",
             value: multiFrameRendering,
         },
     ];
     if (maxCpuUsagePercentage) {
         parameterValuesList.push({
-            name: "MaxCpuUsagePercentage",
+            name: prefix + "_MaxCpuUsagePercentage",
             value: maxCpuUsagePercentage,
         })
     }
     if (isImageSeq) {
         parameterValuesList.push({
-            name: "ChunkSize",
+            name: prefix + "_ChunkSize",
             value: chunkSize,
         });
     }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -33,7 +33,7 @@ function parameterValues(
         },
         {
             name: prefix + "_MultiFrameRendering",
-            value: multiFrameRendering,
+            value: multiFrameRendering === true ? "ON" : "OFF",
         },
     ];
     if (maxCpuUsagePercentage) {

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -2,7 +2,7 @@ var jobTemplateHelperFile = "JobTemplateHelper.json";
 /**
  * Generates the basic parameterValue file for the job template
  **/
-function parameterValues(
+function generateParameterValues(
     renderQueueIndex,
     projectFile,
     outputDir,

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -40,7 +40,7 @@ function parameterValues(
         parameterValuesList.push({
             name: prefix + "_MaxCpuUsagePercentage",
             value: maxCpuUsagePercentage,
-        })
+        });
     }
     if (isImageSeq) {
         parameterValuesList.push({

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -155,9 +155,9 @@ function getFontsFromFile() {
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
         for (var i = 0; i < usedList.length; i++) {
-            const font = usedList[i].font;
-            const fontPostScriptName = font.postScriptName;
-            const fontLocation = font.location || getLocationForFont(fontPostScriptName);
+            var font = usedList[i].font;
+            var fontPostScriptName = font.postScriptName;
+            var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
                 adcAlert(
                     "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
@@ -165,7 +165,7 @@ function getFontsFromFile() {
                 );
                 continue;
             }
-            const fontName = createFontFilename(fontLocation, fontPostScriptName);
+            var fontName = createFontFilename(fontLocation, fontPostScriptName);
             if (fontName) {
                 fontLocations.push([fontName, fontLocation]);
             }
@@ -211,7 +211,7 @@ function getPythonExecutable() {
         try {
             output = system.callSystem(pythonExecutable + " --version");
             if (output && output.indexOf("Python ") !== -1) {
-                const pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
+                var pythonVersion = parseInt(output.substring(output.indexOf(" ") + 1));
                 if (pythonVersion >= 3) {
                     return pythonExecutable;
                 }
@@ -352,18 +352,18 @@ function getFontsFromFileLegacy() {
     const fontLocations = [];
     const items = app.project.items;
     for (var i = items.length; i >= 1; i--) {
-        const item = app.project.item(i);
+        var item = app.project.item(i);
         // Only look at CompItems
         if (!(item instanceof CompItem)) {
             continue;
         }
         for (var j = item.layers.length; j >= 1; j--) {
-            const layer = item.layers[j];
+            var layer = item.layers[j];
             // Only look at TextLayers
             if (!(layer instanceof TextLayer)) {
                 continue;
             }
-            const sourceText = layer.text.sourceText;
+            var sourceText = layer.text.sourceText;
             // Check if the sourceText property has keys.
             // If it has keys, the font can change over time and we need to check all keys for their font
             if (sourceText.numKeys) {
@@ -435,12 +435,12 @@ function generateFontReferences(fontPaths) {
 
     // Copy the font files to the temp folder
     for (var i = 0; i < fontPaths.length; i++) {
-        const fontName = fontPaths[i][0];
-        const fontLocation = fontPaths[i][1];
+        var fontName = fontPaths[i][0];
+        var fontLocation = fontPaths[i][1];
 
-        const fontFile = File(fontLocation);
-        const _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        const fontCopied = fontFile.copy(_tempFontPath);
+        var fontFile = File(fontLocation);
+        var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        var fontCopied = fontFile.copy(_tempFontPath);
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -86,7 +86,7 @@ function findJobAttachments(rootComp) {
     exploredItems[rootComp.id] = true;
     const queue = [rootComp];
     while (queue.length > 0) {
-        const comp = queue.pop();
+        var comp = queue.pop();
         var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
         for (var i = 1; i <= comp.numLayers; i++) {
             var layer = comp.layer(i);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -1,3 +1,15 @@
+var JobParams = [
+    "JobScriptDir",
+    "CondaPackages",
+    "ProjectFile"
+]
+
+var paramPattern = "Param\."
+for (var p=0;p<JobParams.length;p++) {
+    paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
+}
+var paramPatternRegex = new RegExp(paramPattern, 'g')
+
 /**
  * Submit the selected render queue item
  **/

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -10,6 +10,187 @@ for (var p=0;p<JobParams.length;p++) {
 }
 var paramPatternRegex = new RegExp(paramPattern, 'g')
 
+
+// Validate that the RenderQueueIndex for each selectionItem is still valid
+function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
+    if (
+        renderQueueIndex < 1 ||
+        renderQueueIndex > app.project.renderQueue.numItems
+    ) {
+        adcAlert(
+            "Error: Render Queue has changed since last refreshing. Refreshing panel now. Please try again.", true
+        );
+        updateList();
+        return false;
+    }
+
+    var renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+    if (renderQueueItem == null || renderQueueItem.comp.id != selectionItem.compId) {
+        adcAlert(
+            "Error: Render Queue has changed since last refresh. Refreshing panel now. Please try again.", true
+        );
+        updateList();
+        return false;
+    }
+    if (renderQueueItem.numOutputModules > 1) {
+        adcAlert(
+            "Warning: Multiple output modules detected. It is not supported in current submitter. Please raise an issue on Github repo for feature request.", false
+        );
+        return false;
+    }
+    return true;
+}
+
+// Validate that our outputModule is set
+function validateRenderQueueItemOutputModule(renderQueueItem) {
+    // We have already validated that we don't have more than 1 `numOutputModels`
+    var outputModule = renderQueueItem.outputModule(1).file;
+    if (outputModule == null) {
+        adcAlert("Error: Render Queue Item " + renderQueueItem.comp.name + " does not have its output file set", true);
+        return false;
+    }
+    return true;
+}
+
+// Generate our prefixed Parameter Values for the provided comp
+function generateParameterValuesForStep(
+    prefix,
+    renderQueueIndex,
+    outputFolder,
+    outputFileName,
+    isImageSeq,
+    startFrame,
+    endFrame,
+    chunkSize,
+    multiFrameRendering,
+    maxCpuUsagePercentage,
+) {
+    return parameterValues(
+        renderQueueIndex,
+        app.project.file.fsName,
+        outputFolder,
+        outputFileName,
+        isImageSeq,
+        startFrame,
+        endFrame,
+        chunkSize,
+        multiFrameRendering,
+        maxCpuUsagePercentage,
+        prefix,
+    )
+}
+
+// Loading our default template from disk
+function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
+    var path = bundlePath + "/template.json";
+    var templateContents = readFile(path);
+    // Parse the template string to a JSON object
+    var templateObject = JSON.parse(templateContents);
+    templateObject.name = File.decode(app.project.file.name);
+    logger.debug("The template name is " + templateObject.name, submitBundleFile);
+
+    return templateObject
+}
+
+// Generates the job bundle and copies files from our template source folder into it
+function generateBundle() {
+    // create the job bundle folder
+    var bundleRoot = new Folder(
+        dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
+    ); //forward slash works on all operating systems
+    recursiveDelete(bundleRoot);
+    bundleRoot.create();
+
+    var jobTemplateSourceFolder = new Folder(
+        scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
+    );
+    if (!jobTemplateSourceFolder.exists) {
+        adcAlert(
+            "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
+        );
+        return null;
+    }
+    recursiveCopy(jobTemplateSourceFolder, bundleRoot);
+    return bundleRoot;
+}
+
+// Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
+//      Adding our `( <CompName> )` to the label and changing the name to prefixed by `<CompName>_`
+function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
+    var path = bundlePath + "/parameter_definitions_video_fragment.json";
+    if (isImageSeq) {
+        path = bundlePath + "/parameter_definitions_image_fragment.json";
+    }
+    var stepParametersContents = readFile(path);
+    // Parse the template string to a JSON object
+    var stepParametersObject = JSON.parse(stepParametersContents);
+
+    var updatedParameterDefinitions = []
+    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
+        if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
+            // Don't modify these values
+            continue
+        }
+        var replacedDefinition = stepParametersObject.parameterDefinitions[i]
+        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name
+        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label
+
+        updatedParameterDefinitions.push(replacedDefinition)
+    }
+    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
+    return stepParametersObject
+}
+
+// Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
+//      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
+function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
+    var path = bundlePath + "/step_video_fragment.json";
+    if (isImageSeq) {
+        path = bundlePath + "/step_image_fragment.json";
+    }
+    var stepTemplateContents = readFile(path);
+    // Parse the template string to a JSON object
+    var stepTemplateObject = JSON.parse(stepTemplateContents);
+
+    if (isImageSeq) {
+        // Replace parameter names in the creation of `Index`
+        var taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_")
+        taskParameters.name = compName + "_" + taskParameters.name
+        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters
+    }
+
+    stepTemplateObject.steps[0].name = compName;
+    // Replace any parameter names in onRun script
+    var scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
+    var replacedArgs = []
+    for (var i=0;i<scriptArgs.length;i++) {
+        // JobParams
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
+    }
+    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+
+    return stepTemplateObject
+}
+
+// Modifies the `Create Output Directories` job environment by adding all of our output folder parameters
+function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
+    var path = bundlePath + "/job_environments_fragment.json";
+    var jobEnvironmentsContents = readFile(path);
+    // Parse the template string to a JSON object
+    var jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
+
+    for (var j=0;j<jobEnvironmentsObject.jobEnvironments.length;j++) {
+        if (jobEnvironmentsObject.jobEnvironments[j].name === "Create Output Directories") {
+            jobEnvironmentsObject.jobEnvironments[j].script.actions.onEnter.args = [
+                "{{Param.JobScriptDir}}/create_output_directory.py",
+                outputFoldersStr
+            ]
+        }
+    }
+    return jobEnvironmentsObject
+}
+
 /**
  * Submit the selected render queue item
  **/

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -407,9 +407,9 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).multiFrameRendering();
+        var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -243,8 +243,8 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
 
     // Check if warning should be shown
-    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
+    const ignoreWarning = dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
+    const savedVersion = dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -256,11 +256,11 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString())
             if (confirm(versionMismatchWarningMessage)) {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true)
             } else {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false)
                 return;
             }
         } else {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -396,7 +396,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-        var renderQueueItemID = renderQueueIndex + "_" + compName;
+        var renderQueueItemID = "_" + renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -376,9 +376,9 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(renderQueueItem.comp.id).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering();
+        var stepFramesPerTask = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRQIID(renderQueueIndex)).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -148,7 +148,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex,
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
-//      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
+//      Replacing the parameters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
 function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -141,9 +141,9 @@ function generatePrettyParameterName(index, compName, parameter) {
         parameter = "";
     }
     index = index.toString();
-    const max_length = 10;
-    if (compName.length >= max_length) {
-        compName = compName.substring(0, max_length - 3) + "...";
+    const maxLength = 10;
+    if (compName.length >= maxLength) {
+        compName = compName.substring(0, maxLength - 3) + "...";
     }
     return "(" + index + "_" + compName + ") " + parameter;
 }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -10,6 +10,9 @@ for (var p = 0; p < JobParams.length; p++) {
 }
 var paramPatternRegex = new RegExp(paramPattern, 'g')
 
+if (typeof submitBundleFile == 'undefined') {
+    const submitBundleFile = "SubmitButton.jsx";
+}
 
 // Validate that the RenderQueueIndex for each selectionItem is still valid
 function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
@@ -169,8 +172,8 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
-    if (templateObject.steps[0].script.actions.onRun) {
-        templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+    if (stepTemplateObject.steps[0].script.actions.onRun) {
+        stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
         logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
     }
 
@@ -198,7 +201,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 /**
  * Submit the selected render queue item
  **/
-function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
+function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
     // Calculate task run timeout in seconds
     var taskTimeoutSeconds = 0;
     // Validate timeout values during job submission
@@ -208,7 +211,6 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     }
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
-    const submitBundleFile = "SubmitButton.jsx";
     const renderQueueItems = []
 
     // Check to make sure that all of our selection indices are correct

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -201,15 +201,14 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 /**
  * Submit the selected render queue item
  **/
-function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskTimeoutDays, taskTimeoutHours, taskTimeoutMinutes) {
+function SubmitSelection(selection, selectionSettings) {
     // Calculate task run timeout in seconds
-    var taskTimeoutSeconds = 0;
+    var taskTimeoutSeconds = (selectionSettings.taskRunDays() * 24 * 60 * 60) + (selectionSettings.taskRunHours() * 60 * 60) + (selectionSettings.taskRunMinutes() * 60);
     // Validate timeout values during job submission
-    if (taskTimeoutDays === 0 && taskTimeoutHours === 0 && taskTimeoutMinutes === 0) {
+    if (taskTimeoutSeconds <= 0) {
         adcAlert("The following timeout value must be greater than 0: TaskRun", true);
         throw new Error("Task run timeout must be greater than zero");
     }
-    taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
     const renderQueueItems = [];
 
@@ -377,9 +376,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
 
-        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask);
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage);
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering;
+        var stepFramesPerTask = selectionSettings.get(renderQueueItem.comp.id).framesPerTask();
+        var stepMaxCpuUsagePercentage = selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage();
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -434,6 +434,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
+        // Generates template and parameters for the current render queue item, then pushes them to the main template
         var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
@@ -454,6 +455,8 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
     }
+
+    // Writes out final bundle files
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","));
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments;
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -243,8 +243,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
-    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
+    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -256,11 +256,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
+            dcUtil.saveStringMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
+                dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+                dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -4,11 +4,11 @@ var JobParams = [
     "ProjectFile"
 ]
 
-var paramPattern = "Param\."
+var paramPattern = "Param\.";
 for (var p = 0; p < JobParams.length; p++) {
-    paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
+    paramPattern = paramPattern + "(?!" + JobParams[p] + ")";
 }
-var paramPatternRegex = new RegExp(paramPattern, 'g')
+var paramPatternRegex = new RegExp(paramPattern, 'g');
 
 if (typeof submitBundleFile == 'undefined') {
     const submitBundleFile = "SubmitButton.jsx";
@@ -80,7 +80,7 @@ function generateParameterValuesForStep(
         multiFrameRendering,
         maxCpuUsagePercentage,
         prefix,
-    )
+    );
 }
 
 // Loading our default template from disk
@@ -92,7 +92,7 @@ function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
     templateObject.name = File.decode(app.project.file.name);
     logger.debug("The template name is " + templateObject.name, submitBundleFile);
 
-    return templateObject
+    return templateObject;
 }
 
 // Generates the job bundle and copies files from our template source folder into it
@@ -132,16 +132,16 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
     for (var i = 0; i < stepParametersObject.parameterDefinitions.length; i++) {
         if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
             // Don't modify these values
-            continue
+            continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name
-        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label
+        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name;
+        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label;
 
-        updatedParameterDefinitions.push(replacedDefinition)
+        updatedParameterDefinitions.push(replacedDefinition);
     }
-    stepParametersObject.parameterDefinitions = updatedParameterDefinitions
-    return stepParametersObject
+    stepParametersObject.parameterDefinitions = updatedParameterDefinitions;
+    return stepParametersObject;
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
@@ -158,26 +158,26 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_")
-        taskParameters.name = compName + "_" + taskParameters.name
-        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_");
+        taskParameters.name = compName + "_" + taskParameters.name;
+        stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
     stepTemplateObject.steps[0].name = compName;
     // Replace any parameter names in onRun script
-    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
+    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"));
     }
-    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+    stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
         stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
         logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
     }
 
-    return stepTemplateObject
+    return stepTemplateObject;
 }
 
 // Modifies the `Create Output Directories` job environment by adding all of our output folder parameters
@@ -195,7 +195,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
             ]
         }
     }
-    return jobEnvironmentsObject
+    return jobEnvironmentsObject;
 }
 
 /**
@@ -211,7 +211,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
-    const renderQueueItems = []
+    const renderQueueItems = [];
 
     // Check to make sure that all of our selection indices are correct
     for (var i = 0; i < selection.length; i++) {
@@ -224,7 +224,7 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
         var initialRenderQueueItem = app.project.renderQueue.item(initialRenderQueueIndex);
-        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
+        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex]);
     }
 
     // We have valid selections check for saving
@@ -256,11 +256,11 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString())
+            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true)
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true);
             } else {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false)
+                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
                 return;
             }
         } else {
@@ -364,8 +364,8 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
     }
 
     const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
-    template.steps = []
-    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
+    template.steps = [];
+    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions;
 
     const stepOutputFolderParameters = [];
 
@@ -377,9 +377,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             return;
         }
 
-        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage)
-        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering
+        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask);
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage);
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering;
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -410,9 +410,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
 
         // Push step asset references
         for (var d = 0; d < dependencies.length; d++) {
-            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
+            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d]);
         }
-        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
+        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
             compName,
@@ -425,38 +425,38 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
             stepFramesPerTask,
             stepMultiFrameRendering,
             stepMaxCpuUsagePercentage
-        )
+        );
 
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
-                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
+                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p]);
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
+        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
-            template.steps.push(stepTemplate.steps[s])
+            template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {
                 var templateParameterDefinition = template.parameterDefinitions[tpd];
                 var stepParameterDefinition = stepParameters.parameterDefinitions[p];
                 if (templateParameterDefinition.name == stepParameterDefinition.name) {
-                    parameterExists = true
-                    break
+                    parameterExists = true;
+                    break;
                 }
             }
             if (parameterExists === false) {
-                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p])
+                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p]);
             }
         }
     }
-    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
-    template.jobEnvironments = generatedJobEnvironment.jobEnvironments
+    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","));
+    template.jobEnvironments = generatedJobEnvironment.jobEnvironments;
 
     writeFile(bundle.fsName + "/asset_references.json", JSON.stringify(jobAssetReferences, null, 4));
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -55,34 +55,6 @@ function validateRenderQueueItemOutputModule(renderQueueItem) {
     return true;
 }
 
-// Generate our prefixed Parameter Values for the provided comp
-function generateParameterValuesForStep(
-    prefix,
-    renderQueueIndex,
-    outputFolder,
-    outputFileName,
-    isImageSeq,
-    startFrame,
-    endFrame,
-    chunkSize,
-    multiFrameRendering,
-    maxCpuUsagePercentage,
-) {
-    return parameterValues(
-        renderQueueIndex,
-        app.project.file.fsName,
-        outputFolder,
-        outputFileName,
-        isImageSeq,
-        startFrame,
-        endFrame,
-        chunkSize,
-        multiFrameRendering,
-        maxCpuUsagePercentage,
-        prefix,
-    );
-}
-
 // Loading our default template from disk
 function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
     const path = bundlePath + "/template.json";
@@ -443,9 +415,9 @@ function SubmitSelection(selection, selectionSettings) {
         }
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
-        var parameterValues = generateParameterValuesForStep(
-            generateParameterName(renderQueueIndex, compName, ""),
+        var parameterValues = generateParameterValues(
             renderQueueIndex,
+            app.project.file.fsName,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
             isImageSeq,
@@ -453,9 +425,9 @@ function SubmitSelection(selection, selectionSettings) {
             endFrame,
             stepFramesPerTask,
             stepMultiFrameRendering,
-            stepMaxCpuUsagePercentage
+            stepMaxCpuUsagePercentage,
+            generateParameterName(renderQueueIndex, compName, "")
         );
-
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
                 jobParameterValues.parameterValues.push(parameterValues.parameterValues[p]);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -118,8 +118,8 @@ function generateBundle() {
 }
 
 // Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
-//      Adding our `( <CompName> )` to the label and changing the name to prefixed by `<CompName>_`
-function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
+//      Adding our `( <RenderQueueItemID> )` to the label and changing the name to prefixed by `<RenderQueueItemID>_`
+function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID) {
     var path = bundlePath + "/parameter_definitions_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/parameter_definitions_image_fragment.json";
@@ -135,8 +135,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
             continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = compName + "_" + stepParametersObject.parameterDefinitions[i].name;
-        replacedDefinition.userInterface.label = "(" + compName + ") " + replacedDefinition.userInterface.label;
+        replacedDefinition.name = renderQueueItemID + "_" + stepParametersObject.parameterDefinitions[i].name;
+        replacedDefinition.userInterface.label = "(" + renderQueueItemID + ") " + replacedDefinition.userInterface.label;
 
         updatedParameterDefinitions.push(replacedDefinition);
     }
@@ -145,8 +145,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
 }
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
-//      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTimeoutSeconds) {
+//      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -158,18 +158,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_");
-        taskParameters.name = compName + "_" + taskParameters.name;
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + renderQueueItemID + "_");
+        taskParameters.name = renderQueueItemID + "_" + taskParameters.name;
         stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
-    stepTemplateObject.steps[0].name = compName;
+    stepTemplateObject.steps[0].name = renderQueueItemID;
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"));
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + renderQueueItemID + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
@@ -396,7 +396,7 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-
+        var renderQueueItemID = renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
@@ -414,7 +414,7 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
-            compName,
+            renderQueueItemID,
             renderQueueIndex,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
@@ -432,13 +432,13 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}");
+        stepOutputFolderParameters.push("{{Param." + renderQueueItemID + "_OutputDir}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueItemID, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName);
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueItemID);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -242,11 +242,6 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         }
     }
 
-    // Calculate frame range using the utility function
-    const frameRange = dcUtil.calculateFrameRange(rqi);
-    const startFrame = frameRange.startFrame;
-    const endFrame = frameRange.endFrame;
-
     // Check if warning should be shown
     const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
     const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
@@ -395,20 +390,10 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         logger.debug("OutputFile is: " + outputFile, submitBundleFile);
         logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
 
-        var renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
-        var startFrame = Number(
-            timeToFrames(
-                Number(renderSettings["Time Span Start"]),
-                Number(renderSettings["Use this frame rate"])
-            )
-        );
-        var endFrame =
-            Number(
-                timeToFrames(
-                    Number(renderSettings["Time Span End"]),
-                    Number(renderSettings["Use this frame rate"])
-                )
-            ) - 1; // end frame is inclusive so we subtract 1
+        // Calculate frame range using the utility function
+        const frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+        const startFrame = frameRange.startFrame;
+        const endFrame = frameRange.endFrame;
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -143,7 +143,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parmaeters to be pointing to our per-CompName parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -169,6 +169,10 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs
+    if (templateObject.steps[0].script.actions.onRun) {
+        templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+        logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
+    }
 
     return stepTemplateObject
 }
@@ -468,7 +472,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
 
         stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName)
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
         for (var s=0;s<stepTemplate.steps.length;s++) {
             template.steps.push(stepTemplate.steps[s])
         }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -175,10 +175,8 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
-    if (stepTemplateObject.steps[0].script.actions.onRun) {
-        stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
-        logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
-    }
+    stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
+    logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
 
     return stepTemplateObject;
 }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -391,9 +391,9 @@ function SubmitSelection(selection, selectionSettings, framesPerTask, multiFrame
         logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
 
         // Calculate frame range using the utility function
-        const frameRange = dcUtil.calculateFrameRange(renderQueueItem);
-        const startFrame = frameRange.startFrame;
-        const endFrame = frameRange.endFrame;
+        var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+        var startFrame = frameRange.startFrame;
+        var endFrame = frameRange.endFrame;
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -24,7 +24,7 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
         return false;
     }
 
-    var renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+    const renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
     if (renderQueueItem == null || renderQueueItem.comp.id != selectionItem.compId) {
         adcAlert(
             "Error: Render Queue has changed since last refresh. Refreshing panel now. Please try again.", true
@@ -44,7 +44,7 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
 // Validate that our outputModule is set
 function validateRenderQueueItemOutputModule(renderQueueItem) {
     // We have already validated that we don't have more than 1 `numOutputModels`
-    var outputModule = renderQueueItem.outputModule(1).file;
+    const outputModule = renderQueueItem.outputModule(1).file;
     if (outputModule == null) {
         adcAlert("Error: Render Queue Item " + renderQueueItem.comp.name + " does not have its output file set", true);
         return false;
@@ -82,10 +82,10 @@ function generateParameterValuesForStep(
 
 // Loading our default template from disk
 function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
-    var path = bundlePath + "/template.json";
-    var templateContents = readFile(path);
+    const path = bundlePath + "/template.json";
+    const templateContents = readFile(path);
     // Parse the template string to a JSON object
-    var templateObject = JSON.parse(templateContents);
+    const templateObject = JSON.parse(templateContents);
     templateObject.name = File.decode(app.project.file.name);
     logger.debug("The template name is " + templateObject.name, submitBundleFile);
 
@@ -95,13 +95,13 @@ function loadDefaultJobTemplate(bundlePath, submitBundleFile) {
 // Generates the job bundle and copies files from our template source folder into it
 function generateBundle() {
     // create the job bundle folder
-    var bundleRoot = new Folder(
+    const bundleRoot = new Folder(
         dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
     ); //forward slash works on all operating systems
     recursiveDelete(bundleRoot);
     bundleRoot.create();
 
-    var jobTemplateSourceFolder = new Folder(
+    const jobTemplateSourceFolder = new Folder(
         scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
     );
     if (!jobTemplateSourceFolder.exists) {
@@ -121,11 +121,11 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
     if (isImageSeq) {
         path = bundlePath + "/parameter_definitions_image_fragment.json";
     }
-    var stepParametersContents = readFile(path);
+    const stepParametersContents = readFile(path);
     // Parse the template string to a JSON object
-    var stepParametersObject = JSON.parse(stepParametersContents);
+    const stepParametersObject = JSON.parse(stepParametersContents);
 
-    var updatedParameterDefinitions = []
+    const updatedParameterDefinitions = []
     for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
         if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
             // Don't modify these values
@@ -148,13 +148,13 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
     }
-    var stepTemplateContents = readFile(path);
+    const stepTemplateContents = readFile(path);
     // Parse the template string to a JSON object
-    var stepTemplateObject = JSON.parse(stepTemplateContents);
+    const stepTemplateObject = JSON.parse(stepTemplateContents);
 
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
-        var taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
+        const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
         taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + compName + "_")
         taskParameters.name = compName + "_" + taskParameters.name
         stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters
@@ -162,8 +162,8 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
 
     stepTemplateObject.steps[0].name = compName;
     // Replace any parameter names in onRun script
-    var scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
-    var replacedArgs = []
+    const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
+    const replacedArgs = []
     for (var i=0;i<scriptArgs.length;i++) {
         // JobParams
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
@@ -175,10 +175,10 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName) {
 
 // Modifies the `Create Output Directories` job environment by adding all of our output folder parameters
 function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
-    var path = bundlePath + "/job_environments_fragment.json";
-    var jobEnvironmentsContents = readFile(path);
+    const path = bundlePath + "/job_environments_fragment.json";
+    const jobEnvironmentsContents = readFile(path);
     // Parse the template string to a JSON object
-    var jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
+    const jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
 
     for (var j=0;j<jobEnvironmentsObject.jobEnvironments.length;j++) {
         if (jobEnvironmentsObject.jobEnvironments[j].name === "Create Output Directories") {
@@ -205,21 +205,20 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
     const submitBundleFile = "SubmitButton.jsx";
-    var renderQueueItems = []
+    const renderQueueItems = []
 
     // Check to make sure that all of our selection indices are correct
     for (var i=0;i<selection.length;i++) {
         var selectionItem = selection[i];
-        var renderQueueIndex = selectionItem.renderQueueIndex;
-        var renderQueueItem;
+        var initialRenderQueueIndex = selectionItem.renderQueueIndex;
 
         // because our panel is updated independently of the render queue, the two may become out of sync
         // we need to verify that the selection made actually matches what is in the render queue
-        if (!UpdateRenderQueueIndices(renderQueueIndex, selectionItem)) {
+        if (!UpdateRenderQueueIndices(initialRenderQueueIndex, selectionItem)) {
             return;
         }
-        renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
-        renderQueueItems.push([renderQueueItem, renderQueueIndex])
+        var initialRenderQueueItem = app.project.renderQueue.item(initialRenderQueueIndex);
+        renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
     }
 
     //We have a valid selection
@@ -363,7 +362,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
     // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
-    var stepOutputFolderParameters = [];
+    const stepOutputFolderParameters = [];
 
         for (var i = paramDefCopy.length - 1; i >= 0; i--) {
             if (paramDefCopy[i].name == "CondaPackages") {
@@ -371,9 +370,9 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             }
         }
 
-        var stepFramesPerTask = parseInt(selectionSettings.get(selectionItem.compId).framesPerTask() || framesPerTask)
-        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(selectionItem.compId).maxCpuUsagePercentage() || maxCpuUsagePercentage)
-        var stepMultiFrameRendering = selectionSettings.get(selectionItem.compId).multiFrameRendering() || multiFrameRendering
+        var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(renderQueueItem.comp.id).maxCpuUsagePercentage() || maxCpuUsagePercentage)
+        var stepMultiFrameRendering = selectionSettings.get(renderQueueItem.comp.id).multiFrameRendering() || multiFrameRendering
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -459,7 +458,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             }
         }
     }
-    var generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
+    const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
     writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
@@ -468,14 +467,14 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
-    var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
+    const logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");
     logFile.open("w"); // Erase contents of active log file
     logFile.close();
     var submitScriptContents = "";
     var output = "";
     var cmd = "";
     if ($.os.toString().slice(0, 7) === "Windows") {
-        var tempBatFile = new File(
+        const tempBatFile = new File(
             dcUtil.getTempFolder() + "/DeadlineCloudAESubmission.bat"
         );
         cmd =
@@ -498,7 +497,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     } else {
         // Execute the command using a bash in the interactive mode so it loads the bash profile to set
         // the PATH correctly.
-        var shellPath = $.getenv("SHELL") || "/bin/bash";
+        const shellPath = $.getenv("SHELL") || "/bin/bash";
         cmd =
             'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
         submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -370,7 +370,6 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     template.steps = []
     template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
 
-    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
     const stepOutputFolderParameters = [];
 
     for (var i = 0; i < renderQueueItems.length; i++) {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -4,7 +4,7 @@ var JobParams = [
     "ProjectFile"
 ]
 
-var paramPattern = "Param\.";
+var paramPattern = "Param\\.";
 for (var p = 0; p < JobParams.length; p++) {
     paramPattern = paramPattern + "(?!" + JobParams[p] + ")";
 }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -5,7 +5,7 @@ var JobParams = [
 ]
 
 var paramPattern = "Param\."
-for (var p=0;p<JobParams.length;p++) {
+for (var p = 0; p < JobParams.length; p++) {
     paramPattern = paramPattern + "(?!" + JobParams[p] + ")"
 }
 var paramPatternRegex = new RegExp(paramPattern, 'g')
@@ -126,7 +126,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, compName) {
     const stepParametersObject = JSON.parse(stepParametersContents);
 
     const updatedParameterDefinitions = []
-    for (var i=0;i<stepParametersObject.parameterDefinitions.length;i++) {
+    for (var i = 0; i < stepParametersObject.parameterDefinitions.length; i++) {
         if (JobParams.indexOf(stepParametersObject.parameterDefinitions[i].name) !== -1) {
             // Don't modify these values
             continue
@@ -164,7 +164,7 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, compName, taskTime
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args
     const replacedArgs = []
-    for (var i=0;i<scriptArgs.length;i++) {
+    for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
         replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + compName + "_"))
     }
@@ -184,7 +184,7 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
     // Parse the template string to a JSON object
     const jobEnvironmentsObject = JSON.parse(jobEnvironmentsContents);
 
-    for (var j=0;j<jobEnvironmentsObject.jobEnvironments.length;j++) {
+    for (var j = 0; j < jobEnvironmentsObject.jobEnvironments.length; j++) {
         if (jobEnvironmentsObject.jobEnvironments[j].name === "Create Output Directories") {
             jobEnvironmentsObject.jobEnvironments[j].script.actions.onEnter.args = [
                 "{{Param.JobScriptDir}}/create_output_directory.py",
@@ -212,7 +212,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const renderQueueItems = []
 
     // Check to make sure that all of our selection indices are correct
-    for (var i=0;i<selection.length;i++) {
+    for (var i = 0; i < selection.length; i++) {
         var selectionItem = selection[i];
         var initialRenderQueueIndex = selectionItem.renderQueueIndex;
 
@@ -225,59 +225,10 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         renderQueueItems.push([initialRenderQueueItem, initialRenderQueueIndex])
     }
 
-    //We have a valid selection
-    var confirmation = confirm("Project must be saved before submitting. Continue?");
-    if (!confirmation) {
-        return;
-    } else {
-        app.project.save();
-    }
-    if (app.project.file == null) {
-        // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
-        // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
-        return;
-    }
-
-    // Check if warning should be shown
-    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
-    const currentVersion = dcUtil.getAEVersion();
-
-    // Is this AE version not supported in the deadline-cloud channel?
-    if (SUPPORTED_VERSIONS.indexOf(currentVersion) === -1) {
-        // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
-        if (!ignoreWarning || savedVersion !== currentVersion) {
-            const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
-            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
-
-            // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
-            if (confirm(versionMismatchWarningMessage)) {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
-            } else {
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-                return;
-            }
-        } else {
-            logger.debug("Version mismatch already acknowledged, version warning skipped.");
-        }
-        logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
-    }
-
-    var outputPath = "";
-    var outputFile = "";
-    var outputFolder = "";
-    for (var j = 1; j <= rqi.numOutputModules; j++) {
-        var outputModule = rqi.outputModule(j).file;
-        if (outputModule == null) {
-            if (rqi.numOutputModules > 1) {
-                adcAlert("Error: Output module does not have its output file set", true);
-            } else {
-                adcAlert(
-                    "Error: One of your output modules does not have its output file set", true
-                );
-            }
+    // We have valid selections check for saving
+    if (app.project.dirty) {
+        const confirmation = confirm("Project must be saved before submitting. Continue?");
+        if (!confirmation) {
             return;
         } else {
             app.project.save();
@@ -304,8 +255,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
         if (!ignoreWarning || savedVersion !== currentVersion) {
             const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
-            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
-            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
+                " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
+                "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
@@ -321,87 +272,113 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
     }
 
+
     var aftereffectsCondaVersion = dcUtil.getAEVersion();
     if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
         aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
     }
     logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
-    /**
-     * Generates parameter_values json file
-     **/
-    function generateParameterValues(bundlePath, outputFolder, outputFileName, isImageSeq) {
-        var parametersOutDir = bundlePath + "/parameter_values.json";
-        writeFile(
-            parametersOutDir,
-            JSON.stringify(
-                parameterValues(
-                    renderQueueIndex,
-                    app.project.file.fsName,
-                    outputFolder,
-                    outputFileName,
-                    isImageSeq,
-                    startFrame,
-                    endFrame,
-                    framesPerTask,
-                    multiFrameRendering,
-                    maxCpuUsagePercentage
-                ),
-                null,
-                4,
-            )
-        );
+
+    const bundle = generateBundle();
+    const jobAssetReferences = {
+        assetReferences: {
+            inputs: {
+                directories: [],
+                filenames: [],
+            },
+            outputs: {
+                directories: [],
+            },
+            referencedPaths: [],
+        },
+    };
+    const jobParameterDefinitions = {
+        "parameterDefinitions": [{
+                "name": "ProjectFile",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {
+                    "control": "CHOOSE_INPUT_FILE",
+                    "label": "Project file",
+                    "groupLabel": "Source",
+                    "fileFilters": [{
+                            "label": "After Effects project files",
+                            "patterns": [
+                                "*.aep",
+                                "*.aepx"
+                            ]
+                        },
+                        {
+                            "label": "All Files",
+                            "patterns": [
+                                "*"
+                            ]
+                        }
+                    ]
+                },
+                "description": "The After Effects project file to render."
+            },
+            {
+                "name": "JobScriptDir",
+                "description": "Directory containing embedded scripts.",
+                "userInterface": {
+                    "control": "HIDDEN"
+                },
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "IN",
+                "default": "scripts"
+            },
+            {
+                "name": "CondaPackages",
+                "type": "STRING",
+                "userInterface": {
+                    "control": "HIDDEN"
+                },
+                "default": "aftereffects=" + aftereffectsCondaVersion,
+                "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+            }
+        ]
+    }
+    const jobParameterValues = {
+        parameterValues: [{
+                name: "deadline:targetTaskRunStatus",
+                value: "READY",
+            },
+            {
+                name: "deadline:maxFailedTasksCount",
+                value: 20,
+            },
+            {
+                name: "deadline:maxRetriesPerTask",
+                value: 5,
+            },
+            {
+                name: "deadline:priority",
+                value: 50,
+            },
+            {
+                name: "ProjectFile",
+                value: app.project.file.fsName,
+            },
+        ]
     }
 
-    /**
-     * Generates job template json file
-     **/
-    function generateTemplate(bundlePath, isImageSeq) {
-        // Open the template depending on the output type
-        var path = bundlePath + "/video_template.json";
-        if (isImageSeq) {
-            path = bundlePath + "/image_template.json";
-        }
-        var templateContents = readFile(path);
-        // Parse the template string to a JSON object
-        var templateObject = JSON.parse(templateContents);
-        templateObject.name = File.decode(app.project.file.name) + " [" + compName + "]";
-        logger.debug("The template name is " + templateObject.name, submitBundleFile);
-        try {
-            if (templateObject.steps[0].name) {
-                templateObject.steps[0].name = compName;
-                logger.debug("The step name is " + templateObject.steps[0].name, submitBundleFile);
-            }
-        } catch (e) {
-            adcAlert("Error accessing the template's steps name. \nPlease check your template.json and make sure you have name under steps.", true);
-            logger.debug("Error accessing the template's steps name. " + error, submitBundleFile);
-        }
-        try {
-            if (templateObject.steps[0].script && templateObject.steps[0].script.actions) {
-                // Add timeout to the onRun action
-                if (templateObject.steps[0].script.actions.onRun) {
-                    templateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
-                    logger.debug("Added timeout of " + taskTimeoutSeconds + " seconds to onRun action", submitBundleFile);
-                }
-            }
-        } catch (e) {
-            adcAlert("Error accessing the template's actions. \nPlease check your template.json.", true);
-            logger.debug("Error accessing the template's actions: " + e.message, submitBundleFile);
-        }
-
-        var aftereffectsCondaVersion = dcUtil.getAEVersion();
-        if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
-            aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
-        }
-        logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
+    const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
+    template.steps = []
+    template.parameterDefinitions = jobParameterDefinitions.parameterDefinitions
 
     // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
     const stepOutputFolderParameters = [];
 
-        for (var i = paramDefCopy.length - 1; i >= 0; i--) {
-            if (paramDefCopy[i].name == "CondaPackages") {
-                paramDefCopy[i].default = "aftereffects=" + aftereffectsCondaVersion;
-            }
+    for (var i = 0; i < renderQueueItems.length; i++) {
+        var renderQueueItem = renderQueueItems[i][0];
+        var renderQueueIndex = renderQueueItems[i][1];
+
+        if (!validateRenderQueueItemOutputModule(renderQueueItem)) {
+            return;
         }
 
         var stepFramesPerTask = parseInt(selectionSettings.get(renderQueueItem.comp.id).framesPerTask() || framesPerTask)
@@ -446,7 +423,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
         // Push step asset references
-        for (var d=0;d<dependencies.length;d++) {
+        for (var d = 0; d < dependencies.length; d++) {
             jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
         }
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
@@ -464,7 +441,7 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             stepMaxCpuUsagePercentage
         )
 
-        for (var p=0;p<parameterValues.parameterValues.length;p++) {
+        for (var p = 0; p < parameterValues.parameterValues.length; p++) {
             if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
                 jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
             }
@@ -473,13 +450,13 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
 
         var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName, taskTimeoutSeconds)
-        for (var s=0;s<stepTemplate.steps.length;s++) {
+        for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s])
         }
         var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
-        for (var p=0;p<stepParameters.parameterDefinitions.length;p++) {
+        for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
-            for (var tpd=0;tpd<template.parameterDefinitions.length;tpd++) {
+            for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {
                 var templateParameterDefinition = template.parameterDefinitions[tpd];
                 var stepParameterDefinition = stepParameters.parameterDefinitions[p];
                 if (templateParameterDefinition.name == stepParameterDefinition.name) {
@@ -495,9 +472,9 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
-    writeFile(bundle.fsName + "/asset_references.json",JSON.stringify(jobAssetReferences, null, 4));
+    writeFile(bundle.fsName + "/asset_references.json", JSON.stringify(jobAssetReferences, null, 4));
 
-    writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
+    writeFile(bundle.fsName + "/parameter_values.json", JSON.stringify(jobParameterValues, null, 4));
 
     writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));
     logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -14,7 +14,7 @@ if (typeof submitBundleFile == 'undefined') {
     const submitBundleFile = "SubmitButton.jsx";
 }
 
-// Validate that the RenderQueueIndex for each selectionItem is still valid
+// Validate that the RenderQueueIndex for each selectionItem is still valid and update list if they're out of date
 function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
     if (
         renderQueueIndex < 1 ||

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -208,7 +208,7 @@ function SubmitSelection(selection, selectionSettings) {
     // Validate timeout values during job submission
     if (taskTimeoutSeconds <= 0) {
         adcAlert("The following timeout value must be greater than 0: TaskRun", true);
-        throw new Error("Task run timeout must be greater than zero");
+        return;
     }
 
     const renderQueueItems = [];

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -273,8 +273,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
-    const savedVersion = dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, 0);
+    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -286,11 +286,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            dcUtil.saveStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, true);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -205,40 +205,21 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     taskTimeoutSeconds = (taskTimeoutDays * 24 * 60 * 60) + (taskTimeoutHours * 60 * 60) + (taskTimeoutMinutes * 60);
 
     const submitBundleFile = "SubmitButton.jsx";
-    // first we must verify that our selection is valid
-    if (selection == null) {
-        adcAlert("Error: No selection", true);
-        return;
-    }
+    var renderQueueItems = []
 
-    var renderQueueIndex = selection.renderQueueIndex;
-    var rqi;
+    // Check to make sure that all of our selection indices are correct
+    for (var i=0;i<selection.length;i++) {
+        var selectionItem = selection[i];
+        var renderQueueIndex = selectionItem.renderQueueIndex;
+        var renderQueueItem;
 
-    // because our panel is updated independently of the render queue, the two may become out of sync
-    // we need to verify that the selection made actually matches what is in the render queue
-    if (
-        renderQueueIndex < 1 ||
-        renderQueueIndex > app.project.renderQueue.numItems
-    ) {
-        adcAlert(
-            "Error: Render Queue has changed since last refreshing. Refreshing panel now. Please try again.", true
-        );
-        updateList();
-        return;
-    }
-    rqi = app.project.renderQueue.item(renderQueueIndex);
-    if (rqi == null || rqi.comp.id != selection.compId) {
-        adcAlert(
-            "Error: Render Queue has changed since last refresh. Refreshing panel now. Please try again.", true
-        );
-        updateList();
-        return;
-    }
-    if (rqi.numOutputModules > 1) {
-        adcAlert(
-            "Warning: Multiple output modules detected. It is not supported in current submitter. Please raise an issue on Github repo for feature request.", false
-        );
-        return;
+        // because our panel is updated independently of the render queue, the two may become out of sync
+        // we need to verify that the selection made actually matches what is in the render queue
+        if (!UpdateRenderQueueIndices(renderQueueIndex, selectionItem)) {
+            return;
+        }
+        renderQueueItem = app.project.renderQueue.item(renderQueueIndex);
+        renderQueueItems.push([renderQueueItem, renderQueueIndex])
     }
 
     //We have a valid selection
@@ -296,31 +277,22 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             }
             return;
         } else {
-            outputPath = outputModule.fsName;
-            outputFile = outputModule.name;
-            outputFolder = outputModule.parent.fsName;
-            logger.debug("OutputPath is: " + outputPath, submitBundleFile);
-            logger.debug("OutputFile is: " + outputFile, submitBundleFile);
-            logger.debug("outputFolder is: " + outputFolder, submitBundleFile);
+            app.project.save();
+        }
+        if (app.project.file == null) {
+            // If the user hit yes to the prompt, but the file had never been saved, a second prompt would appear asking where they would want to save the project.
+            // If they hit cancel on the second prompt, the project file should be null and we should cancel the submission.
+            return;
         }
     }
+
     // Calculate frame range using the utility function
     const frameRange = dcUtil.calculateFrameRange(rqi);
     const startFrame = frameRange.startFrame;
     const endFrame = frameRange.endFrame;
 
-    var dependencies = findJobAttachments(rqi.comp); // list of filenames
-    var compName = dcUtil.removeIllegalCharacters(rqi.comp.name);
-
-    function generateAssetReferences(bundlePath, sanitizedOutputFolder) {
-        // Write the asset_references.json file
-        var jobAttachmentsContents = jobAttachmentsJson(
-            dependencies,
-            sanitizedOutputFolder
-        );
-        var assetReferencesOutDir = bundlePath + "/asset_references.json";
-        writeFile(assetReferencesOutDir, JSON.stringify(jobAttachmentsContents, null, 4));
-    }
+    const aftereffectsVersion = app.version[0] + app.version[1];
+    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
 
     /**
      * Generates parameter_values json file
@@ -390,58 +362,110 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
         }
         logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
-        var paramDefCopy = templateObject.parameterDefinitions;
+    // generateTemplate(bundle.fsName, isImageSeq, compName, submitBundleFile);
+    var stepOutputFolderParameters = [];
 
         for (var i = paramDefCopy.length - 1; i >= 0; i--) {
             if (paramDefCopy[i].name == "CondaPackages") {
                 paramDefCopy[i].default = "aftereffects=" + aftereffectsCondaVersion;
             }
         }
-        writeFile(bundlePath + "/template.json", JSON.stringify(templateObject, null, 4));
-        logger.debug("Wrote the template.json file to the bundle folder " + bundlePath, submitBundleFile);
-    }
 
-    /**
-     * Generates the job bundle, including template.json, parameter_values.json
-     * and asset_references.json
-     **/
-    function generateBundle() {
-        // create the job bundle folder
-        var bundleRoot = new Folder(
-            dcUtil.getTempFolder() + "/DeadlineCloudAESubmission"
-        ); //forward slash works on all operating systems
-        recursiveDelete(bundleRoot);
-        bundleRoot.create();
-        var bundlePath = bundleRoot.fsName;
+        var stepFramesPerTask = parseInt(selectionSettings.get(selectionItem.compId).framesPerTask() || framesPerTask)
+        var stepMaxCpuUsagePercentage = parseInt(selectionSettings.get(selectionItem.compId).maxCpuUsagePercentage() || maxCpuUsagePercentage)
+        var stepMultiFrameRendering = selectionSettings.get(selectionItem.compId).multiFrameRendering() || multiFrameRendering
+
+        var outputModule = renderQueueItem.outputModule(1).file;
+        var outputPath = outputModule.fsName;
+        var outputFile = outputModule.name;
+        var outputFolder = outputModule.parent.fsName;
+
+        logger.debug("OutputPath is: " + outputPath, submitBundleFile);
+        logger.debug("OutputFile is: " + outputFile, submitBundleFile);
+        logger.debug("OutputFolder is: " + outputFolder, submitBundleFile);
+
+        var renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
+        var startFrame = Number(
+            timeToFrames(
+                Number(renderSettings["Time Span Start"]),
+                Number(renderSettings["Use this frame rate"])
+            )
+        );
+        var endFrame =
+            Number(
+                timeToFrames(
+                    Number(renderSettings["Time Span End"]),
+                    Number(renderSettings["Use this frame rate"])
+                )
+            ) - 1; // end frame is inclusive so we subtract 1
+
+        var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
+        var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
 
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
-        const outputFileNameNoRegex = getFileNameNoRegex(outputFile);
-        const extension = getFileExtension(outputFileNameNoRegex);
+        var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
+        var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        const isImageSeq = isImageOutput(extension);
+        var isImageSeq = isImageOutput(extension);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
-        generateAssetReferences(bundlePath, sanitizedOutputFolder);
-        generateParameterValues(bundlePath, sanitizedOutputFolder, sanitizedOutputFileName, isImageSeq);
-
-        var jobTemplateSourceFolder = new Folder(
-            scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate"
-        );
-        if (!jobTemplateSourceFolder.exists) {
-            adcAlert(
-                "Error: Missing job template at " + jobTemplateSourceFolder.fsName, true
-            );
-            return null;
+        // Push step asset references
+        for (var d=0;d<dependencies.length;d++) {
+            jobAssetReferences.assetReferences.inputs.filenames.push(dependencies[d])
         }
-        recursiveCopy(jobTemplateSourceFolder, bundleRoot);
+        jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder)
 
-        generateTemplate(bundlePath, isImageSeq);
-        return bundleRoot;
+        var parameterValues = generateParameterValuesForStep(
+            compName,
+            renderQueueIndex,
+            sanitizedOutputFolder,
+            sanitizedOutputFileName,
+            isImageSeq,
+            startFrame,
+            endFrame,
+            stepFramesPerTask,
+            stepMultiFrameRendering,
+            stepMaxCpuUsagePercentage
+        )
+
+        for (var p=0;p<parameterValues.parameterValues.length;p++) {
+            if (jobParameterValues.parameterValues.indexOf(parameterValues.parameterValues[p]) === -1) {
+                jobParameterValues.parameterValues.push(parameterValues.parameterValues[p])
+            }
+        }
+
+        stepOutputFolderParameters.push("{{Param." + compName + "_OutputDir}}")
+
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, compName)
+        for (var s=0;s<stepTemplate.steps.length;s++) {
+            template.steps.push(stepTemplate.steps[s])
+        }
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, compName)
+        for (var p=0;p<stepParameters.parameterDefinitions.length;p++) {
+            var parameterExists = false;
+            for (var tpd=0;tpd<template.parameterDefinitions.length;tpd++) {
+                var templateParameterDefinition = template.parameterDefinitions[tpd];
+                var stepParameterDefinition = stepParameters.parameterDefinitions[p];
+                if (templateParameterDefinition.name == stepParameterDefinition.name) {
+                    parameterExists = true
+                    break
+                }
+            }
+            if (parameterExists === false) {
+                template.parameterDefinitions.push(stepParameters.parameterDefinitions[p])
+            }
+        }
     }
-    var bundle = generateBundle();
+    var generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
+    template.jobEnvironments = generatedJobEnvironment.jobEnvironments
+
+    writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
+
+    writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));
+    logger.debug("Wrote the template.json file to the bundle folder " + bundle.fsName, submitBundleFile);
 
     // Runs a bat script that requires extra permissions but will not block the After Effects UI while submitting.
     var logFile = new File(dcUtil.getTempFolder() + "/submitter_output.log");

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -290,8 +290,38 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const startFrame = frameRange.startFrame;
     const endFrame = frameRange.endFrame;
 
-    const aftereffectsVersion = app.version[0] + app.version[1];
-    logger.debug("The major version of After Effects is " + aftereffectsVersion, submitBundleFile);
+    // Check if warning should be shown
+    const ignoreWarning = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING) === "true";
+    const savedVersion = parseFloat(app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION) || "0");
+    const currentVersion = dcUtil.getAEVersion();
+
+    // Is this AE version not supported in the deadline-cloud channel?
+    if (SUPPORTED_VERSIONS.indexOf(currentVersion) === -1) {
+        // If so, has the warning already been ignored or is the user on a different AE version and we should warn them again?
+        if (!ignoreWarning || savedVersion !== currentVersion) {
+            const versionMismatchWarningMessage = "Warning: Your After Effects version " + currentVersion +
+            " is not officially supported in the deadline-cloud conda channel. Supported versions are: " + SUPPORTED_VERSIONS.join(", ") + ". " +
+            "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
+
+            // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
+            if (confirm(versionMismatchWarningMessage)) {
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
+            } else {
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                return;
+            }
+        } else {
+            logger.debug("Version mismatch already acknowledged, version warning skipped.");
+        }
+        logger.debug("Defaulting to After Effects major version conda package to minimize incompatibility issues.");
+    }
+
+    var aftereffectsCondaVersion = dcUtil.getAEVersion();
+    if (SUPPORTED_VERSIONS.indexOf(aftereffectsCondaVersion) === -1) {
+        aftereffectsCondaVersion = Math.floor(aftereffectsCondaVersion);
+    }
+    logger.debug("The compatible version of After Effects is " + aftereffectsCondaVersion, submitBundleFile);
 
     /**
      * Generates parameter_values json file

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -41,6 +41,7 @@ function UpdateRenderQueueIndices(renderQueueIndex, selectionItem) {
         );
         return false;
     }
+    validateRenderQueueItemOutputModule(renderQueueItem);
     return true;
 }
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -273,8 +273,8 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
-    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
+    const ignoreWarning = dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const savedVersion = dcUtil.getNumberSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 
     // Is this AE version not supported in the deadline-cloud channel?
@@ -286,11 +286,11 @@ function SubmitSelection(selection, selectionSettings) {
                 "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
-            dcUtil.saveStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
+            dcUtil.saveStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), true);
             } else {
-                dcUtil.saveBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+                dcUtil.saveBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
                 return;
             }
         } else {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -461,6 +461,8 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
     const generatedJobEnvironment = generateJobEnvironmentFragment(bundle.fsName, stepOutputFolderParameters.join(","))
     template.jobEnvironments = generatedJobEnvironment.jobEnvironments
 
+    writeFile(bundle.fsName + "/asset_references.json",JSON.stringify(jobAssetReferences, null, 4));
+
     writeFile(bundle.fsName + "/parameter_values.json",JSON.stringify(jobParameterValues, null, 4));
 
     writeFile(bundle.fsName + "/template.json", JSON.stringify(template, null, 4));

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -117,9 +117,40 @@ function generateBundle() {
     return bundleRoot;
 }
 
+function generateParameterName(index, compName, parameter) {
+    /** Generates the name of the parameter to be used in the job submission
+     * by prefixing with the index and compName
+     * Truncates compname to avoid going over character limit.
+     **/
+    if (parameter === undefined) {
+        parameter = "";
+    }
+    if (parameter !== "") {
+        parameter = "_" + parameter;
+    }
+    index = index.toString();
+    compName = compName.substring(0, 15);
+    return "_" + index + "_" + compName + parameter;
+}
+
+function generatePrettyParameterName(index, compName, parameter) {
+    /** Generates name of the parameter to be displayed in job submission UI
+     * Truncates compname to avoid going over character limit
+     **/
+    if (parameter === undefined) {
+        parameter = "";
+    }
+    index = index.toString();
+    const max_length = 10;
+    if (compName.length >= max_length) {
+        compName = compName.substring(0, max_length - 3) + "...";
+    }
+    return "(" + index + "_" + compName + ") " + parameter;
+}
+
 // Generates the parameter definitions for each step by loading the `parameter_definitions_<>_fragment.json`
 //      Adding our `( <RenderQueueItemID> )` to the label and changing the name to prefixed by `<RenderQueueItemID>_`
-function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID) {
+function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex, compName) {
     var path = bundlePath + "/parameter_definitions_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/parameter_definitions_image_fragment.json";
@@ -135,8 +166,8 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID
             continue;
         }
         var replacedDefinition = stepParametersObject.parameterDefinitions[i]
-        replacedDefinition.name = renderQueueItemID + "_" + stepParametersObject.parameterDefinitions[i].name;
-        replacedDefinition.userInterface.label = "(" + renderQueueItemID + ") " + replacedDefinition.userInterface.label;
+        replacedDefinition.name = generateParameterName(renderQueueIndex, compName, replacedDefinition.name);
+        replacedDefinition.userInterface.label = generatePrettyParameterName(renderQueueIndex, compName, replacedDefinition.userInterface.label);
 
         updatedParameterDefinitions.push(replacedDefinition);
     }
@@ -146,7 +177,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueItemID
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parmaeters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID, taskTimeoutSeconds) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -158,18 +189,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemID,
     if (isImageSeq) {
         // Replace parameter names in the creation of `Index`
         const taskParameters = stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0]
-        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + renderQueueItemID + "_");
-        taskParameters.name = renderQueueItemID + "_" + taskParameters.name;
+        taskParameters.range = taskParameters.range.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_");
+        taskParameters.name = generateParameterName(renderQueueItemIndex, compName, taskParameters.name);
         stepTemplateObject.steps[0].parameterSpace.taskParameterDefinitions[0] = taskParameters;
     }
 
-    stepTemplateObject.steps[0].name = renderQueueItemID;
+    stepTemplateObject.steps[0].name = generateParameterName(renderQueueItemIndex, compName, "");
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + renderQueueItemID + "_"));
+        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     if (stepTemplateObject.steps[0].script.actions.onRun) {
@@ -396,7 +427,6 @@ function SubmitSelection(selection, selectionSettings) {
 
         var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-        var renderQueueItemID = "_" + renderQueueIndex + "_" + compName;
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
@@ -414,7 +444,7 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValuesForStep(
-            renderQueueItemID,
+            generateParameterName(renderQueueIndex, compName, ""),
             renderQueueIndex,
             sanitizedOutputFolder,
             sanitizedOutputFileName,
@@ -432,13 +462,13 @@ function SubmitSelection(selection, selectionSettings) {
             }
         }
 
-        stepOutputFolderParameters.push("{{Param." + renderQueueItemID + "_OutputDir}}");
+        stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueItemID, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
-        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueItemID);
+        var stepParameters = generateStepParameterFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName);
         for (var p = 0; p < stepParameters.parameterDefinitions.length; p++) {
             var parameterExists = false;
             for (var tpd = 0; tpd < template.parameterDefinitions.length; tpd++) {

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -235,21 +235,15 @@ function buildUI(thisObj) {
         if (selection == null) {
             return false;
         }
-        const renderQueueIndex = selection.renderQueueIndex;
-        const rqi = app.project.renderQueue.item(renderQueueIndex);
-        // Currently we only support one output modele. We have sufficient error handling
-        // after submit button is clicked, so this is a sufficient for now
-        if (rqi.numOutputModules == 1) {
-            var outputModule = rqi.outputModule(1).file;
-            if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
+        if (duplicateNames.length !== 0) {
+            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
+            for (var i=0;i<duplicateNames.length;i++) {
+                message = message + "\n\t" + duplicateNames[i];
             }
+            adcAlert(message, true)
+            return true
         }
-        // Default to true so that we don't block any customers in case we can't
-        // sufficiently verify whether they're submitting an image sequence or not
-        return true;
+        return false
     }
 
     var submitButton = controlsGroup.add("button", undefined, "Submit");

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -31,8 +31,7 @@ function buildUI(thisObj) {
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
 
-    const bounds = list == null ? undefined : list.bounds;
-    var list = listGroup.add("listbox", bounds, "", {
+    var list = listGroup.add("listbox", undefined, "", {
         multiselect: true,
         numberOfColumns: 4,
         showHeaders: true,

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -275,6 +275,7 @@ function buildUI(thisObj) {
     function updateList() {
         var bounds = list == null ? undefined : list.bounds;
         var newList = listGroup.add("listbox", bounds, "", {
+            multiselect: true,
             numberOfColumns: 4,
             showHeaders: true,
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -55,7 +55,7 @@ function buildUI(thisObj) {
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
-    framesPerTaskTextBox.onChange = function() {
+    function onFramesPerTaskChanged() {
         const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
         if (isNaN(newFramesPerTaskValue)) {
             framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
@@ -68,6 +68,7 @@ function buildUI(thisObj) {
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
     }
+    framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
     const mfrGroup = settingsGroup.add("group", undefined, "");
@@ -93,7 +94,7 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
     maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
-    maxCpuUsagePercentageTextBox.onChange = function() {
+    function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
@@ -104,9 +105,10 @@ function buildUI(thisObj) {
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
     }
+    maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
-    mfrCheckBox.onClick = function() {
+    function onMfrCheckBoxClicked() {
         const isMfrChecked = mfrCheckBox.value;
         if (!isMfrChecked) {
             maxCpuUsagePercentageTextBox.text = "N/A";
@@ -116,6 +118,8 @@ function buildUI(thisObj) {
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
         }
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+    mfrCheckBox.onClick = onMfrCheckBoxClicked;
+            var outputModule = renderQueueItem.outputModule(1).file;
     }
 
     // Add Timeouts settings group

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -413,11 +413,6 @@ function buildUI(thisObj) {
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
-            const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
-            var maxCpuUsagePercentage = undefined;
-            if (mfrCheckBox.value) {
-                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
-            }
             if (list.selection === null) {
                 return;
             }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -4,8 +4,9 @@ function populateListBoxItem(item, renderQueueItem, index) {
     item.subItems[0].text = renderQueueItem.comp.name;
 
     const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
-    const startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
-    const endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+    var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
+    var startFrame = frameRange.startFrame;
+    var endFrame = frameRange.endFrame;
 
     item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
     if (renderQueueItem.numOutputModules <= 0) {
@@ -427,14 +428,14 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            const rqi = app.project.renderQueue.item(i);
+            var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {
                 continue;
             }
             if (rqi.status == RQItemStatus.RENDERING || rqi.status == RQItemStatus.WILL_CONTINUE || rqi.status == RQItemStatus.USER_STOPPED || rqi.status == RQItemStatus.ERR_STOPPED || rqi.status == RQItemStatus.DONE) {
                 continue;
             }
-            const item = newList.add('item', i.toString());
+            var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
@@ -450,7 +451,7 @@ function buildUI(thisObj) {
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";
             } else if (rqi.numOutputModules == 1) {
-                const outputFile = rqi.outputModule(1).file;
+                var outputFile = rqi.outputModule(1).file;
                 item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
             } else {
                 item.subItems[2].text = "<multiple output modules>";

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -260,38 +260,10 @@ function buildUI(thisObj) {
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
-
-    // Check for duplicate names
-    function checkForInvalidCompositionNames(selection) {
-        const names = [];
-        const duplicateNames = [];
-        for (var i = 0; i < selection.length; i++) {
-            var selectionItem = selection[i];
-            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
-            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
-            if (names.indexOf(compName) !== -1) {
-                duplicateNames.push(renderQueueItem.comp.name);
-            }
-            names.push(compName);
-        }
-        if (duplicateNames.length !== 0) {
-            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: ";
-            for (var i = 0; i < duplicateNames.length; i++) {
-                message = message + "\n\t" + duplicateNames[i];
-            }
-            adcAlert(message, true);
-            return true;
-        }
-        return false;
-    }
-
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
             if (list.selection === null) {
-                return;
-            }
-            if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }
             SubmitSelection(list.selection, uiSettingsState);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -248,7 +248,7 @@ function buildUI(thisObj) {
         const selectionItem = dcUtil.getSelection(list)
         if (selectionItem) {
             var compId = selectionItem.compId;
-            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuPercentageTextBox.text));
+            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -330,7 +330,7 @@ function buildUI(thisObj) {
             } else {
                 onTaskRunDaysChanged();
                 onTaskRunHoursChanged();
-                OnTaskRunMinutesCHanged();
+                OnTaskRunMinutesChanged();
             }
         }
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
@@ -478,31 +478,26 @@ function buildUI(thisObj) {
 
         function onSelectionChange() {
             const selection = list.selection;
-            if (selection == null) {
-                updateList();
-                framesPerTaskTextBox.text = "";
-                return;
-            }
+            perCompSettingsGroup.enabled = false;
+            
+            framesPerTaskTextBox.text = "";
+            mfrCheckBox.value = false;
+            maxCpuUsagePercentageTextBox.text = ""
+
             submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
 
-            // Disable everything
-            framesPerTaskTextBox.enabled = false
-            mfrCheckBox.enabled = false
-            maxCpuUsagePercentageTextBox.enabled = false
-
-            if (selection.length !== 1) {
+            if (selection == null || selection.length !== 1) {
                 return
             }
             const selectionItem = selection[0]
+            perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
             const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
-            framesPerTaskTextBox.enabled = imageOutput
-            mfrCheckBox.enabled = true
-            maxCpuUsagePercentageTextBox.enabled = true
-
-            framesPerTaskTextBox.text = selectionItem.subItems[1].text
+            framesPerTaskTextBox.enabled = imageOutput;
+            mfrCheckBox.enabled = true;
+            maxCpuUsagePercentageTextBox.enabled = true;
 
             const settings = uiSettingsState.get(selectionItem.compId)
             if (settings === undefined) {
@@ -510,13 +505,14 @@ function buildUI(thisObj) {
                 return
             }
 
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
-            mfrCheckBox.value = settings.multiFrameRendering()
-            maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
-
-            maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+            framesPerTaskTextBox.text = settings.framesPerTask();
+            framesPerTaskTextBox.onChange();
+            maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
+            maxCpuUsagePercentageTextBox.onChange();
+            mfrCheckBox.value = settings.multiFrameRendering();
+            mfrCheckBox.onClick();
         }
-
+        onSelectionChange();
         list.onChange = onSelectionChange;
         list.selection = null;
     }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -6,6 +6,8 @@ function buildUI(thisObj) {
         resizable: true
     });
 
+    var uiSettingsState = new UiSettingsState();
+
     var root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
@@ -67,6 +69,10 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
+        }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
@@ -104,22 +110,45 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
+        }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
         const isMfrChecked = mfrCheckBox.value;
+        var settingsStateValue = false
         if (!isMfrChecked) {
             maxCpuUsagePercentageTextBox.text = "N/A";
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+            settingsStateValue = false
         } else {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
+            settingsStateValue = true
         }
+
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+        for (var s=0;s<list.selection.length;s++) {
+            var selectionItem = list.selection[s];
+            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+        }
+    }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
+
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem.numOutputModules === 1) {
             var outputModule = renderQueueItem.outputModule(1).file;
+            if (outputModule != null) {
+                var outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                var extension = getFileExtension(outputFileNameNoRegex);
+                return isImageOutput(extension);
+            }
+        }
+        return false
     }
 
     // Add Timeouts settings group
@@ -264,6 +293,8 @@ function buildUI(thisObj) {
             var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
+            // Create a default entry for each comp as needed.
+            uiSettingsState.get(item.compId)
             item.subItems[0].text = rqi.comp.name;
             // Calculate frame range using the utility function
             var frameRange = dcUtil.calculateFrameRange(rqi);
@@ -284,34 +315,59 @@ function buildUI(thisObj) {
             listGroup.remove(list);
         }
         list = newList;
-        list.onChange = function() {
-            framesPerTaskTextBox.enabled = isFramesPerTaskEnabled(list.selection);
-            // If no selection, update list and set text box blank. But if there's a selection
-            // and frames per task is disabled, fill textbox with default start-end frame to show that
-            // no image chunking will occur. But if there is a selection and frames per task is enabled,
-            // set it to their default value.
-            if (list.selection == null) {
+
+        function onSelectionChange() {
+            var selection = list.selection;
+            if (selection == null) {
                 updateList();
                 framesPerTaskTextBox.text = "";
-            } else if (!framesPerTaskTextBox.enabled) {
-                framesPerTaskTextBox.text = list.selection.subItems[1].text;
-            } else {
-                framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+                return;
             }
-
-            submitButton.enabled = list.selection != null;
+            submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
-        };
+
+            // Disable everything
+            framesPerTaskTextBox.enabled = false
+            mfrCheckBox.enabled = false
+            maxCpuUsagePercentageTextBox.enabled = false
+
+            if (selection.length !== 1) {
+                return
+            }
+            var selectionItem = selection[0]
+            logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
+            var imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            framesPerTaskTextBox.enabled = imageOutput
+            mfrCheckBox.enabled = true
+            maxCpuUsagePercentageTextBox.enabled = true
+
+            framesPerTaskTextBox.text = selectionItem.subItems[1].text
+
+            var settings = uiSettingsState.get(selectionItem.compId)
+            if (settings === undefined) {
+                logger.warning("Could not find settings for : " + selectionItem.compId);
+                return
+            }
+
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+            mfrCheckBox.value = settings.multiFrameRendering()
+            maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
+
+            maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+        }
+
+        list.onChange = onSelectionChange;
         list.selection = null;
     }
 
     updateList();
-    framesPerTaskTextBox.enabled = isFramesPerTaskEnabled(list.selection);
-
-    refreshButton.onClick = function() {
-        updateList();
+    if (list.selection != null && list.selection.length === 1) {
+        var selectionItem = list.selection[0]
+        var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
+        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
+    refreshButton.onClick = updateList;
 
     submitterPanel.layout.layout(true);
 

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -282,6 +282,14 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 200;
         newList.preferredSize.width = 500;
 
+        // Disable all controls if the render queue is empty
+        // This forces the user to click "refresh" when a new project is opened and populate the list
+        controlsGroup.enabled = app.project.renderQueue.numItems > 0;
+        // Also populate timeout settings because the values could be stale if a new project has been opened since the last refresh
+        taskRunDaysInput.text = uiSettingsState.taskRunDays();
+        taskRunHoursInput.text = uiSettingsState.taskRunHours();
+        taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
+
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -129,11 +129,11 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
-        for (var s = 0; s < list.selection.length; s++) {
-            if (list.selection == null) {
-                return;
-            }
-            const selectionItem = list.selection[s];
+        if (list.selection == null) {
+            return;
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -174,12 +174,95 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        for (var s = 0; s < list.selection.length; s++) {
-            const selectionItem = list.selection[s];
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
+
+    // Add Timeouts settings group
+    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
+    timeoutsPanel.orientation = "column";
+    timeoutsPanel.alignment = ['fill', 'top'];
+    timeoutsPanel.alignChildren = ['left', 'center'];
+    timeoutsPanel.margins = 5;
+
+    // Task run timeout
+    const taskRunGroup = timeoutsPanel.add("group");
+    taskRunGroup.orientation = "row";
+    taskRunGroup.alignment = ['fill', 'top'];
+    taskRunGroup.alignChildren = ['left', 'center'];
+
+    const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
+    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+
+    const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
+    taskRunDaysInput.characters = 3;
+    taskRunDaysGroup.add("statictext", undefined, "days");
+
+    const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
+    taskRunHoursInput.characters = 3;
+    taskRunHoursGroup.add("statictext", undefined, "hours");
+
+    const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
+    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
+    taskRunMinutesInput.characters = 3;
+    taskRunMinutesGroup.add("statictext", undefined, "minutes");
+
+    // Add input validation and save values to settings
+    function onTaskRunCheckboxClicked() {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
+        if (this.value) {
+            dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunTimeout(this.value)
+        }
+    }
+    taskRunCheckbox.onClick = onTaskRunCheckboxClicked
+
+    function onTaskRunDaysChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunDays(this.text)
+        }
+    }
+    taskRunDaysInput.onChange = onTaskRunDaysChanged
+
+    function onTaskRunHoursChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunHours(this.text)
+        }
+    }
+    taskRunHoursInput.onChange = onTaskRunHoursChanged
+
+    function onTaskRunMinutesChanged() {
+        this.text = this.text.replace(/[^0-9]/g, "");
+        if (this.text === "") this.text = "0";
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
+        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setTaskRunMinutes(this.text)
+        }
+    }
+    taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
@@ -196,8 +279,8 @@ function buildUI(thisObj) {
         }
 
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        for (var s = 0; s < list.selection.length; s++) {
-            const selectionItem = list.selection[s];
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
             uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
         }
     }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -259,7 +259,6 @@ function buildUI(thisObj) {
         if (!isMfrChecked) {
             maxCpuUsagePercentageTextBox.text = "N/A";
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-            settingsStateValue = false
         } else {
             maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
             app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -76,13 +76,13 @@ function buildUI(thisObj) {
         if (selectionItem) {
             var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
             if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).framesPerTask();
+                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).framesPerTask();
             }
             if (newFramesPerTaskValue > 9999) {
                 newFramesPerTaskValue = 9999;
             }
             framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -123,7 +123,7 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -133,7 +133,7 @@ function buildUI(thisObj) {
         const isMfrChecked = mfrCheckBox.value;
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var RQIID = dcUtil.getRQIID(selectionItem.renderQueueIndex);
+            var RQIID = dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex);
             if (!isMfrChecked) {
                 maxCpuUsagePercentageTextBox.text = "N/A";
                 uiSettingsState.get(RQIID).setMultiFrameRendering(false);
@@ -341,7 +341,7 @@ function buildUI(thisObj) {
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
 
-            const settings = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex));
+            const settings = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex));
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return;

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -3,7 +3,6 @@ function populateListBoxItem(item, renderQueueItem, index) {
     item.compId = renderQueueItem.comp.id;
     item.subItems[0].text = renderQueueItem.comp.name;
 
-    const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
     var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
     var startFrame = frameRange.startFrame;
     var endFrame = frameRange.endFrame;

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -29,7 +29,7 @@ function refreshList(listBox, uiSettingsState) {
         RQItemStatus.USER_STOPPED,
         RQItemStatus.ERR_STOPPED,
         RQItemStatus.DONE
-    ]
+    ];
     for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
         var renderQueueItem = app.project.renderQueue.item(index);
         if (renderQueueItem == null) {
@@ -64,7 +64,7 @@ function buildUI(thisObj) {
     const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
-    root.alignChildren = ['fill', 'top']
+    root.alignChildren = ['fill', 'top'];
     const logoGroup = root.add("group");
     logoGroup.alignment = 'left';
     logoGroup.add("image", undefined, logoData());
@@ -82,11 +82,11 @@ function buildUI(thisObj) {
     const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
     const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'top'];
-    listGroup.alignChildren = ['fill', 'top']
-    listGroup.orientation = "column"
+    listGroup.alignChildren = ['fill', 'top'];
+    listGroup.orientation = "column";
     var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
         multiline: true
-    })
+    });
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
     multiCompLabel.maximumSize.height = 30;
     multiCompLabel.alignment = ['fill', 'top'];
@@ -112,55 +112,55 @@ function buildUI(thisObj) {
         submitButton.active = true;
 
         // Disable everything
-        framesPerTaskTextBox.enabled = false
-        mfrCheckBox.enabled = false
-        maxCpuUsagePercentageTextBox.enabled = false
-        taskRunCheckbox.enabled = false
-        taskRunDaysInput.enabled = false
-        taskRunHoursInput.enabled = false
-        taskRunMinutesInput.enabled = false
+        framesPerTaskTextBox.enabled = false;
+        mfrCheckBox.enabled = false;
+        maxCpuUsagePercentageTextBox.enabled = false;
+        taskRunCheckbox.enabled = false;
+        taskRunDaysInput.enabled = false;
+        taskRunHoursInput.enabled = false;
+        taskRunMinutesInput.enabled = false;
 
         if (selection.length !== 1) {
-            return
+            return;
         }
-        const selectionItem = selection[0]
+        const selectionItem = selection[0];
         logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
-        framesPerTaskTextBox.enabled = imageOutput
-        mfrCheckBox.enabled = true
-        maxCpuUsagePercentageTextBox.enabled = true
-        taskRunCheckbox.enabled = true
-        taskRunDaysInput.enabled = true
-        taskRunHoursInput.enabled = true
-        taskRunMinutesInput.enabled = true
+        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
+        framesPerTaskTextBox.enabled = imageOutput;
+        mfrCheckBox.enabled = true;
+        maxCpuUsagePercentageTextBox.enabled = true;
+        taskRunCheckbox.enabled = true;
+        taskRunDaysInput.enabled = true;
+        taskRunHoursInput.enabled = true;
+        taskRunMinutesInput.enabled = true;
 
         logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
-        framesPerTaskTextBox.text = selectionItem.subItems[1].text
+        framesPerTaskTextBox.text = selectionItem.subItems[1].text;
 
-        const settings = uiSettingsState.get(selectionItem.compId)
+        const settings = uiSettingsState.get(selectionItem.compId);
         if (settings === undefined) {
             logger.warning("Could not find settings for : " + selectionItem.compId);
-            return
+            return;
         }
 
         if (imageOutput === true) {
             logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text;
         }
         logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
-        mfrCheckBox.value = settings.multiFrameRendering()
+        mfrCheckBox.value = settings.multiFrameRendering();
         logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
-        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
+        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
 
-        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
 
-        taskRunCheckbox.value = settings.taskRunTimeoutEnabled()
-        taskRunDaysInput.enabled = taskRunCheckbox.value
-        taskRunDaysInput.text = settings.taskRunDays()
-        taskRunHoursInput.enabled = taskRunCheckbox.value
-        taskRunHoursInput.text = settings.taskRunHours()
-        taskRunMinutesInput.enabled = taskRunCheckbox.value
-        taskRunMinutesInput.text = settings.taskRunMinutes()
+        taskRunCheckbox.value = settings.taskRunTimeoutEnabled();
+        taskRunDaysInput.enabled = taskRunCheckbox.value;
+        taskRunDaysInput.text = settings.taskRunDays();
+        taskRunHoursInput.enabled = taskRunCheckbox.value;
+        taskRunHoursInput.text = settings.taskRunHours();
+        taskRunMinutesInput.enabled = taskRunCheckbox.value;
+        taskRunMinutesInput.text = settings.taskRunMinutes();
     }
 
     list.onChange = onSelectionChange;
@@ -186,7 +186,7 @@ function buildUI(thisObj) {
 
     const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task");
     framesPerTaskLabel.alignment = ['left', 'center'];
-    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output."
+    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output.";
 
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
@@ -245,7 +245,7 @@ function buildUI(thisObj) {
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        const selectionItem = dcUtil.getSelection(list)
+        const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
             var compId = selectionItem.compId;
             uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
@@ -280,10 +280,10 @@ function buildUI(thisObj) {
                 return isImageOutput(extension);
             }
         }
-        return false
+        return false;
     }
 
-    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings")
+    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings");
     globalSettingsGroup.orientation = "column";
     globalSettingsGroup.alignment = ['fill', 'top'];
     globalSettingsGroup.alignChildren = ['left', 'top'];
@@ -338,7 +338,7 @@ function buildUI(thisObj) {
         taskRunDaysInput.enabled = taskRunCheckbox.value;
         taskRunHoursInput.enabled = taskRunCheckbox.value;
         taskRunMinutesInput.enabled = taskRunCheckbox.value;
-        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
+        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value);
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked;
     onTaskRunCheckboxClicked();
@@ -346,11 +346,11 @@ function buildUI(thisObj) {
     function onTaskRunDaysChanged() {
         var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunDaysInput.text)
+        var new_value = parseInt(taskRunDaysInput.text);
         if (taskRunDaysInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunDays(new_value)
+                uiSettingsState.setTaskRunDays(new_value);
             }
         }
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
@@ -360,11 +360,11 @@ function buildUI(thisObj) {
     function onTaskRunHoursChanged() {
         var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunHoursInput.text)
+        var new_value = parseInt(taskRunHoursInput.text);
         if (taskRunHoursInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunHours(new_value)
+                uiSettingsState.setTaskRunHours(new_value);
             }
         }
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
@@ -374,11 +374,11 @@ function buildUI(thisObj) {
     function onTaskRunMinutesChanged() {
         var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunMinutesInput.text)
+        var new_value = parseInt(taskRunMinutesInput.text);
         if (taskRunMinutesInput.text === "") new_value = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunMinutes(new_value)
+                uiSettingsState.setTaskRunMinutes(new_value);
             }
         }
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
@@ -400,14 +400,14 @@ function buildUI(thisObj) {
             names.push(compName);
         }
         if (duplicateNames.length !== 0) {
-            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
+            var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: ";
             for (var i = 0; i < duplicateNames.length; i++) {
                 message = message + "\n\t" + duplicateNames[i];
             }
-            adcAlert(message, true)
-            return true
+            adcAlert(message, true);
+            return true;
         }
-        return false
+        return false;
     }
 
     const submitButton = controlsGroup.add("button", undefined, "Submit");
@@ -416,10 +416,10 @@ function buildUI(thisObj) {
             const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
             var maxCpuUsagePercentage = undefined;
             if (mfrCheckBox.value) {
-                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
+                maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
             }
             if (checkForInvalidCompositionNames(list.selection)) {
-                return
+                return;
             }
             if (taskRunCheckbox.value) {
                 SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
@@ -455,7 +455,7 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
-            uiSettingsState.get(item.compId)
+            uiSettingsState.get(item.compId);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -485,27 +485,27 @@ function buildUI(thisObj) {
 
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
-            maxCpuUsagePercentageTextBox.text = ""
+            maxCpuUsagePercentageTextBox.text = "";
 
             submitButton.enabled = true;
             submitButton.active = false;
             submitButton.active = true;
 
             if (selection == null || selection.length !== 1) {
-                return
+                return;
             }
-            const selectionItem = selection[0]
+            const selectionItem = selection[0];
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
             framesPerTaskTextBox.enabled = imageOutput;
             mfrCheckBox.enabled = true;
             maxCpuUsagePercentageTextBox.enabled = true;
 
-            const settings = uiSettingsState.get(selectionItem.compId)
+            const settings = uiSettingsState.get(selectionItem.compId);
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
-                return
+                return;
             }
 
             framesPerTaskTextBox.text = settings.framesPerTask();
@@ -523,9 +523,9 @@ function buildUI(thisObj) {
     updateList();
     refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
-        const selectionItem = list.selection[0]
-        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
-        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
+        const selectionItem = list.selection[0];
+        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
+        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
     refreshButton.onClick = function() {
         refreshList(list, uiSettingsState);
@@ -537,7 +537,7 @@ function buildUI(thisObj) {
         this.layout.resize();
     }
     if (!(thisObj instanceof Panel)) {
-        submitterPanel.center()
+        submitterPanel.center();
         submitterPanel.show();
         submitterPanel.update();
     }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -1,3 +1,58 @@
+function populateListBoxItem(item, renderQueueItem, index) {
+    item.renderQueueIndex = index;
+    item.compId = renderQueueItem.comp.id;
+    item.subItems[0].text = renderQueueItem.comp.name;
+
+    const renderSettings = renderQueueItem.getSettings(GetSettingsFormat.STRING_SETTABLE);
+    const startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
+    const endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+
+    item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
+    if (renderQueueItem.numOutputModules <= 0) {
+        item.subItems[2].text = "<not set>";
+    } else if (renderQueueItem.numOutputModules == 1) {
+        const outputFile = renderQueueItem.outputModule(1).file;
+        item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
+    } else {
+        item.subItems[2].text = "<multiple output modules>";
+    }
+}
+
+
+function refreshList(listBox, uiSettingsState) {
+    listBox.removeAll();
+    const framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK) || "50"
+    const multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)
+    const maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)
+
+    const InvalidRenderQueueItemStatuses = [
+        RQItemStatus.RENDERING,
+        RQItemStatus.WILL_CONTINUE,
+        RQItemStatus.USER_STOPPED,
+        RQItemStatus.ERR_STOPPED,
+        RQItemStatus.DONE
+    ]
+    for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
+        var renderQueueItem = app.project.renderQueue.item(index);
+        if (renderQueueItem == null) {
+            continue;
+        }
+
+        if (InvalidRenderQueueItemStatuses.indexOf(renderQueueItem.status) !== -1) {
+            // Status is in InvalidRenderQueueItemStatuses.
+            continue;
+        }
+
+        var item = listBox.add('item', index.toString());
+        populateListBoxItem(item, renderQueueItem, index);
+        // TODO: Value
+
+        uiSettingsState.create(item.compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage);
+    }
+
+    listBox.selection = null;
+}
+
 /**
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
@@ -181,6 +236,42 @@ function buildUI(thisObj) {
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
+    // Disable max CPU percentage textbox when multi frame rendering is disabled
+    function onMfrCheckBoxClicked() {
+        const isMfrChecked = mfrCheckBox.value;
+        var settingsStateValue = false
+        if (!isMfrChecked) {
+            maxCpuUsagePercentageTextBox.text = "N/A";
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+            settingsStateValue = false
+        } else {
+            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
+            settingsStateValue = true
+        }
+
+        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+        }
+    }
+    mfrCheckBox.onClick = onMfrCheckBoxClicked;
+
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem.numOutputModules === 1) {
+            const outputModule = renderQueueItem.outputModule(1).file;
+            if (outputModule != null) {
+                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                const extension = getFileExtension(outputFileNameNoRegex);
+                return isImageOutput(extension);
+            }
+        }
+        return false
+    }
+
+
     // Add Timeouts settings group
     const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
@@ -264,123 +355,18 @@ function buildUI(thisObj) {
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 
-    // Disable max CPU percentage textbox when multi frame rendering is disabled
-    function onMfrCheckBoxClicked() {
-        const isMfrChecked = mfrCheckBox.value;
-        var settingsStateValue = false
-        if (!isMfrChecked) {
-            maxCpuUsagePercentageTextBox.text = "N/A";
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-            settingsStateValue = false
-        } else {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
-            settingsStateValue = true
-        }
-
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
-        }
-    }
-    mfrCheckBox.onClick = onMfrCheckBoxClicked;
-
-    function isRenderQueueItemImageOutput(renderQueueItem) {
-        if (renderQueueItem.numOutputModules === 1) {
-            const outputModule = renderQueueItem.outputModule(1).file;
-            if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
+    // Check for duplicate names
+    function checkForInvalidCompositionNames(selection) {
+        const names = [];
+        const duplicateNames = [];
+        for (var i = 0; i < selection.length; i++) {
+            var selectionItem = selection[i];
+            var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
+            var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
+            if (names.indexOf(compName) !== -1) {
+                duplicateNames.push(renderQueueItem.comp.name);
             }
-        }
-        return false
-    }
-
-    // Add Timeouts settings group
-    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
-    timeoutsPanel.orientation = "column";
-    timeoutsPanel.alignment = ['fill', 'top'];
-    timeoutsPanel.alignChildren = ['left', 'center'];
-    timeoutsPanel.margins = 5;
-
-    // Task run timeout
-    const taskRunGroup = timeoutsPanel.add("group");
-    taskRunGroup.orientation = "row";
-    taskRunGroup.alignment = ['fill', 'top'];
-    taskRunGroup.alignChildren = ['left', 'center'];
-
-    const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-
-    const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
-    taskRunDaysInput.characters = 3;
-    taskRunDaysGroup.add("statictext", undefined, "days");
-
-    const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
-    taskRunHoursInput.characters = 3;
-    taskRunHoursGroup.add("statictext", undefined, "hours");
-
-    const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
-    taskRunMinutesInput.characters = 3;
-    taskRunMinutesGroup.add("statictext", undefined, "minutes");
-
-    // Function to validate timeout values
-    function validateTimeoutValues() {
-        // Check if all values are zero when checkbox is checked
-        if (taskRunCheckbox.value) {
-            var days = parseInt(taskRunDaysInput.text) || 0;
-            var hours = parseInt(taskRunHoursInput.text) || 0;
-            var minutes = parseInt(taskRunMinutesInput.text) || 0;
-
-            if (days === 0 && hours === 0 && minutes === 0) {
-                adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                // Set days back to default value of 2
-                taskRunDaysInput.text = "2";
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Add input validation and save values to settings
-    taskRunCheckbox.onClick = function() {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
-        if (this.value) {
-            validateTimeoutValues();
-        }
-    };
-
-    taskRunDaysInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
-        validateTimeoutValues();
-    };
-
-    taskRunHoursInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
-        validateTimeoutValues();
-    };
-
-    taskRunMinutesInput.onChange = function() {
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
-        validateTimeoutValues();
-    };
-
-    // If an image sequence was selected, enable frames per task textbox. Otherwise disable it.
-    function isFramesPerTaskEnabled(selection) {
-        if (selection == null) {
-            return false;
+            names.push(compName);
         }
         if (duplicateNames.length !== 0) {
             var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
@@ -401,10 +387,13 @@ function buildUI(thisObj) {
             if (mfrCheckBox.value) {
                 maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text)
             }
+            if (checkForInvalidCompositionNames(list.selection)) {
+                return
+            }
             if (taskRunCheckbox.value) {
-                SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
+                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
             } else {
-                SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
+                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
             }
             list.selection = null;
         }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -299,7 +299,6 @@ function buildUI(thisObj) {
     taskRunGroup.orientation = "row";
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
-
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
     taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
 

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -31,7 +31,7 @@ function buildUI(thisObj) {
     listGroup.alignment = ['fill', 'top'];
     listGroup.alignChildren = ['fill', 'top'];
     listGroup.orientation = "column";
-    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
+    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click, Command+Click (Mac), or Ctrl+Click (Windows) can be used to select multiple render queue items and group them together as a single job submission", {
         multiline: true
     });
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
@@ -49,7 +49,7 @@ function buildUI(thisObj) {
     controlsPanel.alignment = ['fill', 'top'];
 
     // Container with settings to modify comp-specific settings
-    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Precomp-Specific Settings");
+    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Render Queue Item Settings");
     perCompSettingsGroup.orientation = "column";
     perCompSettingsGroup.alignment = ['fill', 'top'];
     perCompSettingsGroup.alignChildren = ['left', 'top'];

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -22,10 +22,7 @@ function populateListBoxItem(item, renderQueueItem, index) {
 
 function refreshList(listBox, uiSettingsState) {
     listBox.removeAll();
-    const framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK) || "50"
-    const multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)
-    const maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)
-
+   
     const InvalidRenderQueueItemStatuses = [
         RQItemStatus.RENDERING,
         RQItemStatus.WILL_CONTINUE,
@@ -48,7 +45,7 @@ function refreshList(listBox, uiSettingsState) {
         populateListBoxItem(item, renderQueueItem, index);
         // TODO: Value
 
-        uiSettingsState.create(item.compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage);
+        uiSettingsState.create(item.compId);
     }
 
     listBox.selection = null;
@@ -157,7 +154,7 @@ function buildUI(thisObj) {
 
         maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
 
-        taskRunCheckbox.value = settings.taskRunTimeout()
+        taskRunCheckbox.value = settings.taskRunTimeoutEnabled()
         taskRunDaysInput.enabled = taskRunCheckbox.value
         taskRunDaysInput.text = settings.taskRunDays()
         taskRunHoursInput.enabled = taskRunCheckbox.value
@@ -196,22 +193,18 @@ function buildUI(thisObj) {
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
 
     function onFramesPerTaskChanged() {
-        const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
-        if (isNaN(newFramesPerTaskValue)) {
-            framesPerTaskTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
-        } else if (newFramesPerTaskValue > 9999) {
-            framesPerTaskTextBox.text = "9999";
-        } else {
-            // Need to reassign in case input string is a number followed my random characters
-            // since parseInt parses the first number it finds in a provided string.
-            framesPerTaskTextBox.text = newFramesPerTaskValue;
-        }
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
         if (list.selection == null) {
             return;
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
+            if (isNaN(newFramesPerTaskValue)){
+                framesPerTaskTextBox.text = uiSettingsState.get(selectionItem.compId).framesPerTask;
+            } else if (newFramesPerTaskValue > 9999) {
+                framesPerTaskTextBox.text = "9999"
+            } else {
+                framesPerTaskTextBox.text = newFramesPerTaskValue
+            }
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -225,7 +218,7 @@ function buildUI(thisObj) {
     mfrGroup.margins = 5;
 
     const mfrCheckBox = mfrGroup.add("checkbox", undefined, "Enable Multi-Frame Rendering");
-    mfrCheckBox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING) === "true";
+    mfrCheckBox.value = DEFAULT_MULTI_FRAME_RENDERING;
 
     const maxCpuUsagePercentageGroup = mfrGroup.add("group", undefined, "");
     maxCpuUsagePercentageGroup.orientation = "row";
@@ -240,21 +233,21 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.alignment = ['fill', 'top'];
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
+    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? DEFAULT_MAX_CPU_USAGE_PERCENTAGE : "N/A";
 
     function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+            maxCpuUsagePercentageTextBox.text = DEFAULT_MAX_CPU_USAGE_PERCENTAGE;
         } else {
             // Need to reassign in case input string is a number followed my random characters
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        const selectionItem = dcUtil.getSelection(list);
+        const selectionItem = dcUtil.getSelection(list)
         if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
+            var compId = selectionItem.compId;
+            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuPercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -262,22 +255,18 @@ function buildUI(thisObj) {
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
         const isMfrChecked = mfrCheckBox.value;
-        var settingsStateValue = false
-        if (!isMfrChecked) {
-            maxCpuUsagePercentageTextBox.text = "N/A";
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-        } else {
-            maxCpuUsagePercentageTextBox.text = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "true");
-            settingsStateValue = true
-        }
-
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
+            var compId = selectionItem.compId;
+            if (!isMfrChecked) {
+                maxCpuUsagePercentageTextBox.text = "N/A";
+                uiSettingsState.get(compId).setMultiFrameRendering(false);
+            } else {
+                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(compId).maxCpuUsagePercentage();
+                uiSettingsState.get(compId).setMultiFrameRendering(true);
+            }
         }
+        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
@@ -310,72 +299,82 @@ function buildUI(thisObj) {
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled;
 
     const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS));
+    const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, uiSettingsState.taskRunDays());
     taskRunDaysInput.characters = 3;
     taskRunDaysGroup.add("statictext", undefined, "days");
 
     const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS));
+    const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, uiSettingsState.taskRunHours());
     taskRunHoursInput.characters = 3;
     taskRunHoursGroup.add("statictext", undefined, "hours");
 
     const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
-    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES));
+    const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, uiSettingsState.taskRunMinutes());
     taskRunMinutesInput.characters = 3;
     taskRunMinutesGroup.add("statictext", undefined, "minutes");
 
     // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, dcUtil.toBooleanString(this.value));
+        uiSettingsState.setTaskRunTimeoutEnabled(this.value);
         if (this.value) {
-            dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
+            if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+                uiSettingsState.setTaskRunDays(DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS;
+                uiSettingsState.setTaskRunHours(DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_HOURS;
+                uiSettingsState.setTaskRunMinutes(DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_MINUTES;
+            }
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunTimeout(this.value)
-        }
+        uiSettingsState.setTaskRunTimeoutEnabled(this.value)
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunDays(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunDays(parseInt(this.text))
     }
     taskRunDaysInput.onChange = onTaskRunDaysChanged
 
     function onTaskRunHoursChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunHours(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunHours(parseInt(this.text))
     }
     taskRunHoursInput.onChange = onTaskRunHoursChanged
 
     function onTaskRunMinutesChanged() {
+        var old_text = this.text;
         this.text = this.text.replace(/[^0-9]/g, "");
         if (this.text === "") this.text = "0";
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, this.text);
-        dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text);
-
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(selectionItem.compId).setTaskRunMinutes(this.text)
+        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (isNaN(Number(old_text))) {
+                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+            } else {
+                this.text = old_text
+            }
         }
+        uiSettingsState.setTaskRunMinutes(parseInt(this.text))
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
 

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -1,24 +1,3 @@
-function populateListBoxItem(item, renderQueueItem, index) {
-    item.renderQueueIndex = index;
-    item.compId = renderQueueItem.comp.id;
-    item.subItems[0].text = renderQueueItem.comp.name;
-
-    var frameRange = dcUtil.calculateFrameRange(renderQueueItem);
-    var startFrame = frameRange.startFrame;
-    var endFrame = frameRange.endFrame;
-
-    item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
-    if (renderQueueItem.numOutputModules <= 0) {
-        item.subItems[2].text = "<not set>";
-    } else if (renderQueueItem.numOutputModules == 1) {
-        const outputFile = renderQueueItem.outputModule(1).file;
-        item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
-    } else {
-        item.subItems[2].text = "<multiple output modules>";
-    }
-}
-
-
 /**
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
@@ -97,13 +76,13 @@ function buildUI(thisObj) {
         if (selectionItem) {
             var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
             if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(selectionItem.compId).framesPerTask();
+                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).framesPerTask();
             }
             if (newFramesPerTaskValue > 9999) {
                 newFramesPerTaskValue = 9999;
             }
             framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(selectionItem.compId).setFramesPerTask(newFramesPerTaskValue);
+            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -144,8 +123,7 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var compId = selectionItem.compId;
-            uiSettingsState.get(compId).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
+            uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
         }
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
@@ -155,13 +133,13 @@ function buildUI(thisObj) {
         const isMfrChecked = mfrCheckBox.value;
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            var compId = selectionItem.compId;
+            var RQIID = dcUtil.getRQIID(selectionItem.renderQueueIndex);
             if (!isMfrChecked) {
                 maxCpuUsagePercentageTextBox.text = "N/A";
-                uiSettingsState.get(compId).setMultiFrameRendering(false);
+                uiSettingsState.get(RQIID).setMultiFrameRendering(false);
             } else {
-                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(compId).maxCpuUsagePercentage();
-                uiSettingsState.get(compId).setMultiFrameRendering(true);
+                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(RQIID).maxCpuUsagePercentage();
+                uiSettingsState.get(RQIID).setMultiFrameRendering(true);
             }
         }
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
@@ -346,7 +324,7 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
-            uiSettingsState.get(item.compId);
+            uiSettingsState.get(i);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -390,19 +368,22 @@ function buildUI(thisObj) {
             const selectionItem = selection[0];
             perCompSettingsGroup.enabled = true;
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-            framesPerTaskTextBox.enabled = imageOutput;
-            mfrCheckBox.enabled = true;
-            maxCpuUsagePercentageTextBox.enabled = true;
 
-            const settings = uiSettingsState.get(selectionItem.compId);
+            const settings = uiSettingsState.get(dcUtil.getRQIID(selectionItem.renderQueueIndex));
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return;
             }
 
-            framesPerTaskTextBox.text = settings.framesPerTask();
-            framesPerTaskTextBox.onChange();
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
+            if (imageOutput) {
+                framesPerTaskTextBox.text = settings.framesPerTask();
+                framesPerTaskTextBox.enabled = true;
+                framesPerTaskTextBox.onChange()
+            } else {
+                framesPerTaskTextBox.text = "Selection is not image sequence";
+                framesPerTaskTextBox.enabled = false;
+            }
             maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
             maxCpuUsagePercentageTextBox.onChange();
             mfrCheckBox.value = settings.multiFrameRendering();

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -281,6 +281,7 @@ function buildUI(thisObj) {
         });
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
+
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);
             if (rqi == null) {
@@ -311,6 +312,8 @@ function buildUI(thisObj) {
                 item.subItems[2].text = "<multiple output modules>";
             }
         }
+
+        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
 
         if (list != null) {
             listGroup.remove(list);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -219,13 +219,12 @@ function buildUI(thisObj) {
     onTaskRunCheckboxClicked();
 
     function onTaskRunDaysChanged() {
-        var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunDaysInput.text);
-        if (taskRunDaysInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunDaysInput.text);
+        if (taskRunDaysInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunDays(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunDays(newValue);
             }
         }
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
@@ -233,13 +232,12 @@ function buildUI(thisObj) {
     taskRunDaysInput.onChange = onTaskRunDaysChanged;
 
     function onTaskRunHoursChanged() {
-        var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunHoursInput.text);
-        if (taskRunHoursInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunHoursInput.text);
+        if (taskRunHoursInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunHours(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunHours(newValue);
             }
         }
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
@@ -247,13 +245,12 @@ function buildUI(thisObj) {
     taskRunHoursInput.onChange = onTaskRunHoursChanged;
 
     function onTaskRunMinutesChanged() {
-        var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        var new_value = parseInt(taskRunMinutesInput.text);
-        if (taskRunMinutesInput.text === "") new_value = 0;
+        var newValue = parseInt(taskRunMinutesInput.text);
+        if (taskRunMinutesInput.text === "") newValue = 0;
         if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (!isNaN(new_value)) {
-                uiSettingsState.setTaskRunMinutes(new_value);
+            if (!isNaN(newValue)) {
+                uiSettingsState.setTaskRunMinutes(newValue);
             }
         }
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -351,7 +351,7 @@ function buildUI(thisObj) {
             if (imageOutput) {
                 framesPerTaskTextBox.text = settings.framesPerTask();
                 framesPerTaskTextBox.enabled = true;
-                framesPerTaskTextBox.onChange()
+                framesPerTaskTextBox.onChange();
             } else {
                 framesPerTaskTextBox.text = "Selection is not image sequence";
                 framesPerTaskTextBox.enabled = false;

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -22,7 +22,7 @@ function populateListBoxItem(item, renderQueueItem, index) {
 
 function refreshList(listBox, uiSettingsState) {
     listBox.removeAll();
-   
+
     const InvalidRenderQueueItemStatuses = [
         RQItemStatus.RENDERING,
         RQItemStatus.WILL_CONTINUE,
@@ -198,14 +198,15 @@ function buildUI(thisObj) {
         }
         const selectionItem = dcUtil.getSelection(list);
         if (selectionItem) {
-            if (isNaN(newFramesPerTaskValue)){
-                framesPerTaskTextBox.text = uiSettingsState.get(selectionItem.compId).framesPerTask;
-            } else if (newFramesPerTaskValue > 9999) {
-                framesPerTaskTextBox.text = "9999"
-            } else {
-                framesPerTaskTextBox.text = newFramesPerTaskValue
+            var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
+            if (isNaN(newFramesPerTaskValue)) {
+                newFramesPerTaskValue = uiSettingsState.get(selectionItem.compId).framesPerTask();
             }
-            uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
+            if (newFramesPerTaskValue > 9999) {
+                newFramesPerTaskValue = 9999;
+            }
+            framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
+            uiSettingsState.get(selectionItem.compId).setFramesPerTask(newFramesPerTaskValue);
         }
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
@@ -318,65 +319,69 @@ function buildUI(thisObj) {
 
     // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
-        uiSettingsState.setTaskRunTimeoutEnabled(this.value);
-        if (this.value) {
-            if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        if (taskRunCheckbox.value) {
+            if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
                 uiSettingsState.setTaskRunDays(DEFAULT_TASK_RUN_TIMEOUT_DAYS);
                 taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS;
                 uiSettingsState.setTaskRunHours(DEFAULT_TASK_RUN_TIMEOUT_HOURS);
                 taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_HOURS;
                 uiSettingsState.setTaskRunMinutes(DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
                 taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_MINUTES;
+            } else {
+                onTaskRunDaysChanged();
+                onTaskRunHoursChanged();
+                OnTaskRunMinutesCHanged();
             }
         }
-        uiSettingsState.setTaskRunTimeoutEnabled(this.value)
+        uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
     }
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunDaysInput.text;
+        taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
+        if (taskRunDaysInput.text === "") taskRunDaysInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunDaysInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunDays(parseInt(this.text))
+        uiSettingsState.setTaskRunDays(parseInt(taskRunDaysInput.text))
     }
     taskRunDaysInput.onChange = onTaskRunDaysChanged
 
     function onTaskRunHoursChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunHoursInput.text;
+        taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
+        if (taskRunHoursInput.text === "") taskRunHoursInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunHoursInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunHours(parseInt(this.text))
+        uiSettingsState.setTaskRunHours(parseInt(taskRunHoursInput.text))
     }
     taskRunHoursInput.onChange = onTaskRunHoursChanged
 
     function onTaskRunMinutesChanged() {
-        var old_text = this.text;
-        this.text = this.text.replace(/[^0-9]/g, "");
-        if (this.text === "") this.text = "0";
-        if (!dcUtil.validateTimeoutValues(this.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+        var old_text = taskRunMinutesInput.text;
+        taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
+        if (taskRunMinutesInput.text === "") taskRunMinutesInput.text = "0";
+        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
             if (isNaN(Number(old_text))) {
-                this.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS 
+                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
             } else {
-                this.text = old_text
+                taskRunMinutesInput.text = old_text
             }
         }
-        uiSettingsState.setTaskRunMinutes(parseInt(this.text))
+        uiSettingsState.setTaskRunMinutes(parseInt(taskRunMinutesInput.text))
     }
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged
+
 
     // Check for duplicate names
     function checkForInvalidCompositionNames(selection) {

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -279,8 +279,8 @@ function buildUI(thisObj) {
             columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
             columnWidths: [32, 160, 120, 240],
         });
-        newList.preferredSize.height = 400
-        newList.preferredSize.width = 500
+        newList.preferredSize.height = 200;
+        newList.preferredSize.width = 500;
 
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
             var rqi = app.project.renderQueue.item(i);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -330,7 +330,7 @@ function buildUI(thisObj) {
             } else {
                 onTaskRunDaysChanged();
                 onTaskRunHoursChanged();
-                OnTaskRunMinutesChanged();
+                onTaskRunMinutesChanged();
             }
         }
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
@@ -338,49 +338,46 @@ function buildUI(thisObj) {
     taskRunCheckbox.onClick = onTaskRunCheckboxClicked
 
     function onTaskRunDaysChanged() {
-        var old_text = taskRunDaysInput.text;
+        var original_value = uiSettingsState.taskRunDays();
         taskRunDaysInput.text = taskRunDaysInput.text.replace(/[^0-9]/g, "");
-        if (taskRunDaysInput.text === "") taskRunDaysInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunDaysInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunDaysInput.text = old_text
+        var new_value = parseInt(taskRunDaysInput.text)
+        if (taskRunDaysInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunDays(new_value)
             }
         }
-        uiSettingsState.setTaskRunDays(parseInt(taskRunDaysInput.text))
+        taskRunDaysInput.text = uiSettingsState.taskRunDays();
     }
-    taskRunDaysInput.onChange = onTaskRunDaysChanged
+    taskRunDaysInput.onChange = onTaskRunDaysChanged;
 
     function onTaskRunHoursChanged() {
-        var old_text = taskRunHoursInput.text;
+        var original_value = uiSettingsState.taskRunHours();
         taskRunHoursInput.text = taskRunHoursInput.text.replace(/[^0-9]/g, "");
-        if (taskRunHoursInput.text === "") taskRunHoursInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunHoursInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunHoursInput.text = old_text
+        var new_value = parseInt(taskRunHoursInput.text)
+        if (taskRunHoursInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunHours(new_value)
             }
         }
-        uiSettingsState.setTaskRunHours(parseInt(taskRunHoursInput.text))
+        taskRunHoursInput.text = uiSettingsState.taskRunHours();
     }
-    taskRunHoursInput.onChange = onTaskRunHoursChanged
+    taskRunHoursInput.onChange = onTaskRunHoursChanged;
 
     function onTaskRunMinutesChanged() {
-        var old_text = taskRunMinutesInput.text;
+        var original_value = uiSettingsState.taskRunMinutes();
         taskRunMinutesInput.text = taskRunMinutesInput.text.replace(/[^0-9]/g, "");
-        if (taskRunMinutesInput.text === "") taskRunMinutesInput.text = "0";
-        if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
-            if (isNaN(Number(old_text))) {
-                taskRunMinutesInput.text = DEFAULT_TASK_RUN_TIMEOUT_DAYS
-            } else {
-                taskRunMinutesInput.text = old_text
+        var new_value = parseInt(taskRunMinutesInput.text)
+        if (taskRunMinutesInput.text === "") new_value = 0;
+        if (dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
+            if (!isNaN(new_value)) {
+                uiSettingsState.setTaskRunMinutes(new_value)
             }
         }
-        uiSettingsState.setTaskRunMinutes(parseInt(taskRunMinutesInput.text))
+        taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
     }
-    taskRunMinutesInput.onChange = onTaskRunMinutesChanged
+    taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
 
     // Check for duplicate names
@@ -479,7 +476,7 @@ function buildUI(thisObj) {
         function onSelectionChange() {
             const selection = list.selection;
             perCompSettingsGroup.enabled = false;
-            
+
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = ""

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -84,9 +84,15 @@ function buildUI(thisObj) {
     }
     const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
     const listGroup = root.add("panel", undefined, "");
-    listGroup.alignment = ['fill', 'fill'];
-    listGroup.alignChildren = ['fill', 'fill']
-
+    listGroup.alignment = ['fill', 'top'];
+    listGroup.alignChildren = ['fill', 'top']
+    listGroup.orientation = "column"
+    var multiCompLabel = listGroup.add("statictext", undefined, "Shift+Click or Ctrl+Click can be used to select multiple precomps and group them together as a single job submission", {
+        multiline: true
+    })
+    // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
+    multiCompLabel.maximumSize.height = 30;
+    multiCompLabel.alignment = ['fill', 'top'];
     var list = listGroup.add("listbox", undefined, "", {
         multiselect: true,
         numberOfColumns: 4,
@@ -169,14 +175,14 @@ function buildUI(thisObj) {
     const controlsPanel = controlsGroup.add("panel", undefined, "");
     controlsPanel.alignment = ['fill', 'top'];
 
-    // Container with all settings to modify job submission
-    const settingsGroup = controlsPanel.add("group", undefined, "");
-    settingsGroup.orientation = "column";
-    settingsGroup.alignment = ['fill', 'top'];
-    settingsGroup.alignChildren = ['left', 'top'];
+    // Container with settings to modify comp-specific settings
+    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Precomp-Specific Settings");
+    perCompSettingsGroup.orientation = "column";
+    perCompSettingsGroup.alignment = ['fill', 'top'];
+    perCompSettingsGroup.alignChildren = ['left', 'top'];
 
     // Setting up frame per task GUI
-    const framesPerTaskGroup = settingsGroup.add("group", undefined, "");
+    const framesPerTaskGroup = perCompSettingsGroup.add("group", undefined, "");
     framesPerTaskGroup.orientation = "row";
     framesPerTaskGroup.alignment = ['fill', 'top'];
     framesPerTaskGroup.alignChildren = ['left', 'center'];
@@ -212,7 +218,7 @@ function buildUI(thisObj) {
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
-    const mfrGroup = settingsGroup.add("group", undefined, "");
+    const mfrGroup = perCompSettingsGroup.add("group", undefined, "");
     mfrGroup.orientation = "column";
     mfrGroup.alignment = ['fill', 'top'];
     mfrGroup.alignChildren = ['left', 'center'];
@@ -287,13 +293,16 @@ function buildUI(thisObj) {
         return false
     }
 
-
+    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings")
+    globalSettingsGroup.orientation = "column";
+    globalSettingsGroup.alignment = ['fill', 'top'];
+    globalSettingsGroup.alignChildren = ['left', 'top'];
     // Add Timeouts settings group
-    const timeoutsPanel = settingsGroup.add("panel", undefined, "Timeouts");
+    const timeoutsPanel = globalSettingsGroup.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
     timeoutsPanel.alignment = ['fill', 'top'];
     timeoutsPanel.alignChildren = ['left', 'center'];
-    timeoutsPanel.margins = 5;
+    timeoutsPanel.margins = 10;
 
     // Task run timeout
     const taskRunGroup = timeoutsPanel.add("group");

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -424,11 +424,7 @@ function buildUI(thisObj) {
             if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }
-            if (taskRunCheckbox.value) {
-                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
-            } else {
-                SubmitSelection(list.selection, uiSettingsState, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
-            }
+            SubmitSelection(list.selection, uiSettingsState);
             list.selection = null;
         }
     }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -300,24 +300,26 @@ function buildUI(thisObj) {
     taskRunGroup.alignment = ['fill', 'top'];
     taskRunGroup.alignChildren = ['left', 'center'];
     const taskRunCheckbox = taskRunGroup.add("checkbox", undefined, "Task run");
-    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled;
+    taskRunCheckbox.value = uiSettingsState.taskRunTimeoutEnabled();
 
     const taskRunDaysGroup = taskRunGroup.add("group", undefined, "");
     const taskRunDaysInput = taskRunDaysGroup.add("edittext", undefined, uiSettingsState.taskRunDays());
     taskRunDaysInput.characters = 3;
     taskRunDaysGroup.add("statictext", undefined, "days");
+    taskRunDaysInput.text = uiSettingsState.taskRunDays();
 
     const taskRunHoursGroup = taskRunGroup.add("group", undefined, "");
     const taskRunHoursInput = taskRunHoursGroup.add("edittext", undefined, uiSettingsState.taskRunHours());
     taskRunHoursInput.characters = 3;
     taskRunHoursGroup.add("statictext", undefined, "hours");
+    taskRunHoursInput.text = uiSettingsState.taskRunHours();
 
     const taskRunMinutesGroup = taskRunGroup.add("group", undefined, "");
     const taskRunMinutesInput = taskRunMinutesGroup.add("edittext", undefined, uiSettingsState.taskRunMinutes());
     taskRunMinutesInput.characters = 3;
     taskRunMinutesGroup.add("statictext", undefined, "minutes");
+    taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
 
-    // Add input validation and save values to settings
     function onTaskRunCheckboxClicked() {
         if (taskRunCheckbox.value) {
             if (!dcUtil.validateTimeoutValues(taskRunCheckbox.value, taskRunDaysInput.text, taskRunHoursInput.text, taskRunMinutesInput.text)) {
@@ -333,9 +335,13 @@ function buildUI(thisObj) {
                 onTaskRunMinutesChanged();
             }
         }
+        taskRunDaysInput.enabled = taskRunCheckbox.value;
+        taskRunHoursInput.enabled = taskRunCheckbox.value;
+        taskRunMinutesInput.enabled = taskRunCheckbox.value;
         uiSettingsState.setTaskRunTimeoutEnabled(taskRunCheckbox.value)
     }
-    taskRunCheckbox.onClick = onTaskRunCheckboxClicked
+    taskRunCheckbox.onClick = onTaskRunCheckboxClicked;
+    onTaskRunCheckboxClicked();
 
     function onTaskRunDaysChanged() {
         var original_value = uiSettingsState.taskRunDays();

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -2,32 +2,32 @@
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
 function buildUI(thisObj) {
-    var submitterPanel = (thisObj instanceof Panel) ? thisObj : new Window("palette", "Submit to AWS Deadline Cloud", undefined, {
+    const submitterPanel = (thisObj instanceof Panel) ? thisObj : new Window("palette", "Submit to AWS Deadline Cloud", undefined, {
         resizable: true
     });
 
-    var uiSettingsState = new UiSettingsState();
+    const uiSettingsState = new UiSettingsState();
 
-    var root = submitterPanel.add("group");
+    const root = submitterPanel.add("group");
     root.orientation = "column";
     root.alignment = ['fill', 'fill'];
     root.alignChildren = ['fill', 'top']
-    var logoGroup = root.add("group");
+    const logoGroup = root.add("group");
     logoGroup.alignment = 'left';
     logoGroup.add("image", undefined, logoData());
-    var logoText = logoGroup.add("statictext", undefined, "AWS Deadline Cloud");
-    var arialBold24Font = ScriptUI.newFont("Arial", ScriptUI.FontStyle.BOLD, 64);
+    const logoText = logoGroup.add("statictext", undefined, "AWS Deadline Cloud");
+    const arialBold24Font = ScriptUI.newFont("Arial", ScriptUI.FontStyle.BOLD, 64);
     logoText.graphics.font = arialBold24Font;
-    var headerButtonGroup = root.add("group");
-    var focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
+    const headerButtonGroup = root.add("group");
+    const focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
     focusRenderQueueButton.onClick = function() {
         // we quickly toggle the window to make sure it gains focus
         // sometimes this causes a flicker
         app.project.renderQueue.showWindow(false);
         app.project.renderQueue.showWindow(true);
     }
-    var refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
-    var listGroup = root.add("panel", undefined, "");
+    const refreshButton = headerButtonGroup.add("button", undefined, "Refresh");
+    const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
     var list = null;
@@ -57,6 +57,7 @@ function buildUI(thisObj) {
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
+
     function onFramesPerTaskChanged() {
         const newFramesPerTaskValue = Math.abs(parseInt(framesPerTaskTextBox.text));
         if (isNaN(newFramesPerTaskValue)) {
@@ -69,8 +70,8 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = newFramesPerTaskValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }
     }
@@ -100,6 +101,7 @@ function buildUI(thisObj) {
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
     maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
     maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE) : "N/A";
+
     function onMaxCpuUsagePercentageChanged() {
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
         if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
@@ -110,8 +112,8 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, maxCpuUsagePercentageTextBox.text);
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setMaxCpuUsagePercentage(maxCpuUsagePercentageTextBox.text)
         }
     }
@@ -132,8 +134,8 @@ function buildUI(thisObj) {
         }
 
         maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
-        for (var s=0;s<list.selection.length;s++) {
-            var selectionItem = list.selection[s];
+        for (var s = 0; s < list.selection.length; s++) {
+            const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setMultiFrameRendering(settingsStateValue)
         }
     }
@@ -141,10 +143,10 @@ function buildUI(thisObj) {
 
     function isRenderQueueItemImageOutput(renderQueueItem) {
         if (renderQueueItem.numOutputModules === 1) {
-            var outputModule = renderQueueItem.outputModule(1).file;
+            const outputModule = renderQueueItem.outputModule(1).file;
             if (outputModule != null) {
-                var outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                var extension = getFileExtension(outputFileNameNoRegex);
+                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
+                const extension = getFileExtension(outputFileNameNoRegex);
                 return isImageOutput(extension);
             }
         }
@@ -237,7 +239,7 @@ function buildUI(thisObj) {
         }
         if (duplicateNames.length !== 0) {
             var message = "Selected submission items must have unique names. Found (" + duplicateNames.length * 2 + ") compositions with the same name: "
-            for (var i=0;i<duplicateNames.length;i++) {
+            for (var i = 0; i < duplicateNames.length; i++) {
                 message = message + "\n\t" + duplicateNames[i];
             }
             adcAlert(message, true)
@@ -246,7 +248,7 @@ function buildUI(thisObj) {
         return false
     }
 
-    var submitButton = controlsGroup.add("button", undefined, "Submit");
+    const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function() {
         if (getPythonExecutable()) {
             const multiFrameRendering = mfrCheckBox.value ? "ON" : "OFF";
@@ -256,8 +258,7 @@ function buildUI(thisObj) {
             }
             if (taskRunCheckbox.value) {
                 SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, parseInt(taskRunDaysInput.text), parseInt(taskRunHoursInput.text), parseInt(taskRunMinutesInput.text));
-            }
-            else {
+            } else {
                 SubmitSelection(list.selection, parseInt(framesPerTaskTextBox.text), multiFrameRendering, maxCpuUsagePercentage, 2, 0, 0);
             }
             list.selection = null;
@@ -267,8 +268,8 @@ function buildUI(thisObj) {
     submitButton.enabled = false;
 
     function updateList() {
-        var bounds = list == null ? undefined : list.bounds;
-        var newList = listGroup.add("listbox", bounds, "", {
+        const bounds = list == null ? undefined : list.bounds;
+        const newList = listGroup.add("listbox", bounds, "", {
             multiselect: true,
             numberOfColumns: 4,
             showHeaders: true,
@@ -278,28 +279,30 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 400
         newList.preferredSize.width = 500
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            var rqi = app.project.renderQueue.item(i);
+            const rqi = app.project.renderQueue.item(i);
             if (rqi == null) {
                 continue;
             }
             if (rqi.status == RQItemStatus.RENDERING || rqi.status == RQItemStatus.WILL_CONTINUE || rqi.status == RQItemStatus.USER_STOPPED || rqi.status == RQItemStatus.ERR_STOPPED || rqi.status == RQItemStatus.DONE) {
                 continue;
             }
-            var item = newList.add('item', i.toString());
+            const item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             // Create a default entry for each comp as needed.
             uiSettingsState.get(item.compId)
             item.subItems[0].text = rqi.comp.name;
+
             // Calculate frame range using the utility function
             var frameRange = dcUtil.calculateFrameRange(rqi);
             var startFrame = frameRange.startFrame;
             var endFrame = frameRange.endFrame;
+
             item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";
             } else if (rqi.numOutputModules == 1) {
-                var outputFile = rqi.outputModule(1).file;
+                const outputFile = rqi.outputModule(1).file;
                 item.subItems[2].text = outputFile == null ? "<not set>" : outputFile.fsName;
             } else {
                 item.subItems[2].text = "<multiple output modules>";
@@ -312,7 +315,7 @@ function buildUI(thisObj) {
         list = newList;
 
         function onSelectionChange() {
-            var selection = list.selection;
+            const selection = list.selection;
             if (selection == null) {
                 updateList();
                 framesPerTaskTextBox.text = "";
@@ -330,16 +333,16 @@ function buildUI(thisObj) {
             if (selection.length !== 1) {
                 return
             }
-            var selectionItem = selection[0]
+            const selectionItem = selection[0]
             logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-            var imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
             framesPerTaskTextBox.enabled = imageOutput
             mfrCheckBox.enabled = true
             maxCpuUsagePercentageTextBox.enabled = true
 
             framesPerTaskTextBox.text = selectionItem.subItems[1].text
 
-            var settings = uiSettingsState.get(selectionItem.compId)
+            const settings = uiSettingsState.get(selectionItem.compId)
             if (settings === undefined) {
                 logger.warning("Could not find settings for : " + selectionItem.compId);
                 return
@@ -358,8 +361,8 @@ function buildUI(thisObj) {
 
     updateList();
     if (list.selection != null && list.selection.length === 1) {
-        var selectionItem = list.selection[0]
-        var renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
+        const selectionItem = list.selection[0]
+        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
     refreshButton.onClick = updateList;

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -19,37 +19,6 @@ function populateListBoxItem(item, renderQueueItem, index) {
 }
 
 
-function refreshList(listBox, uiSettingsState) {
-    listBox.removeAll();
-
-    const InvalidRenderQueueItemStatuses = [
-        RQItemStatus.RENDERING,
-        RQItemStatus.WILL_CONTINUE,
-        RQItemStatus.USER_STOPPED,
-        RQItemStatus.ERR_STOPPED,
-        RQItemStatus.DONE
-    ];
-    for (var index = 1; index <= app.project.renderQueue.numItems; index++) {
-        var renderQueueItem = app.project.renderQueue.item(index);
-        if (renderQueueItem == null) {
-            continue;
-        }
-
-        if (InvalidRenderQueueItemStatuses.indexOf(renderQueueItem.status) !== -1) {
-            // Status is in InvalidRenderQueueItemStatuses.
-            continue;
-        }
-
-        var item = listBox.add('item', index.toString());
-        populateListBoxItem(item, renderQueueItem, index);
-        // TODO: Value
-
-        uiSettingsState.create(item.compId);
-    }
-
-    listBox.selection = null;
-}
-
 /**
  * Builds the Script UI for the Deadline Cloud Submitter
  **/
@@ -89,80 +58,9 @@ function buildUI(thisObj) {
     // Label height needs to be set manually because ExtendScript does not accurately calculate the height of multiline text objects.
     multiCompLabel.maximumSize.height = 30;
     multiCompLabel.alignment = ['fill', 'top'];
-    var list = listGroup.add("listbox", undefined, "", {
-        multiselect: true,
-        numberOfColumns: 4,
-        showHeaders: true,
-        columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
-        columnWidths: [32, 160, 120, 240],
-    });
-    list.preferredSize.height = 400;
-    list.preferredSize.width = 500;
-
-    function onSelectionChange() {
-        const selection = list.selection;
-        if (selection == null) {
-            refreshList(list, uiSettingsState);
-            framesPerTaskTextBox.text = "";
-            return;
-        }
-        submitButton.enabled = true;
-        submitButton.active = false;
-        submitButton.active = true;
-
-        // Disable everything
-        framesPerTaskTextBox.enabled = false;
-        mfrCheckBox.enabled = false;
-        maxCpuUsagePercentageTextBox.enabled = false;
-        taskRunCheckbox.enabled = false;
-        taskRunDaysInput.enabled = false;
-        taskRunHoursInput.enabled = false;
-        taskRunMinutesInput.enabled = false;
-
-        if (selection.length !== 1) {
-            return;
-        }
-        const selectionItem = selection[0];
-        logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-        framesPerTaskTextBox.enabled = imageOutput;
-        mfrCheckBox.enabled = true;
-        maxCpuUsagePercentageTextBox.enabled = true;
-        taskRunCheckbox.enabled = true;
-        taskRunDaysInput.enabled = true;
-        taskRunHoursInput.enabled = true;
-        taskRunMinutesInput.enabled = true;
-
-        logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
-        framesPerTaskTextBox.text = selectionItem.subItems[1].text;
-
-        const settings = uiSettingsState.get(selectionItem.compId);
-        if (settings === undefined) {
-            logger.warning("Could not find settings for : " + selectionItem.compId);
-            return;
-        }
-
-        if (imageOutput === true) {
-            logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
-            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text;
-        }
-        logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
-        mfrCheckBox.value = settings.multiFrameRendering();
-        logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
-        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
-
-        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-
-        taskRunCheckbox.value = settings.taskRunTimeoutEnabled();
-        taskRunDaysInput.enabled = taskRunCheckbox.value;
-        taskRunDaysInput.text = settings.taskRunDays();
-        taskRunHoursInput.enabled = taskRunCheckbox.value;
-        taskRunHoursInput.text = settings.taskRunHours();
-        taskRunMinutesInput.enabled = taskRunCheckbox.value;
-        taskRunMinutesInput.text = settings.taskRunMinutes();
-    }
-
-    list.onChange = onSelectionChange;
+    // The list can't be populated until everything else is defined but we still need the variable set
+    // So it can be referenced by other UI elements
+    var list = null;
 
     const controlsGroup = root.add("group", undefined, "");
     controlsGroup.orientation = 'column';
@@ -510,20 +408,19 @@ function buildUI(thisObj) {
             mfrCheckBox.value = settings.multiFrameRendering();
             mfrCheckBox.onClick();
         }
-        onSelectionChange();
         list.onChange = onSelectionChange;
         list.selection = null;
+        onSelectionChange();
     }
 
     updateList();
-    refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
         const selectionItem = list.selection[0];
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
     refreshButton.onClick = function() {
-        refreshList(list, uiSettingsState);
+        updateList();
     }
 
     submitterPanel.layout.layout(true);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -418,6 +418,9 @@ function buildUI(thisObj) {
             if (mfrCheckBox.value) {
                 maxCpuUsagePercentage = parseInt(maxCpuUsagePercentageTextBox.text);
             }
+            if (list.selection === null) {
+                return;
+            }
             if (checkForInvalidCompositionNames(list.selection)) {
                 return;
             }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -486,11 +486,13 @@ function buildUI(thisObj) {
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = "";
 
-            submitButton.enabled = true;
-            submitButton.active = false;
-            submitButton.active = true;
+            if (selection === null) {
+                submitButton.enabled = false;
+            } else {
+                submitButton.enabled = true;
+            }
 
-            if (selection == null || selection.length !== 1) {
+            if (selection === null || selection.length !== 1) {
                 return;
             }
             const selectionItem = selection[0];

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -111,6 +111,10 @@ function buildUI(thisObj) {
         framesPerTaskTextBox.enabled = false
         mfrCheckBox.enabled = false
         maxCpuUsagePercentageTextBox.enabled = false
+        taskRunCheckbox.enabled = false
+        taskRunDaysInput.enabled = false
+        taskRunHoursInput.enabled = false
+        taskRunMinutesInput.enabled = false
 
         if (selection.length !== 1) {
             return
@@ -121,6 +125,10 @@ function buildUI(thisObj) {
         framesPerTaskTextBox.enabled = imageOutput
         mfrCheckBox.enabled = true
         maxCpuUsagePercentageTextBox.enabled = true
+        taskRunCheckbox.enabled = true
+        taskRunDaysInput.enabled = true
+        taskRunHoursInput.enabled = true
+        taskRunMinutesInput.enabled = true
 
         logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
         framesPerTaskTextBox.text = selectionItem.subItems[1].text
@@ -141,6 +149,14 @@ function buildUI(thisObj) {
         maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
 
         maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+
+        taskRunCheckbox.value = settings.taskRunTimeout()
+        taskRunDaysInput.enabled = taskRunCheckbox.value
+        taskRunDaysInput.text = settings.taskRunDays()
+        taskRunHoursInput.enabled = taskRunCheckbox.value
+        taskRunHoursInput.text = settings.taskRunHours()
+        taskRunMinutesInput.enabled = taskRunCheckbox.value
+        taskRunMinutesInput.text = settings.taskRunMinutes()
     }
 
     list.onChange = onSelectionChange;

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -68,6 +68,7 @@ function buildUI(thisObj) {
         mfrCheckBox.enabled = true
         maxCpuUsagePercentageTextBox.enabled = true
 
+        logger.debug("    Setting framesPerTaskTextBox.text to: " + selectionItem.subItems[1].text);
         framesPerTaskTextBox.text = selectionItem.subItems[1].text
 
         const settings = uiSettingsState.get(selectionItem.compId)
@@ -76,9 +77,14 @@ function buildUI(thisObj) {
             return
         }
 
-        framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+        if (imageOutput === true) {
+            logger.debug("    Setting framesPerTaskTextBox.text to: " + (settings.framesPerTask() || selectionItem.subItems[1].text));
+            framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+        }
+        logger.debug("    Setting mfrCheckBox.value to: " + settings.multiFrameRendering());
         mfrCheckBox.value = settings.multiFrameRendering()
-        maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
+        logger.debug("    Setting maxCpuUsagePercentageTextBox.text to: " + settings.maxCpuUsagePercentage());
+        maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage()
 
         maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
     }
@@ -125,6 +131,9 @@ function buildUI(thisObj) {
         }
         app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, framesPerTaskTextBox.text);
         for (var s = 0; s < list.selection.length; s++) {
+            if (list.selection == null) {
+                return;
+            }
             const selectionItem = list.selection[s];
             uiSettingsState.get(selectionItem.compId).setFramesPerTask(framesPerTaskTextBox.text)
         }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -30,7 +30,61 @@ function buildUI(thisObj) {
     const listGroup = root.add("panel", undefined, "");
     listGroup.alignment = ['fill', 'fill'];
     listGroup.alignChildren = ['fill', 'fill']
-    var list = null;
+
+    const bounds = list == null ? undefined : list.bounds;
+    var list = listGroup.add("listbox", bounds, "", {
+        multiselect: true,
+        numberOfColumns: 4,
+        showHeaders: true,
+        columnTitles: ['#', 'Name', 'Frames', 'Output Path'],
+        columnWidths: [32, 160, 120, 240],
+    });
+    list.preferredSize.height = 400;
+    list.preferredSize.width = 500;
+
+    function onSelectionChange() {
+        const selection = list.selection;
+        if (selection == null) {
+            refreshList(list, uiSettingsState);
+            framesPerTaskTextBox.text = "";
+            return;
+        }
+        submitButton.enabled = true;
+        submitButton.active = false;
+        submitButton.active = true;
+
+        // Disable everything
+        framesPerTaskTextBox.enabled = false
+        mfrCheckBox.enabled = false
+        maxCpuUsagePercentageTextBox.enabled = false
+
+        if (selection.length !== 1) {
+            return
+        }
+        const selectionItem = selection[0]
+        logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
+        const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex))
+        framesPerTaskTextBox.enabled = imageOutput
+        mfrCheckBox.enabled = true
+        maxCpuUsagePercentageTextBox.enabled = true
+
+        framesPerTaskTextBox.text = selectionItem.subItems[1].text
+
+        const settings = uiSettingsState.get(selectionItem.compId)
+        if (settings === undefined) {
+            logger.warning("Could not find settings for : " + selectionItem.compId);
+            return
+        }
+
+        framesPerTaskTextBox.text = settings.framesPerTask() || selectionItem.subItems[1].text
+        mfrCheckBox.value = settings.multiFrameRendering()
+        maxCpuUsagePercentageTextBox.value = settings.maxCpuUsagePercentage()
+
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value
+    }
+
+    list.onChange = onSelectionChange;
+
     const controlsGroup = root.add("group", undefined, "");
     controlsGroup.orientation = 'column';
     controlsGroup.alignment = ['fill', 'bottom'];
@@ -360,12 +414,15 @@ function buildUI(thisObj) {
     }
 
     updateList();
+    refreshList(list, uiSettingsState);
     if (list.selection != null && list.selection.length === 1) {
         const selectionItem = list.selection[0]
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex)
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem)
     }
-    refreshButton.onClick = updateList;
+    refreshButton.onClick = function() {
+        refreshList(list, uiSettingsState);
+    }
 
     submitterPanel.layout.layout(true);
 

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -1,0 +1,40 @@
+function UiSettingsState() {
+    this.settings = {}
+}
+function UiSettingsStore(name) {
+    this.name = name;
+    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+
+    this.framesPerTask = function () {
+        return this._framesPerTask
+    }
+    this.setFramesPerTask = function (value) {
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        this._framesPerTask = value
+    }
+
+    this.multiFrameRendering = function () {
+        return this._multiFrameRendering
+    }
+    this.setMultiFrameRendering = function (value) {
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        this._multiFrameRendering = value
+    }
+
+    this.maxCpuUsagePercentage = function () {
+        return this._maxCpuUsagePercentage
+    }
+    this.setMaxCpuUsagePercentage = function (value) {
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
+        this._maxCpuUsagePercentage = value
+    }
+}
+
+UiSettingsState.prototype.get = function(compId) {
+    if (!this.settings[compId]) {
+        this.settings[compId] = new UiSettingsStore(compId)
+    }
+    return this.settings[compId]
+}

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -32,6 +32,24 @@ function UiSettingsStore(name) {
     }
 }
 
+UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+    if (!this.settings[compId]) {
+        this.settings[compId] = new UiSettingsStore(compId)
+    }
+    if (framesPerTask === undefined) {
+        framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+    }
+    if (multiFrameRendering === undefined) {
+        multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    }
+    if (maxCpuUsagePercentage === undefined) {
+        maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+    }
+    this.settings[compId].setFramesPerTask(framesPerTask);
+    this.settings[compId].setMultiFrameRendering(multiFrameRendering);
+    this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+}
+
 UiSettingsState.prototype.get = function(compId) {
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId)

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -10,6 +10,15 @@ function UiSettingsStore(name) {
     // _maxCpuUsagePercentage: string
     this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
 
+    // _taskRunTimeout: bool
+    this._taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    // _taskRunDays: string
+    this._taskRunDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
+    // _taskRunHours: string
+    this._taskRunHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
+    // _taskRunMinutes: string
+    this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
+
     this.framesPerTask = function () {
         return this._framesPerTask
     }
@@ -33,9 +42,41 @@ function UiSettingsStore(name) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
         this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
+
+    this.taskRunTimeout = function () {
+        return this._taskRunTimeout
+    }
+    this.setTaskRunTimeout = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
+        this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunDays = function () {
+        return this._taskRunDays
+    }
+    this.setTaskRunDays = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
+        this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunHours = function () {
+        return this._taskRunHours
+    }
+    this.setTaskRunHours = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
+        this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
+    }
+
+    this.taskRunMinutes = function () {
+        return this._taskRunMinutes
+    }
+    this.setTaskRunMinutes = function (value) {
+        logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
+        this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
+    }
 }
 
-UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId)
     }
@@ -48,9 +89,26 @@ UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRe
     if (maxCpuUsagePercentage === undefined) {
         maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
     }
+    if (taskRunTimeout === undefined) {
+        taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
+    }
+    if (taskRunTimeoutDays === undefined) {
+        taskRunTimeoutDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
+    }
+    if (taskRunTimeoutHours === undefined) {
+        taskRunTimeoutHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
+    }
+    if (taskRunTimeoutMinutes === undefined) {
+        taskRunTimeoutMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
+    }
+
     this.settings[compId].setFramesPerTask(framesPerTask);
     this.settings[compId].setMultiFrameRendering(multiFrameRendering);
     this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+    this.settings[compId].setTaskRunTimeout(taskRunTimeout);
+    this.settings[compId].setTaskRunDays(taskRunTimeoutDays);
+    this.settings[compId].setTaskRunHours(taskRunTimeoutHours);
+    this.settings[compId].setTaskRunMinutes(taskRunTimeoutMinutes);
 }
 
 UiSettingsState.prototype.get = function(compId) {

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -4,7 +4,7 @@ function UiSettingsState() {
 function UiSettingsStore(name) {
     this.name = name;
     // _framesPerTask: string
-    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
     // _multiFrameRendering: bool
     this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
     // _maxCpuUsagePercentage: string

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -3,8 +3,11 @@ function UiSettingsState() {
 }
 function UiSettingsStore(name) {
     this.name = name;
+    // _framesPerTask: string
     this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);;
+    // _multiFrameRendering: bool
     this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    // _maxCpuUsagePercentage: string
     this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
 
     this.framesPerTask = function () {
@@ -12,7 +15,7 @@ function UiSettingsStore(name) {
     }
     this.setFramesPerTask = function (value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
-        this._framesPerTask = value
+        this._framesPerTask = typeof value === "string" ? value : value.toString()
     }
 
     this.multiFrameRendering = function () {
@@ -20,7 +23,7 @@ function UiSettingsStore(name) {
     }
     this.setMultiFrameRendering = function (value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
-        this._multiFrameRendering = value
+        this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
     }
 
     this.maxCpuUsagePercentage = function () {
@@ -28,7 +31,7 @@ function UiSettingsStore(name) {
     }
     this.setMaxCpuUsagePercentage = function (value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        this._maxCpuUsagePercentage = value
+        this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
 }
 

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -73,30 +73,30 @@ function UiSettingsStore(name) {
     }
 }
 
-UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+UiSettingsState.prototype.create = function(RQIID, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
     /**
-     * Adds new UISettingsStore to store settings for the comp associated with compId
+     * Adds new UISettingsStore to store settings for the comp associated with Render Queue Item ID
      */
-    if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId);
+    if (!this.settings[RQIID]) {
+        this.settings[RQIID] = new UiSettingsStore(RQIID);
     }
     if (framesPerTask !== undefined) {
-        this.settings[compId].setFramesPerTask(framesPerTask);
+        this.settings[RQIID].setFramesPerTask(framesPerTask);
     }
     if (multiFrameRendering !== undefined) {
-        this.settings[compId].setMultiFrameRendering(multiFrameRendering);
+        this.settings[RQIID].setMultiFrameRendering(multiFrameRendering);
     }
     if (maxCpuUsagePercentage !== undefined) {
-        this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+        this.settings[RQIID].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
     }
 }
 
-UiSettingsState.prototype.get = function(compId) {
+UiSettingsState.prototype.get = function(RQIID) {
     /**
-     * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
+     * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
-    if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId);
+    if (!this.settings[RQIID]) {
+        this.settings[RQIID] = new UiSettingsStore(RQIID);
     }
-    return this.settings[compId]
+    return this.settings[RQIID]
 }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -1,118 +1,100 @@
 function UiSettingsState() {
+    /**
+     * Container that stores all of the configurable properties in the submitter UI
+     */
+
+    // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
-}
 
-function UiSettingsStore(name) {
-    this.name = name;
-    // _framesPerTask: string
-    this._framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
-    // _multiFrameRendering: bool
-    this._multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
-    // _maxCpuUsagePercentage: string
-    this._maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
-
-    // _taskRunTimeout: bool
-    this._taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-    // _taskRunDays: string
-    this._taskRunDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
-    // _taskRunHours: string
-    this._taskRunHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
-    // _taskRunMinutes: string
-    this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
-
-    this.framesPerTask = function() {
-        return this._framesPerTask
+    // () -> bool
+    this.taskRunTimeoutEnabled = function() {
+        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
-    this.setFramesPerTask = function(value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
-        this._framesPerTask = typeof value === "string" ? value : value.toString()
+    // (value: bool) -> void
+    this.setTaskRunTimeoutEnabled = function(value) {
+        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, value);
     }
-
-    this.multiFrameRendering = function() {
-        return this._multiFrameRendering
-    }
-    this.setMultiFrameRendering = function(value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
-        this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
-    }
-
-    this.maxCpuUsagePercentage = function() {
-        return this._maxCpuUsagePercentage
-    }
-    this.setMaxCpuUsagePercentage = function(value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
-    }
-
-    this.taskRunTimeout = function() {
-        return this._taskRunTimeout
-    }
-    this.setTaskRunTimeout = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
-        this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
-    }
-
+    // () -> int
     this.taskRunDays = function() {
-        return this._taskRunDays
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
+
     this.setTaskRunDays = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
-        this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, value);
     }
 
     this.taskRunHours = function() {
-        return this._taskRunHours
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
+
     this.setTaskRunHours = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
-        this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, value);
     }
 
     this.taskRunMinutes = function() {
-        return this._taskRunMinutes
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
+
     this.setTaskRunMinutes = function(value) {
-        logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
-        this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, value);
+    }
+
+}
+
+function UiSettingsStore(name) {
+    /**
+     * Stores comp-specific settings for the comp with given name.
+     */
+    this.name = name;
+
+    this.framesPerTask = function() {
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name +"_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+    }
+    this.setFramesPerTask = function(value) {
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
+    }
+
+    this.multiFrameRendering = function() {
+        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
+    }
+    this.setMultiFrameRendering = function(value) {
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
+    }
+
+    this.maxCpuUsagePercentage = function() {
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE)
+
+    }
+    this.setMaxCpuUsagePercentage = function(value) {
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name+"_"+DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value)
     }
 }
 
-UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
+UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
+    /**
+     * Adds new UISettingsStore to store settings for the comp associated with compId
+     */
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId);
     }
-    if (framesPerTask === undefined) {
-        framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);
+    if (framesPerTask !== undefined) {
+        this.settings[compId].setFramesPerTask(framesPerTask);
     }
-    if (multiFrameRendering === undefined) {
-        multiFrameRendering = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING);
+    if (multiFrameRendering !== undefined) {
+        this.settings[compId].setMultiFrameRendering(multiFrameRendering);
     }
-    if (maxCpuUsagePercentage === undefined) {
-        maxCpuUsagePercentage = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE);
+    if (maxCpuUsagePercentage !== undefined) {
+        this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
     }
-    if (taskRunTimeout === undefined) {
-        taskRunTimeout = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED);
-    }
-    if (taskRunTimeoutDays === undefined) {
-        taskRunTimeoutDays = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS);
-    }
-    if (taskRunTimeoutHours === undefined) {
-        taskRunTimeoutHours = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS);
-    }
-    if (taskRunTimeoutMinutes === undefined) {
-        taskRunTimeoutMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
-    }
-
-    this.settings[compId].setFramesPerTask(framesPerTask);
-    this.settings[compId].setMultiFrameRendering(multiFrameRendering);
-    this.settings[compId].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
-    this.settings[compId].setTaskRunTimeout(taskRunTimeout);
-    this.settings[compId].setTaskRunDays(taskRunTimeoutDays);
-    this.settings[compId].setTaskRunHours(taskRunTimeoutHours);
-    this.settings[compId].setTaskRunMinutes(taskRunTimeoutMinutes);
 }
 
 UiSettingsState.prototype.get = function(compId) {
+    /**
+     * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
+     */
     if (!this.settings[compId]) {
         this.settings[compId] = new UiSettingsStore(compId)
     }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -8,86 +8,69 @@ function UiSettingsState() {
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
     // (value: bool) -> void
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
 
-function UiSettingsStore(name) {
+function UiSettingsStore(xmpPathPrefix, name) {
     /**
      * Stores comp-specific settings for the comp with given name.
      */
     this.name = name;
+    this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value);
-    }
-}
-
-UiSettingsState.prototype.create = function(RQIID, framesPerTask, multiFrameRendering, maxCpuUsagePercentage) {
-    /**
-     * Adds new UISettingsStore to store settings for the comp associated with Render Queue Item ID
-     */
-    if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(RQIID);
-    }
-    if (framesPerTask !== undefined) {
-        this.settings[RQIID].setFramesPerTask(framesPerTask);
-    }
-    if (multiFrameRendering !== undefined) {
-        this.settings[RQIID].setMultiFrameRendering(multiFrameRendering);
-    }
-    if (maxCpuUsagePercentage !== undefined) {
-        this.settings[RQIID].setMaxCpuUsagePercentage(maxCpuUsagePercentage);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 
@@ -96,7 +79,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(RQIID);
+        this.settings[RQIID] = new UiSettingsStore(this.xmpPath, RQIID);
     }
     return this.settings[RQIID]
 }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -8,35 +8,35 @@ function UiSettingsState() {
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
     // (value: bool) -> void
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
@@ -49,28 +49,28 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPField(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -6,6 +6,8 @@ function UiSettingsState() {
     // Contains UiSettingsStore objects that store comp-specific settings
     this.settings = {}
 
+    this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
+
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
         return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
@@ -79,7 +81,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(this.xmpPath, RQIID);
+        this.settings[RQIID] = new UiSettingsStore(dcUtil.composeXMPPath(this.xmpPath, "rqi_specific_settings"), RQIID);
     }
     return this.settings[RQIID]
 }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -1,6 +1,7 @@
 function UiSettingsState() {
     this.settings = {}
 }
+
 function UiSettingsStore(name) {
     this.name = name;
     // _framesPerTask: string
@@ -19,66 +20,66 @@ function UiSettingsStore(name) {
     // _taskRunMinutes: string
     this._taskRunMinutes = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES);
 
-    this.framesPerTask = function () {
+    this.framesPerTask = function() {
         return this._framesPerTask
     }
-    this.setFramesPerTask = function (value) {
+    this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
         this._framesPerTask = typeof value === "string" ? value : value.toString()
     }
 
-    this.multiFrameRendering = function () {
+    this.multiFrameRendering = function() {
         return this._multiFrameRendering
     }
-    this.setMultiFrameRendering = function (value) {
+    this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
         this._multiFrameRendering = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.maxCpuUsagePercentage = function () {
+    this.maxCpuUsagePercentage = function() {
         return this._maxCpuUsagePercentage
     }
-    this.setMaxCpuUsagePercentage = function (value) {
+    this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
         this._maxCpuUsagePercentage = typeof value === "string" ? value : value.toString()
     }
 
-    this.taskRunTimeout = function () {
+    this.taskRunTimeout = function() {
         return this._taskRunTimeout
     }
-    this.setTaskRunTimeout = function (value) {
+    this.setTaskRunTimeout = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunTimeout to " + value)
         this._taskRunTimeout = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunDays = function () {
+    this.taskRunDays = function() {
         return this._taskRunDays
     }
-    this.setTaskRunDays = function (value) {
+    this.setTaskRunDays = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunDays to " + value)
         this._taskRunDays = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunHours = function () {
+    this.taskRunHours = function() {
         return this._taskRunHours
     }
-    this.setTaskRunHours = function (value) {
+    this.setTaskRunHours = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunHours to " + value)
         this._taskRunHours = typeof value === "boolean" ? value : (value === "true")
     }
 
-    this.taskRunMinutes = function () {
+    this.taskRunMinutes = function() {
         return this._taskRunMinutes
     }
-    this.setTaskRunMinutes = function (value) {
+    this.setTaskRunMinutes = function(value) {
         logger.warning("(" + this.name + ") Setting taskRunMinutes to " + value)
         this._taskRunMinutes = typeof value === "boolean" ? value : (value === "true")
     }
 }
 
-UiSettingsState.prototype.create = function (compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
+UiSettingsState.prototype.create = function(compId, framesPerTask, multiFrameRendering, maxCpuUsagePercentage, taskRunTimeout, taskRunTimeoutDays, taskRunTimeoutHours, taskRunTimeoutMinutes) {
     if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId)
+        this.settings[compId] = new UiSettingsStore(compId);
     }
     if (framesPerTask === undefined) {
         framesPerTask = app.settings.getSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK);

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -7,6 +7,7 @@ function UiSettingsState() {
     this.settings = {}
 
     this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
+    this.rqiXmpPath = dcUtil.composeXMPPath(this.xmpPath, "rqiSpecificSettings");
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
@@ -81,7 +82,7 @@ UiSettingsState.prototype.get = function(RQIID) {
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
     if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(dcUtil.composeXMPPath(this.xmpPath, "rqi_specific_settings"), RQIID);
+        this.settings[RQIID] = new UiSettingsStore(this.rqiXmpPath, RQIID);
     }
     return this.settings[RQIID]
 }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -48,10 +48,10 @@ function UiSettingsStore(name) {
     this.name = name;
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name +"_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value)
+        logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
         dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_FRAMESPERTASK, value);
     }
 
@@ -59,17 +59,17 @@ function UiSettingsStore(name) {
         return dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value)
+        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
         dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, this.name + "_" + DEADLINECLOUD_MULTI_FRAME_RENDERING, value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE)
+        return dcUtil.getNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value)
-        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name+"_"+DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value)
+        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
+        dcUtil.saveNumberSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, name + "_" + DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, value);
     }
 }
 
@@ -96,7 +96,7 @@ UiSettingsState.prototype.get = function(compId) {
      * Gets UISettingsStore associated with given compId, or creates a new default one if it doesn't exit
      */
     if (!this.settings[compId]) {
-        this.settings[compId] = new UiSettingsStore(compId)
+        this.settings[compId] = new UiSettingsStore(compId);
     }
     return this.settings[compId]
 }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -11,35 +11,35 @@ function UiSettingsState() {
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), DEFAULT_TASK_RUN_TIMEOUT_ENABLED);
     }
     // (value: bool) -> void
     this.setTaskRunTimeoutEnabled = function(value) {
-        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED), value);
     }
     // () -> int
     this.taskRunDays = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), DEFAULT_TASK_RUN_TIMEOUT_DAYS);
     }
 
     this.setTaskRunDays = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS), value);
     }
 
     this.taskRunHours = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), DEFAULT_TASK_RUN_TIMEOUT_HOURS);
     }
 
     this.setTaskRunHours = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS), value);
     }
 
     this.taskRunMinutes = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), DEFAULT_TASK_RUN_TIMEOUT_MINUTES);
     }
 
     this.setTaskRunMinutes = function(value) {
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
 }
@@ -52,28 +52,28 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
     this.framesPerTask = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function(value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function() {
-        return dcUtil.getBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function(value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function() {
-        return dcUtil.getNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
     this.setMaxCpuUsagePercentage = function(value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberSetting(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 }
 

--- a/src/utils/Logger.jsx
+++ b/src/utils/Logger.jsx
@@ -45,7 +45,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
         backupCount = backupCount || _DC_LOGGER_DEFAULT_BACKUP_COUNT;
         logDirectoryPath = logDirectoryPath || dcUtil.getUserDirectory() + "/.deadline/logs/submitters";
         logDirectoryPath = dcUtil.normPath(logDirectoryPath);
-        var folderObject = new Folder(logDirectoryPath);
+        const folderObject = new Folder(logDirectoryPath);
         if (!folderObject.exists) {
             folderObject.create();
         }
@@ -83,8 +83,8 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
             if (!rolloverFile.exists) {
                 continue;
             }
-            var j = i + 1;
-            var rolloverTargetPath = logDirectoryPath + logFileName + "." + j
+            const j = i + 1;
+            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file
@@ -105,16 +105,16 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
 
             var levelName = LOG_LEVEL_MAP[level];
             // Check the length of the string
-            var currentLength = levelName.length;
+            const currentLength = levelName.length;
 
             // If the length is less than the target length, pad with spaces
             if (currentLength < 8) {
-                var spacesToAdd = 8 - currentLength;
+                const spacesToAdd = 8 - currentLength;
                 for (var i = 0; i < spacesToAdd; i++) {
                     levelName += " ";
                 }
             }
-            var logMessage = getCurrentTimeAsStr() + " - " + "[" + levelName + "] " + " " + src_module + ": " + msg;
+            const logMessage = getCurrentTimeAsStr() + " - " + "[" + levelName + "] " + " " + src_module + ": " + msg;
 
             logFile.open("a");
             logFile.writeln(logMessage);
@@ -152,18 +152,18 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
 }
 
 function getCurrentTimeAsStr() {
-    var date = new Date();
-    var year = date.getFullYear();
+    const date = new Date();
+    const year = date.getFullYear();
     // Zero pad all integers to a length of 2
-    var month = ("0" + (date.getMonth() + 1)).slice(-2); // Months are zero-based
-    var day = ("0" + date.getDate()).slice(-2);
+    const month = ("0" + (date.getMonth() + 1)).slice(-2); // Months are zero-based
+    const day = ("0" + date.getDate()).slice(-2);
 
-    var currentDate = year + "-" + month + "-" + day;
-    var hours = ("0" + date.getHours()).slice(-2);
-    var minutes = ("0" + date.getMinutes()).slice(-2);
-    var seconds = ("0" + date.getSeconds()).slice(-2);
-    var currentTime = hours + ":" + minutes + ":" + seconds;
-    var logDateTime = currentDate + " " + currentTime;
+    const currentDate = year + "-" + month + "-" + day;
+    const hours = ("0" + date.getHours()).slice(-2);
+    const minutes = ("0" + date.getMinutes()).slice(-2);
+    const seconds = ("0" + date.getSeconds()).slice(-2);
+    const currentTime = hours + ":" + minutes + ":" + seconds;
+    const logDateTime = currentDate + " " + currentTime;
     return logDateTime;
 }
 

--- a/src/utils/Logger.jsx
+++ b/src/utils/Logger.jsx
@@ -83,7 +83,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
             if (!rolloverFile.exists) {
                 continue;
             }
-            const j = i + 1;
+            var j = i + 1;
             const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
             rolloverFile.copy(rolloverTargetPath);
         }

--- a/src/utils/Logger.jsx
+++ b/src/utils/Logger.jsx
@@ -7,7 +7,7 @@ var LOG_LEVEL = {
     DEBUG: 4
 };
 
-var LOG_LEVEL_MAP = dcUtil.invertObject(LOG_LEVEL)
+var LOG_LEVEL_MAP = dcUtil.invertObject(LOG_LEVEL);
 
 // Global log level
 // Set the desired logging level
@@ -79,16 +79,16 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
         // Rollover older files first
         var rolloverFile;
         for (var i = backupCount - 1; i > 0; i--) { // Last file does not need rollover, it is allowed to get overwritten.
-            rolloverFile = new File(logDirectoryPath + logFileName + "." + i)
+            rolloverFile = new File(logDirectoryPath + logFileName + "." + i);
             if (!rolloverFile.exists) {
                 continue;
             }
             var j = i + 1;
-            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j
+            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file
-        logFile.copy(logDirectoryPath + logFileName + "." + 1)
+        logFile.copy(logDirectoryPath + logFileName + "." + 1);
         logFile.open("w"); // Erase contents of active log file
         logFile.close();
     }
@@ -172,5 +172,5 @@ function getCurrentTimeAsStr() {
 var _scriptFileName = "OpenAeSubmitter.jsx";
 var logFileName = "aftereffects.log";
 var logDirectoryPath = dcUtil.getUserDirectory() + "/.deadline/logs/submitters/";
-var logNormDirectoryPath = dcUtil.normPath(logDirectoryPath)
+var logNormDirectoryPath = dcUtil.normPath(logDirectoryPath);
 var logger = Logger(logFileName, logNormDirectoryPath);

--- a/src/utils/Logger.jsx
+++ b/src/utils/Logger.jsx
@@ -84,7 +84,7 @@ function Logger(logFileName, logDirectoryPath, maxBytes, backupCount) {
                 continue;
             }
             var j = i + 1;
-            const rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
+            var rolloverTargetPath = logDirectoryPath + logFileName + "." + j;
             rolloverFile.copy(rolloverTargetPath);
         }
         // Rollover active file

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -866,6 +866,13 @@ function __generateUtil() {
         return list.selection[0];
     }
 
+    function getRQIID(renderQueueIndex) {
+        /** Calculates an ID for the Render Queue Item with the given index in the render queue
+         * Not guaranteed to be unique
+         */
+        return app.project.file.name + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -909,7 +916,8 @@ function __generateUtil() {
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
-        "getTempFolder": getTempFolder
+        "getTempFolder": getTempFolder,
+        "getRQIID": getRQIID
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -922,9 +922,8 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.timeSpanStart * rqi.comp.frameRate));
-        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
-        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+        const startFrame = Number(Math.round(rqi.timeSpanStart * rqi.comp.frameRate));
+        const endFrame = Number(Math.round((rqi.timeSpanStart + rqi.timeSpanDuration) * rqi.comp.frameRate))
         return {
             startFrame: startFrame,
             endFrame: endFrame

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -815,77 +815,78 @@ function __generateUtil() {
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
         "getTempFolder": getTempFolder,
-        "calculateFrameRange": calculateFrameRange "validateTimeoutValues": validateTimeoutValues,
+        "calculateFrameRange": calculateFrameRange,
+        "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder
     }
+}
 
-    dcUtil = __generateUtil();
+dcUtil = __generateUtil();
 
 
-    // Global constants, wrapped with if-blocks to ensure they are only defined once
-    // to avoid errors due to redeclaration
-    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-        const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-    }
-    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-        const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-    }
-    if (typeof SUPPORTED_VERSIONS === "undefined") {
-        const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-    }
-    if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-        const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-    }
-    if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-        const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-    }
-    if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-        const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-    }
-    if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-        const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-    }
-    if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-        const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-    }
-    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-        const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-    }
-    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-    }
+// Global constants, wrapped with if-blocks to ensure they are only defined once
+// to avoid errors due to redeclaration
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+}
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+}
+if (typeof SUPPORTED_VERSIONS === "undefined") {
+    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+}
+if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+}
+if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+}
+if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+}
+if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+}
+if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+}
+if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
 }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -962,6 +962,39 @@ function __generateUtil() {
         return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
     }
 
+    function getXMPPathLeaf(path) {
+        const regex = /.*xmp:(.*)/;
+        return regex.exec(path)[1];
+    }
+
+    function deleteUnusedMetadata(renderMetadataRoot) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        var paths = []
+        var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
+        while (property = iterator.next()) {
+            paths.push(property.path);
+        }
+        var ids = []
+        for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
+            ids.push(getRQIID(i));
+        }
+        for (var i = 0; i < paths.length; i++) {
+            var presentInArray = false;
+            var currentPath = paths[i];
+            for (var j = 0; j < ids.length; j++) {
+                var renderQueueID = ids[j];
+                if (getXMPPathLeaf(currentPath) === renderQueueID) {
+                    presentInArray=true;
+                    break;
+                }
+            }
+            if (!presentInArray) {
+                metadata.deleteProperty(XMPConst.NS_XMP, currentPath);
+            }
+        }
+        app.project.xmpPacket = metadata.serialize();
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -1010,7 +1043,8 @@ function __generateUtil() {
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
-        "metadataKeyExists": metadataKeyExists
+        "metadataKeyExists": metadataKeyExists,
+        "deleteUnusedMetadata": deleteUnusedMetadata
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -684,7 +684,7 @@ function __generateUtil() {
          */
         // If submit layers pressed -> itemName is not comp name and therefore comp will not be found with render command
         // Check if itemName is an available comp in the project, if not, it is a layer submission
-        const comp = itemName;
+        var comp = itemName;
         const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
             const item = app.project.rootFolder.items[i];

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1,4 +1,68 @@
+if ( ExternalObject.AdobeXMPScript == undefined ) {
+    ExternalObject.AdobeXMPScript = new ExternalObject( "lib:AdobeXMPScript");
+}
+
 var scriptFolder = Folder.current.fsName;
+
+// Global constants, wrapped with if-blocks to ensure they are only defined once
+// to avoid errors due to redeclaration
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+}
+if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+}
+if (typeof SUPPORTED_VERSIONS === "undefined") {
+    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+}
+if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+    const DEADLINECLOUD_SUBMITTER_SETTINGS = "DeadlineCloudSubmitter";
+}
+if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+}
+if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+}
+if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+}
+if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+}
+if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
+}
+if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
+    const DEFAULT_FRAMESPERTASK = 10;
+}
+if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
+    const DEFAULT_MULTI_FRAME_RENDERING = false;
+}
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -144,12 +208,66 @@ function __generateUtil() {
         return false;
     }
 
+    /**
+     * Combines prefix and key to construct a key for accessing a value in XMPMetadata 
+     * @param {String} prefix 
+     * @param {String} key 
+     * @returns {String}
+     */
+    function buildMetadataKey(prefix, key) {
+        return "xmp:" + prefix + "__" + key;
+    }
+
+    /**
+     * Saves item to project's XMP Metadata
+     * @param {String} prefix 
+     * @param {String} key 
+     * @param {*} value 
+     * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
+     */
+    function saveToMetadata(prefix, key, value, type) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        metadata.setProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), value, type);
+        app.project.xmpPacket = metadata.serialize();
+    }
+
+    /**
+     * Checks if item with given key exists in project's XMPMetadata
+     * @param {String} prefix 
+     * @param {String} key 
+     * @returns {boolean}
+     */
+    function metadataKeyExists(prefix, key) {
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key)) !== undefined;
+    }
+
+    /**
+     * Loads value from project's XMP metadata 
+     * @param {String} prefix 
+     * @param {String} key 
+     * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
+     * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
+     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
+     */
+    function loadFromMetadata(prefix, key, defaultValue, type) {
+        if (!metadataKeyExists(prefix, key)) {
+            if (defaultValue !== undefined) {
+                saveToMetadata(prefix, key, defaultValue, type);
+            } else {
+                throw Error("Key '" + buildMetadataKey(prefix, key) + "' does not exist in project XMP Metadata, and no default value is set.")
+            }
+        }
+        var metadata = new XMPMeta(app.project.xmpPacket);
+        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), type).value;
+    }
+
     function saveBoolSetting(sectionName, keyName, value) {
         /**
          * Sets boolean value in app settings
          */
         validateType(value, "boolean");
-        app.settings.saveSetting(sectionName, keyName, value.toString());
+        saveToMetadata(sectionName, keyName, value, XMPConst.BOOLEAN);
     }
 
     function getBoolSetting(sectionName, keyName, defaultValue) {
@@ -157,14 +275,7 @@ function __generateUtil() {
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
-            }
-            saveBoolSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "defaultValue");
-        }
-        return parseBool(app.settings.getSetting(sectionName, keyName));
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
     function saveNumberSetting(sectionName, keyName, value) {
@@ -172,7 +283,7 @@ function __generateUtil() {
          * Sets integer value in app settings
          */
         validateType(value, "number");
-        app.settings.saveSetting(sectionName, keyName, value.toString());
+        saveToMetadata(sectionName, keyName, value, XMPConst.NUMBER);
     }
 
     function getNumberSetting(sectionName, keyName, defaultValue) {
@@ -180,21 +291,7 @@ function __generateUtil() {
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
-            }
-            saveNumberSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
-        }
-        if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
-            }
-            saveNumberSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + defaultValue);
-        }
-        return Number(app.settings.getSetting(sectionName, keyName));
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.NUMBER);
     }
 
     function saveStringSetting(sectionName, keyName, value) {
@@ -202,7 +299,7 @@ function __generateUtil() {
          * Sets string in app settings
          */
         validateType(value, "string");
-        app.settings.saveSetting(sectionName, keyName, value);
+        saveToMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
     }
 
     function getStringSetting(sectionName, keyName, defaultValue) {
@@ -210,14 +307,7 @@ function __generateUtil() {
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (defaultValue === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
-            }
-            setStringSetting(sectionName, keyName, defaultValue);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
-        }
-        return app.settings.getSetting(sectionName, keyName)
+        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -238,7 +328,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function() {
+        textObj.onChange = function () {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -247,7 +337,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function() {
+        sliderObj.onChange = function () {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -679,43 +769,43 @@ function __generateUtil() {
 
         const hostRequirements = {
             "attributes": [{
-                    "name": "attr.worker.os.family",
-                    "anyOf": [
-                        osGroup.OSDropdownList.selection.text.toLowerCase()
-                    ]
-                },
-                {
-                    "name": "attr.worker.cpu.arch",
-                    "anyOf": [
-                        cpuArchGroup.cpuDropdownList.selection.text
-                    ]
-                }
+                "name": "attr.worker.os.family",
+                "anyOf": [
+                    osGroup.OSDropdownList.selection.text.toLowerCase()
+                ]
+            },
+            {
+                "name": "attr.worker.cpu.arch",
+                "anyOf": [
+                    cpuArchGroup.cpuDropdownList.selection.text
+                ]
+            }
             ],
             "amounts": [{
-                    "name": "amount.worker.vcpu",
-                    "min": parseInt(cpuGroup.cpuMinText.text),
-                    "max": parseInt(cpuGroup.cpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.memory",
-                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.gpu",
-                    "min": parseInt(gpuGroup.gpuMinText.text),
-                    "max": parseInt(gpuGroup.gpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.gpu.memory",
-                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.disk.scratch",
-                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-                }
+                "name": "amount.worker.vcpu",
+                "min": parseInt(cpuGroup.cpuMinText.text),
+                "max": parseInt(cpuGroup.cpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.memory",
+                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.gpu",
+                "min": parseInt(gpuGroup.gpuMinText.text),
+                "max": parseInt(gpuGroup.gpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.gpu.memory",
+                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.disk.scratch",
+                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+            }
             ]
         }
 
@@ -868,9 +958,9 @@ function __generateUtil() {
 
     function getRQIID(renderQueueIndex) {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
-         * Not guaranteed to be unique
+         * Not guaranteed to be unique if render queue items are reordered
          */
-        return app.project.file.name + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+        return app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
     }
 
     return {
@@ -921,72 +1011,8 @@ function __generateUtil() {
     }
 }
 
-dcUtil = __generateUtil();
+var dcUtil = __generateUtil();
 
-
-// Global constants, wrapped with if-blocks to ensure they are only defined once
-// to avoid errors due to redeclaration
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-}
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-}
-if (typeof SUPPORTED_VERSIONS === "undefined") {
-    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-}
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-}
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
-if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-}
-if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-}
-if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
-}
-if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
-}
-if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
-    const DEFAULT_FRAMESPERTASK = 10;
-}
-if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
-    const DEFAULT_MULTI_FRAME_RENDERING = false;
-}
-if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
-}
-
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
+// Getting a setting that doesn't already exist will set it to its default value
+dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
+dcUtil.getStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -107,6 +107,13 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
+function validateType(item, item_type) {
+    actual_type = typeof item;
+    if (actual_type !== item_type) {
+        throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
+    }
+}
+
 function __generateUtil() {
 
     const scriptFileUtilName = "Util.jsx";
@@ -135,6 +142,82 @@ function __generateUtil() {
             return true;
 
         return false;
+    }
+
+    function saveBoolSetting(sectionName, keyName, value) {
+        /**
+         * Sets boolean value in app settings
+         */
+        validateType(value, "boolean")
+        app.settings.saveSetting(sectionName, keyName, value.toString())
+    }
+
+    function getBoolSetting(sectionName, keyName, default_value) {
+        /**
+         * Gets boolean value from app settings, or sets it to the default value if no setting exists.
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
+            }
+            setBoolSetting(sectionName, keyName, default_value);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
+        }
+        return parseBool(app.settings.getSetting(sectionName, keyName));
+    }
+
+    function saveNumberSetting(sectionName, keyName, value) {
+        /**
+         * Sets integer value in app settings
+         */
+        validateType(value, "number")
+        app.settings.saveSetting(sectionName, keyName, value.toString())
+    }
+
+    function getNumberSetting(sectionName, keyName, default_value) {
+        /**
+         * Gets number value from app settings, or sets default_value if setting does not exist
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
+            }
+            setNumberSetting(sectionName, keyName, default_value)
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+        }
+        if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
+            }
+            setNumberSetting(sectionName, keyName, default_value)
+            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
+        }
+        return Number(app.settings.getSetting(sectionName, keyName));
+    }
+
+    function saveStringSetting(sectionName, keyName, value) {
+        /**
+         * Sets string in app settings
+         */
+        validateType(value, "string");
+        app.settings.saveSetting(sectionName, keyName, value);
+    }
+
+    function getStringSetting(sectionName, keyName, defaultValue) {
+         /**
+         * Gets string value from app settings, or sets default_value if setting does not exist
+         * Set default_value to undefined to error on missing setting
+         */
+        if (!app.settings.haveSetting(sectionName, keyName)) {
+            if (default_value === undefined) {
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
+            }
+            setStringSetting(sectionName, keyName, default_value);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+        }
+        return app.settings.getSetting(sectionName, keyName) 
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -760,14 +843,16 @@ function __generateUtil() {
     }
 
     function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+        /**
+         * Parses in input strings for days, hours, and minutes in timeout, validates them, and alerts user if invalid
+         */
         if (enabled) {
-            var days = parseInt(daysInput.text) || 0;
-            var hours = parseInt(hoursInput.text) || 0;
+            var days = parseInt(daysInput) || 0;
+            var hours = parseInt(hoursInput) || 0;
             var minutes = parseInt(minutesInput.text) || 0;
 
             if (days === 0 && hours === 0 && minutes === 0) {
                 adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
                 return false;
             }
         }
@@ -785,6 +870,12 @@ function __generateUtil() {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
         "parseBool": parseBool,
+        "saveBoolSetting": saveBoolSetting,
+        "getBoolSetting": getBoolSetting,
+        "saveNumberSetting": saveNumberSetting,
+        "getNumberSetting": getNumberSetting,
+        "saveStringSetting": saveStringSetting,
+        "getStringSetting": getStringSetting,
         "trimIllegalChars": trimIllegalChars,
         "sliderTextSync": sliderTextSync,
         "changeTextValue": changeTextValue,
@@ -863,30 +954,31 @@ if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
 if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
     const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
 }
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_DAYS = 2;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_HOURS = 0;
+}
+if (typeof DEFAULT_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+    const DEFAULT_TASK_RUN_TIMEOUT_MINUTES = 0;
+}
+if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
+    const DEFAULT_FRAMESPERTASK = 10;
+}
+if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
+    const DEFAULT_MULTI_FRAME_RENDERING = false;
+}
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE) {
+    const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
+
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
 }
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+    saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
 }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -753,143 +753,138 @@ function __generateUtil() {
         const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
-
         return {
             startFrame: startFrame,
             endFrame: endFrame
         };
     }
 
-        function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
-            if (enabled) {
-                var days = parseInt(daysInput.text) || 0;
-                var hours = parseInt(hoursInput.text) || 0;
-                var minutes = parseInt(minutesInput.text) || 0;
+    function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+        if (enabled) {
+            var days = parseInt(daysInput.text) || 0;
+            var hours = parseInt(hoursInput.text) || 0;
+            var minutes = parseInt(minutesInput.text) || 0;
 
-                if (days === 0 && hours === 0 && minutes === 0) {
-                    adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
-                    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        function getSelection(list) {
-            for (var s = 0; s < list.selection.length; s++) {
-                return list.selection[s];
+            if (days === 0 && hours === 0 && minutes === 0) {
+                adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                return false;
             }
         }
-
-        return {
-            "invertObject": invertObject,
-            "toBooleanString": toBooleanString,
-            "parseBool": parseBool,
-            "trimIllegalChars": trimIllegalChars,
-            "sliderTextSync": sliderTextSync,
-            "changeTextValue": changeTextValue,
-            "changeSliderValue": changeSliderValue,
-            "checkGPUAccelType": checkGPUAccelType,
-            "spinBoxLimiterMin": spinBoxLimiterMin,
-            "spinBoxLimiterMax": spinBoxLimiterMax,
-            "getAssetsInScene": getAssetsInScene,
-            "editTextIntValidation": editTextIntValidation,
-            "getDescription": getDescription,
-            "wrappedCallSystem": wrappedCallSystem,
-            "parseErrorData": parseErrorData,
-            "parseVersionData": parseVersionData,
-            "createExportBundleDir": createExportBundleDir,
-            "removeLineBreak": removeLineBreak,
-            "setListBoxSelection": setListBoxSelection,
-            "getPath": getPath,
-            "getPartialExportDir": getPartialExportDir,
-            "collectHostRequirements": collectHostRequirements,
-            "deepCopy": deepCopy,
-            "getActiveComp": getActiveComp,
-            "normalizePath": normalizePath,
-            "normPath": normalizePath,
-            "enforceForwardSlashes": enforceForwardSlashes,
-            "removeIllegalCharacters": removeIllegalCharacters,
-            "removePercentageFromFileName": removePercentageFromFileName,
-            "getTempFile": getTempFile,
-            "getUserDirectory": getUserDirectory,
-            "getAEVersion": getAEVersion,
-            "getTempFolder": getTempFolder,
-            "calculateFrameRange": calculateFrameRange
-            "validateTimeoutValues": validateTimeoutValues,
-            "getSelection": getSelection,
-            "getTempFolder": getTempFolder
+        return true;
     }
 
+    function getSelection(list) {
+        for (var s = 0; s < list.selection.length; s++) {
+            return list.selection[s];
+        }
+    }
+
+    return {
+        "invertObject": invertObject,
+        "toBooleanString": toBooleanString,
+        "parseBool": parseBool,
+        "trimIllegalChars": trimIllegalChars,
+        "sliderTextSync": sliderTextSync,
+        "changeTextValue": changeTextValue,
+        "changeSliderValue": changeSliderValue,
+        "checkGPUAccelType": checkGPUAccelType,
+        "spinBoxLimiterMin": spinBoxLimiterMin,
+        "spinBoxLimiterMax": spinBoxLimiterMax,
+        "getAssetsInScene": getAssetsInScene,
+        "editTextIntValidation": editTextIntValidation,
+        "getDescription": getDescription,
+        "wrappedCallSystem": wrappedCallSystem,
+        "parseErrorData": parseErrorData,
+        "parseVersionData": parseVersionData,
+        "createExportBundleDir": createExportBundleDir,
+        "removeLineBreak": removeLineBreak,
+        "setListBoxSelection": setListBoxSelection,
+        "getPath": getPath,
+        "getPartialExportDir": getPartialExportDir,
+        "collectHostRequirements": collectHostRequirements,
+        "deepCopy": deepCopy,
+        "getActiveComp": getActiveComp,
+        "normalizePath": normalizePath,
+        "normPath": normalizePath,
+        "enforceForwardSlashes": enforceForwardSlashes,
+        "removeIllegalCharacters": removeIllegalCharacters,
+        "removePercentageFromFileName": removePercentageFromFileName,
+        "getTempFile": getTempFile,
+        "getUserDirectory": getUserDirectory,
+        "getAEVersion": getAEVersion,
+        "getTempFolder": getTempFolder,
+        "calculateFrameRange": calculateFrameRange "validateTimeoutValues": validateTimeoutValues,
+        "getSelection": getSelection,
+        "getTempFolder": getTempFolder
+    }
+
+    dcUtil = __generateUtil();
+
+
+    // Global constants, wrapped with if-blocks to ensure they are only defined once
+    // to avoid errors due to redeclaration
+    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+        const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+    }
+    if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+        const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+    }
+    if (typeof SUPPORTED_VERSIONS === "undefined") {
+        const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+    }
+    if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+        const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+    }
+    if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+        const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+    }
+    if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+        const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+    }
+    if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+        const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+    }
+    if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+        const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+    }
+    if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+        const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+    }
+    if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+        app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+    }
 }
-
-
-
-dcUtil = __generateUtil();
-
-
-                        // Global constants, wrapped with if-blocks to ensure they are only defined once
-                        // to avoid errors due to redeclaration
-                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-                            const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-                        }
-                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-                            const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-                        }
-                        if (typeof SUPPORTED_VERSIONS === "undefined") {
-                            const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-                        }
-                        if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-                            const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-                        }
-                        if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-                            const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-                        }
-                        if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-                            const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-                        }
-                        if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-                            const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-                        }
-                        if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-                            const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-                        }
-                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-                        }
-                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-                        }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -922,8 +922,10 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.round(rqi.timeSpanStart * rqi.comp.frameRate));
-        const endFrame = Number(Math.round((rqi.timeSpanStart + rqi.timeSpanDuration) * rqi.comp.frameRate))
+        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
+        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+
         return {
             startFrame: startFrame,
             endFrame: endFrame

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -342,7 +342,7 @@ function __generateUtil() {
 
         // Test every path in our list by creating a test file
         for (var i = 0; i < altPaths.length; i++) {
-            const folder = new Folder(altPaths[i]);
+            var folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -948,10 +948,9 @@ function __generateUtil() {
     }
 
     function getSelection(list) {
-        for (var s = 0; s < list.selection.length; s++) {
-            return list.selection[s];
+        if (list.selection.length >= 1) {
+            return list.selection[0];
         }
-        return list.selection[0];
     }
 
     function getRenderQueueItemID(renderQueueIndex) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -212,8 +212,8 @@ function __generateUtil() {
 
     /**
      * Appends stem to existing XMP path
-     * @param {String} root 
-     * @param {String} stem 
+     * @param {String} root
+     * @param {String} stem
      * @returns {String}
      */
     function composeXMPPath(root, stem) {
@@ -222,8 +222,8 @@ function __generateUtil() {
 
     /**
      * Saves item to project's XMP Metadata
-     * @param {String} key 
-     * @param {*} value 
+     * @param {String} key
+     * @param {*} value
      * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
      */
     function saveToMetadata(key, value, type) {
@@ -234,7 +234,7 @@ function __generateUtil() {
 
     /**
      * Checks if item with given key exists in project's XMPMetadata
-     * @param {String} key 
+     * @param {String} key
      * @returns {boolean}
      */
     function metadataKeyExists(key) {
@@ -243,11 +243,11 @@ function __generateUtil() {
     }
 
     /**
-     * Loads value from project's XMP metadata 
-     * @param {String} key 
+     * Loads value from project's XMP metadata
+     * @param {String} key
      * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
      * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
-     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
+     * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist.
      */
     function loadFromMetadata(key, defaultValue, type) {
         if (!metadataKeyExists(key)) {
@@ -530,7 +530,7 @@ function __generateUtil() {
             }
 
             // Create and write to a test file to make sure we have write permissions
-            const file = new File(folder.fsName + testFileSuffix);
+            var file = new File(folder.fsName + testFileSuffix);
             file.open("w");
             file.writeln("test");
             file.close();
@@ -722,11 +722,11 @@ function __generateUtil() {
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
             folderName = subFolders[idx].fullName;
-            const match = folderName.match(regex);
+            var match = folderName.match(regex);
             if (!match) {
                 continue;
             }
-            const seqNr = parseInt(match[1]) // Convert first capture group to int
+            var seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
                 maxSeqNumber = seqNr;
             }
@@ -766,7 +766,7 @@ function __generateUtil() {
         // Remark: gpu memory and worker memory need to be scaled with *1024, for some of the amount capabilities, the unit displayed on the UI is different
         // then the unit used within template, so use this factor to scale the input values.
 
-        const hostRequirements = {
+        var hostRequirements = {
             "attributes": [{
                 "name": "attr.worker.os.family",
                 "anyOf": [
@@ -859,7 +859,7 @@ function __generateUtil() {
         var comp = itemName;
         const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
-            const item = app.project.rootFolder.items[i];
+            var item = app.project.rootFolder.items[i];
 
             if (item instanceof CompItem) {
                 compList.push(app.project.activeItem.name);

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -182,7 +182,7 @@ function validateType(item, itemType) {
 
 function __generateUtil() {
 
-    const scriptFileUtilName = "Util.jsx";
+    const scriptFileUtilName = "Utils.jsx";
 
 
     function toBooleanString(value) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -221,16 +221,6 @@ function __generateUtil() {
     }
 
     /**
-     * Creates XMP path to access field of struct 
-     * @param {String} structPath 
-     * @param {String} fieldName 
-     * @returns 
-     */
-    function composeXMPField(structPath, fieldName) {
-        return structPath + "/xmp:" + fieldName
-    }
-
-    /**
      * Saves item to project's XMP Metadata
      * @param {String} key 
      * @param {*} value 
@@ -1018,7 +1008,6 @@ function __generateUtil() {
         "getTempFolder": getTempFolder,
         "getRQIID": getRQIID,
         "composeXMPPath": composeXMPPath,
-        "composeXMPField": composeXMPField,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists
@@ -1028,5 +1017,5 @@ function __generateUtil() {
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
-dcUtil.getStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
+dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -161,7 +161,7 @@ function __generateUtil() {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
             }
-            setBoolSetting(sectionName, keyName, default_value);
+            saveBoolSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
         }
         return parseBool(app.settings.getSetting(sectionName, keyName));
@@ -184,14 +184,14 @@ function __generateUtil() {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
             }
-            setNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value)
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            setNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value)
             logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
@@ -972,13 +972,13 @@ if (typeof DEFAULT_FRAMESPERTASK === "undefined") {
 if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
     const DEFAULT_MULTI_FRAME_RENDERING = false;
 }
-if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE) {
+if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
 }
 
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+    dcUtil.saveBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
 }
 if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+    dcUtil.saveStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
 }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1,11 +1,13 @@
-if ( ExternalObject.AdobeXMPScript == undefined ) {
-    ExternalObject.AdobeXMPScript = new ExternalObject( "lib:AdobeXMPScript");
+if (ExternalObject.AdobeXMPScript == undefined) {
+    ExternalObject.AdobeXMPScript = new ExternalObject("lib:AdobeXMPScript");
 }
 
 var scriptFolder = Folder.current.fsName;
 
 // Global constants, wrapped with if-blocks to ensure they are only defined once
 // to avoid errors due to redeclaration
+// Note that once these values have been set their values will persist until Aftereffects is relaunched,
+// So make sure to restart Aftereffects is you change them
 if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
     const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
 }
@@ -15,8 +17,8 @@ if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
 if (typeof SUPPORTED_VERSIONS === "undefined") {
     const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
 }
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "DeadlineCloudSubmitter";
+if (typeof DEADLINECLOUD_SETTINGS_ROOT === "undefined") {
+    const DEADLINECLOUD_SETTINGS_ROOT = "xmp:DeadlineCloudSubmitter";
 }
 if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
     const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
@@ -209,105 +211,112 @@ function __generateUtil() {
     }
 
     /**
-     * Combines prefix and key to construct a key for accessing a value in XMPMetadata 
-     * @param {String} prefix 
-     * @param {String} key 
+     * Appends stem to existing XMP path
+     * @param {String} root 
+     * @param {String} stem 
      * @returns {String}
      */
-    function buildMetadataKey(prefix, key) {
-        return "xmp:" + prefix + "__" + key;
+    function composeXMPPath(root, stem) {
+        return root + "/xmp:" + stem;
+    }
+
+    /**
+     * Creates XMP path to access field of struct 
+     * @param {String} structPath 
+     * @param {String} fieldName 
+     * @returns 
+     */
+    function composeXMPField(structPath, fieldName) {
+        return structPath + "/xmp:" + fieldName
     }
 
     /**
      * Saves item to project's XMP Metadata
-     * @param {String} prefix 
      * @param {String} key 
      * @param {*} value 
      * @param {String} [type] Optional data type for value. These are enumerated in XMPConst.
      */
-    function saveToMetadata(prefix, key, value, type) {
+    function saveToMetadata(key, value, type) {
         var metadata = new XMPMeta(app.project.xmpPacket);
-        metadata.setProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), value, type);
+        metadata.setProperty(XMPConst.NS_XMP, key, value, type);
         app.project.xmpPacket = metadata.serialize();
     }
 
     /**
      * Checks if item with given key exists in project's XMPMetadata
-     * @param {String} prefix 
      * @param {String} key 
      * @returns {boolean}
      */
-    function metadataKeyExists(prefix, key) {
+    function metadataKeyExists(key) {
         var metadata = new XMPMeta(app.project.xmpPacket);
-        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key)) !== undefined;
+        return metadata.getProperty(XMPConst.NS_XMP, key) !== undefined;
     }
 
     /**
      * Loads value from project's XMP metadata 
-     * @param {String} prefix 
      * @param {String} key 
      * @param {*} [defaultValue] If value with given key doesn't exist in the XMPMetadata yet, a new one will be created with this value and the new value will be returned
      * @param {String} [type] Optionally specify type of object being stored. These are enumerated in XMPConst
      * @returns {XMPProperty} Returns property if it exists, or defaultValue if it doesn't, or throws an error if no defaultValue is defined and property doesn't exist. 
      */
-    function loadFromMetadata(prefix, key, defaultValue, type) {
-        if (!metadataKeyExists(prefix, key)) {
+    function loadFromMetadata(key, defaultValue, type) {
+        if (!metadataKeyExists(key)) {
             if (defaultValue !== undefined) {
-                saveToMetadata(prefix, key, defaultValue, type);
+                saveToMetadata(key, defaultValue, type);
             } else {
-                throw Error("Key '" + buildMetadataKey(prefix, key) + "' does not exist in project XMP Metadata, and no default value is set.")
+                throw Error("Key '" + key + "' does not exist in project XMP Metadata, and no default value is set.")
             }
         }
         var metadata = new XMPMeta(app.project.xmpPacket);
-        return metadata.getProperty(XMPConst.NS_XMP, buildMetadataKey(prefix, key), type).value;
+        return metadata.getProperty(XMPConst.NS_XMP, key, type).value;
     }
 
-    function saveBoolSetting(sectionName, keyName, value) {
+    function saveBoolSetting(keyName, value) {
         /**
          * Sets boolean value in app settings
          */
         validateType(value, "boolean");
-        saveToMetadata(sectionName, keyName, value, XMPConst.BOOLEAN);
+        saveToMetadata(keyName, value, XMPConst.BOOLEAN);
     }
 
-    function getBoolSetting(sectionName, keyName, defaultValue) {
+    function getBoolSetting(keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.BOOLEAN)
+        return loadFromMetadata(keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
-    function saveNumberSetting(sectionName, keyName, value) {
+    function saveNumberSetting(keyName, value) {
         /**
          * Sets integer value in app settings
          */
         validateType(value, "number");
-        saveToMetadata(sectionName, keyName, value, XMPConst.NUMBER);
+        saveToMetadata(keyName, value, XMPConst.NUMBER);
     }
 
-    function getNumberSetting(sectionName, keyName, defaultValue) {
+    function getNumberSetting(keyName, defaultValue) {
         /**
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.NUMBER);
+        return loadFromMetadata(keyName, defaultValue, XMPConst.NUMBER);
     }
 
-    function saveStringSetting(sectionName, keyName, value) {
+    function saveStringSetting(keyName, value) {
         /**
          * Sets string in app settings
          */
         validateType(value, "string");
-        saveToMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
+        saveToMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
-    function getStringSetting(sectionName, keyName, defaultValue) {
+    function getStringSetting(keyName, defaultValue) {
         /**
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
          */
-        return loadFromMetadata(sectionName, keyName, defaultValue, XMPConst.STRING);
+        return loadFromMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -960,7 +969,7 @@ function __generateUtil() {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
          * Not guaranteed to be unique if render queue items are reordered
          */
-        return app.project.renderQueue.item(renderQueueIndex).comp.id + "_" + renderQueueIndex.toString();
+        return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
     }
 
     return {
@@ -1007,12 +1016,17 @@ function __generateUtil() {
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder,
-        "getRQIID": getRQIID
+        "getRQIID": getRQIID,
+        "composeXMPPath": composeXMPPath,
+        "composeXMPField": composeXMPField,
+        "saveToMetadata": saveToMetadata,
+        "loadFromMetadata": loadFromMetadata,
+        "metadataKeyExists": metadataKeyExists
     }
 }
 
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, false);
-dcUtil.getStringSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+dcUtil.getBoolSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringSetting(dcUtil.composeXMPField(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1039,7 +1039,6 @@ function __generateUtil() {
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
-        "getTempFolder": getTempFolder,
         "getRenderQueueItemID": getRenderQueueItemID,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -922,7 +922,7 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor(rqi.timeSpanStart * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
         return {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -778,6 +778,7 @@ function __generateUtil() {
         for (var s = 0; s < list.selection.length; s++) {
             return list.selection[s];
         }
+        return list.selection[0];
     }
 
     return {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -849,7 +849,7 @@ function __generateUtil() {
         if (enabled) {
             var days = parseInt(daysInput) || 0;
             var hours = parseInt(hoursInput) || 0;
-            var minutes = parseInt(minutesInput.text) || 0;
+            var minutes = parseInt(minutesInput) || 0;
 
             if (days === 0 && hours === 0 && minutes === 0) {
                 adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -261,7 +261,7 @@ function __generateUtil() {
         return metadata.getProperty(XMPConst.NS_XMP, key, type).value;
     }
 
-    function saveBoolSetting(keyName, value) {
+    function saveBoolMetadata(keyName, value) {
         /**
          * Sets boolean value in app settings
          */
@@ -269,7 +269,7 @@ function __generateUtil() {
         saveToMetadata(keyName, value, XMPConst.BOOLEAN);
     }
 
-    function getBoolSetting(keyName, defaultValue) {
+    function getBoolMetadata(keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
          * Set defaultValue to undefined to error on missing setting
@@ -277,7 +277,7 @@ function __generateUtil() {
         return loadFromMetadata(keyName, defaultValue, XMPConst.BOOLEAN)
     }
 
-    function saveNumberSetting(keyName, value) {
+    function saveNumberMetadata(keyName, value) {
         /**
          * Sets integer value in app settings
          */
@@ -285,7 +285,7 @@ function __generateUtil() {
         saveToMetadata(keyName, value, XMPConst.NUMBER);
     }
 
-    function getNumberSetting(keyName, defaultValue) {
+    function getNumberMetadata(keyName, defaultValue) {
         /**
          * Gets number value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
@@ -293,7 +293,7 @@ function __generateUtil() {
         return loadFromMetadata(keyName, defaultValue, XMPConst.NUMBER);
     }
 
-    function saveStringSetting(keyName, value) {
+    function saveStringMetadata(keyName, value) {
         /**
          * Sets string in app settings
          */
@@ -301,7 +301,7 @@ function __generateUtil() {
         saveToMetadata(keyName, defaultValue, XMPConst.STRING);
     }
 
-    function getStringSetting(keyName, defaultValue) {
+    function getStringMetadata(keyName, defaultValue) {
         /**
          * Gets string value from app settings, or sets defaultValue if setting does not exist
          * Set defaultValue to undefined to error on missing setting
@@ -999,12 +999,12 @@ function __generateUtil() {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
         "parseBool": parseBool,
-        "saveBoolSetting": saveBoolSetting,
-        "getBoolSetting": getBoolSetting,
-        "saveNumberSetting": saveNumberSetting,
-        "getNumberSetting": getNumberSetting,
-        "saveStringSetting": saveStringSetting,
-        "getStringSetting": getStringSetting,
+        "saveBoolMetadata": saveBoolMetadata,
+        "getBoolMetadata": getBoolMetadata,
+        "saveNumberMetadata": saveNumberMetadata,
+        "getNumberMetadata": getNumberMetadata,
+        "saveStringMetadata": saveStringMetadata,
+        "getStringMetadata": getStringMetadata,
         "trimIllegalChars": trimIllegalChars,
         "sliderTextSync": sliderTextSync,
         "changeTextValue": changeTextValue,
@@ -1051,5 +1051,5 @@ function __generateUtil() {
 var dcUtil = __generateUtil();
 
 // Getting a setting that doesn't already exist will set it to its default value
-dcUtil.getBoolSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
-dcUtil.getStringSetting(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());
+dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING), false);
+dcUtil.getStringMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), dcUtil.getAEVersion().toString());

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -596,43 +596,43 @@ function __generateUtil() {
 
         const hostRequirements = {
             "attributes": [{
-                "name": "attr.worker.os.family",
-                "anyOf": [
-                    osGroup.OSDropdownList.selection.text.toLowerCase()
-                ]
-            },
-            {
-                "name": "attr.worker.cpu.arch",
-                "anyOf": [
-                    cpuArchGroup.cpuDropdownList.selection.text
-                ]
-            }
+                    "name": "attr.worker.os.family",
+                    "anyOf": [
+                        osGroup.OSDropdownList.selection.text.toLowerCase()
+                    ]
+                },
+                {
+                    "name": "attr.worker.cpu.arch",
+                    "anyOf": [
+                        cpuArchGroup.cpuDropdownList.selection.text
+                    ]
+                }
             ],
             "amounts": [{
-                "name": "amount.worker.vcpu",
-                "min": parseInt(cpuGroup.cpuMinText.text),
-                "max": parseInt(cpuGroup.cpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.memory",
-                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.gpu",
-                "min": parseInt(gpuGroup.gpuMinText.text),
-                "max": parseInt(gpuGroup.gpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.gpu.memory",
-                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.disk.scratch",
-                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-            }
+                    "name": "amount.worker.vcpu",
+                    "min": parseInt(cpuGroup.cpuMinText.text),
+                    "max": parseInt(cpuGroup.cpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.memory",
+                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.gpu",
+                    "min": parseInt(gpuGroup.gpuMinText.text),
+                    "max": parseInt(gpuGroup.gpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.gpu.memory",
+                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.disk.scratch",
+                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+                }
             ]
         }
 
@@ -749,7 +749,7 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-         // NOTE: we're not using displayStartFrame since it is rounded up
+        // NOTE: we're not using displayStartFrame since it is rounded up
         const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
         const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
@@ -760,109 +760,136 @@ function __generateUtil() {
         };
     }
 
-    return {
-        "invertObject": invertObject,
-        "toBooleanString": toBooleanString,
-        "parseBool": parseBool,
-        "trimIllegalChars": trimIllegalChars,
-        "sliderTextSync": sliderTextSync,
-        "changeTextValue": changeTextValue,
-        "changeSliderValue": changeSliderValue,
-        "checkGPUAccelType": checkGPUAccelType,
-        "spinBoxLimiterMin": spinBoxLimiterMin,
-        "spinBoxLimiterMax": spinBoxLimiterMax,
-        "getAssetsInScene": getAssetsInScene,
-        "editTextIntValidation": editTextIntValidation,
-        "getDescription": getDescription,
-        "wrappedCallSystem": wrappedCallSystem,
-        "parseErrorData": parseErrorData,
-        "parseVersionData": parseVersionData,
-        "createExportBundleDir": createExportBundleDir,
-        "removeLineBreak": removeLineBreak,
-        "setListBoxSelection": setListBoxSelection,
-        "getPath": getPath,
-        "getPartialExportDir": getPartialExportDir,
-        "collectHostRequirements": collectHostRequirements,
-        "deepCopy": deepCopy,
-        "getActiveComp": getActiveComp,
-        "normalizePath": normalizePath,
-        "normPath": normalizePath,
-        "enforceForwardSlashes": enforceForwardSlashes,
-        "removeIllegalCharacters": removeIllegalCharacters,
-        "removePercentageFromFileName": removePercentageFromFileName,
-        "getTempFile": getTempFile,
-        "getUserDirectory": getUserDirectory,
-        "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder,
-        "calculateFrameRange": calculateFrameRange
+        function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
+            if (enabled) {
+                var days = parseInt(daysInput.text) || 0;
+                var hours = parseInt(hoursInput.text) || 0;
+                var minutes = parseInt(minutesInput.text) || 0;
+
+                if (days === 0 && hours === 0 && minutes === 0) {
+                    adcAlert("Timeout cannot be set to zero. Please enter a value greater than zero for days, hours, or minutes.", true);
+                    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        function getSelection(list) {
+            for (var s = 0; s < list.selection.length; s++) {
+                return list.selection[s];
+            }
+        }
+
+        return {
+            "invertObject": invertObject,
+            "toBooleanString": toBooleanString,
+            "parseBool": parseBool,
+            "trimIllegalChars": trimIllegalChars,
+            "sliderTextSync": sliderTextSync,
+            "changeTextValue": changeTextValue,
+            "changeSliderValue": changeSliderValue,
+            "checkGPUAccelType": checkGPUAccelType,
+            "spinBoxLimiterMin": spinBoxLimiterMin,
+            "spinBoxLimiterMax": spinBoxLimiterMax,
+            "getAssetsInScene": getAssetsInScene,
+            "editTextIntValidation": editTextIntValidation,
+            "getDescription": getDescription,
+            "wrappedCallSystem": wrappedCallSystem,
+            "parseErrorData": parseErrorData,
+            "parseVersionData": parseVersionData,
+            "createExportBundleDir": createExportBundleDir,
+            "removeLineBreak": removeLineBreak,
+            "setListBoxSelection": setListBoxSelection,
+            "getPath": getPath,
+            "getPartialExportDir": getPartialExportDir,
+            "collectHostRequirements": collectHostRequirements,
+            "deepCopy": deepCopy,
+            "getActiveComp": getActiveComp,
+            "normalizePath": normalizePath,
+            "normPath": normalizePath,
+            "enforceForwardSlashes": enforceForwardSlashes,
+            "removeIllegalCharacters": removeIllegalCharacters,
+            "removePercentageFromFileName": removePercentageFromFileName,
+            "getTempFile": getTempFile,
+            "getUserDirectory": getUserDirectory,
+            "getAEVersion": getAEVersion,
+            "getTempFolder": getTempFolder,
+            "calculateFrameRange": calculateFrameRange
+            "validateTimeoutValues": validateTimeoutValues,
+            "getSelection": getSelection,
+            "getTempFolder": getTempFolder
     }
+
 }
+
+
 
 dcUtil = __generateUtil();
 
 
-// Global constants, wrapped with if-blocks to ensure they are only defined once
-// to avoid errors due to redeclaration
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
-}
-if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
-    const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
-}
-if (typeof SUPPORTED_VERSIONS === "undefined") {
-    const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
-}
-if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
-    const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
-}
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
-if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
-    const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
-}
-if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
-    const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
-}
-if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
-    const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
-}
-if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
-    const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
-}
-if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
-    app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
-}
+                        // Global constants, wrapped with if-blocks to ensure they are only defined once
+                        // to avoid errors due to redeclaration
+                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING === "undefined") {
+                            const DEADLINECLOUD_IGNORE_VERSION_WARNING = "ignoreVersionWarning";
+                        }
+                        if (typeof DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION === "undefined") {
+                            const DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION = "ignoreVersionWarningVersion";
+                        }
+                        if (typeof SUPPORTED_VERSIONS === "undefined") {
+                            const SUPPORTED_VERSIONS = [24.6, 25.1, 25.2];
+                        }
+                        if (typeof DEADLINECLOUD_SUBMITTER_SETTINGS === "undefined") {
+                            const DEADLINECLOUD_SUBMITTER_SETTINGS = "Deadline Cloud Submitter";
+                        }
+                        if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
+                            const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
+                        }
+                        if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
+                            const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
+                        }
+                        if (typeof DEADLINECLOUD_MULTI_FRAME_RENDERING === "undefined") {
+                            const DEADLINECLOUD_MULTI_FRAME_RENDERING = "multiFrameRendering";
+                        }
+                        if (typeof DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
+                            const DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE = "maxCpuUsagePercentage";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED = "taskRunTimeoutEnabled";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS = "taskRunTimeoutDays";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS = "taskRunTimeoutHours";
+                        }
+                        if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
+                            const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, dcUtil.getAEVersion().toString());
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_FRAMESPERTASK, "10");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MULTI_FRAME_RENDERING, "false");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE, "90");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_ENABLED, "10");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_DAYS, "2");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS, "0");
+                        }
+                        if (!app.settings.haveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES)) {
+                            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES, "0");
+                        }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -955,7 +955,7 @@ function __generateUtil() {
         return list.selection[0];
     }
 
-    function getRQIID(renderQueueIndex) {
+    function getRenderQueueItemID(renderQueueIndex) {
         /** Calculates an ID for the Render Queue Item with the given index in the render queue
          * Not guaranteed to be unique if render queue items are reordered
          */
@@ -976,7 +976,7 @@ function __generateUtil() {
         }
         var ids = []
         for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            ids.push(getRQIID(i));
+            ids.push(getRenderQueueItemID(i));
         }
         for (var i = 0; i < paths.length; i++) {
             var presentInArray = false;
@@ -1039,7 +1039,7 @@ function __generateUtil() {
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
         "getTempFolder": getTempFolder,
-        "getRQIID": getRQIID,
+        "getRenderQueueItemID": getRenderQueueItemID,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1,16 +1,16 @@
 var scriptFolder = Folder.current.fsName;
 
 function readFile(filePath) {
-    var f = new File(filePath);
+    const f = new File(filePath);
     f.encoding = "UTF-8";
     f.open("r");
-    var fileContents = f.read();
+    const fileContents = f.read();
     f.close();
     return fileContents;
 }
 
 function writeFile(filePath, fileContents) {
-    var f = new File(filePath);
+    const f = new File(filePath);
     f.encoding = "UTF-8";
     f.open("w");
     f.write(fileContents);
@@ -19,7 +19,7 @@ function writeFile(filePath, fileContents) {
 }
 
 function sanitizeOutputs(outputPaths) {
-    var sanitized = [];
+    const sanitized = [];
     var sanitizedPath = "";
     for (var i = 0; i < outputPaths.length; i++) {
         sanitizedPath = sanitizeFilePath(outputPaths[i]);
@@ -109,7 +109,7 @@ function adcAlert(message, errorIcon) {
 
 function __generateUtil() {
 
-    var scriptFileUtilName = "Util.jsx";
+    const scriptFileUtilName = "Util.jsx";
 
 
     function toBooleanString(value) {
@@ -156,7 +156,7 @@ function __generateUtil() {
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
         textObj.onChange = function() {
-            var newValue = parseFloat(textObj.text);
+            const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
                 logger.log("Changed editText(" + textObj.name + ") value to: " + newValue, scriptFileUtilName, LOG_LEVEL.DEBUG);
@@ -178,7 +178,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        var sliderValue = Math.round(sliderObj.value);
+        const sliderValue = Math.round(sliderObj.value);
         if (!isNaN(sliderValue) && sliderValue >= minValue && sliderValue <= maxValue) {
             textObj.text = sliderValue;
         }
@@ -194,7 +194,7 @@ function __generateUtil() {
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
 
-        var newValue = parseFloat(textObj.text);
+        const newValue = parseFloat(textObj.text);
         if (newValue < minValue) {
             textObj.text = minValue;
             sliderObj.value = minValue;
@@ -251,7 +251,7 @@ function __generateUtil() {
          * @param {Object} listBox - Source object to retrieve data from.
          * Returns array with assets available in the scene.
          */
-        var _assetsList = []
+        const _assetsList = []
         for (var i = 0; i < listBox.items.length; i++) {
             _assetsList.push(listBox.items[i].text);
         }
@@ -300,7 +300,7 @@ function __generateUtil() {
          * Inverts a given JavaScript object.
          * Only inverts the first level, does not handle nested objects properly.
          */
-        var ret = {};
+        const ret = {};
         for (var key in jsObject) {
             ret[jsObject[key]] = key;
         }
@@ -311,8 +311,8 @@ function __generateUtil() {
         /**
          * Return File instance from temporary directory with the given name.
          */
-        var _tempFilePath = normalizePath(getTempFolder() + "/" + fileName);
-        var _tempFile = File(_tempFilePath);
+        const _tempFilePath = normalizePath(getTempFolder() + "/" + fileName);
+        const _tempFile = File(_tempFilePath);
         return _tempFile;
     }
 
@@ -342,7 +342,7 @@ function __generateUtil() {
 
         // Test every path in our list by creating a test file
         for (var i = 0; i < altPaths.length; i++) {
-            var folder = new Folder(altPaths[i]);
+            const folder = new Folder(altPaths[i]);
 
             // Create the path if it does not already exist
             folder.create();
@@ -399,9 +399,9 @@ function __generateUtil() {
 
     function _wrappedCallSystemWindows(cmd) {
 
-        var tempOutputFile = getTempFile("deadline_cloud_ae_pipe.txt");
-        var tempBootstrapBatFile = getTempFile("aeCallSystemBootstrap.bat");
-        var tempBatFile = getTempFile("aeCallSystem.bat");
+        const tempOutputFile = getTempFile("deadline_cloud_ae_pipe.txt");
+        const tempBootstrapBatFile = getTempFile("aeCallSystemBootstrap.bat");
+        const tempBatFile = getTempFile("aeCallSystem.bat");
         logger.debug("Command output path: " + tempOutputFile.fsName, scriptFileUtilName);
         _makeBootstrapBatFile(tempBootstrapBatFile, tempBatFile);
         // Wrapped command with error code output
@@ -420,12 +420,12 @@ function __generateUtil() {
         logger.debug(cmd, scriptFileUtilName);
         // Call bootstrap script and return result via intermediary file.
         system.callSystem(tempBootstrapBatFile.fsName);
-        var output = system.callSystem("cmd /c \"type " + tempOutputFile.fsName + "\"");
+        const output = system.callSystem("cmd /c \"type " + tempOutputFile.fsName + "\"");
         return output;
     }
 
     function _makeBootstrapBatFile(bootstrapFile, tempFile) {
-        var _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
+        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
         bootstrapFile.open("w");
         bootstrapFile.writeln(_cmd);
         bootstrapFile.close();
@@ -448,12 +448,12 @@ function __generateUtil() {
         var result = "";
         var message = "";
         var return_code = 0;
-        var errorIndex = output.indexOf("ERROR CODE:");
+        const errorIndex = output.indexOf("ERROR CODE:");
         if (errorIndex !== -1) {
             // Extract the word and everything behind it
             result = output.substring(errorIndex);
             message = cmd + " Failed. Error has occurred.";
-            var regex = /ERROR CODE:(.*)/;
+            const regex = /ERROR CODE:(.*)/;
             return_code = regex.exec(result);
             return {
                 "return_code": return_code,
@@ -477,14 +477,14 @@ function __generateUtil() {
          * [MAJOR, MINOR, PATCH]
          */
         // Regular expression to match "version " followed by version number
-        var regex = /version\s+(\d+)\.(\d+)\.(\d+)/i;
+        const regex = /version\s+(\d+)\.(\d+)\.(\d+)/i;
 
         // Test if the inputString matches the pattern
-        var parsedVersionNumberOutput = output.match(regex);
+        const parsedVersionNumberOutput = output.match(regex);
 
         // Output the result
         if (parsedVersionNumberOutput) {
-            var versionNumbers = [
+            const versionNumbers = [
                 parseInt(parsedVersionNumberOutput[1]), // Major
                 parseInt(parsedVersionNumberOutput[2]), // Minor
                 parseInt(parsedVersionNumberOutput[3]) // Path
@@ -503,8 +503,8 @@ function __generateUtil() {
          * @param {string} fileName: Job name
          * Returns export directory
          */
-        var partialDir = getPartialExportDir(exportBundleDir);
-        var dir = getPath(partialDir, fileName, exportBundleDir);
+        const partialDir = getPartialExportDir(exportBundleDir);
+        const dir = getPath(partialDir, fileName, exportBundleDir);
         return dir.fsName;
     }
 
@@ -540,21 +540,21 @@ function __generateUtil() {
 
     function getPath(toCheckDir, fileName, rootDir) {
         // 1. Find highest sequence number used for today.
-        var splitDir = toCheckDir.split("//");
-        var toCheckFolderName = splitDir[splitDir.length - 1];
-        var parentDir = toCheckDir.replace(toCheckFolderName, "");
-        var mainDir = new Folder(parentDir);
-        var subFolders = mainDir.getFiles();
-        var regex = new RegExp(toCheckFolderName + "(\\d+)-.*");
+        const splitDir = toCheckDir.split("//");
+        const toCheckFolderName = splitDir[splitDir.length - 1];
+        const parentDir = toCheckDir.replace(toCheckFolderName, "");
+        const mainDir = new Folder(parentDir);
+        const subFolders = mainDir.getFiles();
+        const regex = new RegExp(toCheckFolderName + "(\\d+)-.*");
         var maxSeqNumber = 0;
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
             folderName = subFolders[idx].fullName
-            var match = folderName.match(regex)
+            const match = folderName.match(regex)
             if (!match) {
                 continue;
             }
-            var seqNr = parseInt(match[1]) // Convert first capture group to int
+            const seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
                 maxSeqNumber = seqNr
             }
@@ -565,7 +565,7 @@ function __generateUtil() {
         if (nextSeqNumber < 10) {
             nextSeqNumber = "0" + nextSeqNumber;
         }
-        var folder = new Folder(toCheckDir + nextSeqNumber + "-AfterEffects-" + fileName);
+        const folder = new Folder(toCheckDir + nextSeqNumber + "-AfterEffects-" + fileName);
         if (!folder.exists) {
             folder.create();
         }
@@ -578,15 +578,15 @@ function __generateUtil() {
          * @param {string} job_history_dir: Directory where job bundles is written to on submission.
          * Returns partial job history directory.
          */
-        var currentDate = new Date();
-        var year = currentDate.getFullYear();
+        const currentDate = new Date();
+        const year = currentDate.getFullYear();
         // Zero pad all integers to a length of 2
-        var month = ("0" + (currentDate.getMonth() + 1)).slice(-2); // Months are zero-based
-        var day = ("0" + currentDate.getDate()).slice(-2);
+        const month = ("0" + (currentDate.getMonth() + 1)).slice(-2); // Months are zero-based
+        const day = ("0" + currentDate.getDate()).slice(-2);
         // Create the formatted string
-        var formattedYearMonth = year + '-' + month;
-        var formattedDate = year + '-' + month + '-' + day;
-        var dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
+        const formattedYearMonth = year + '-' + month;
+        const formattedDate = year + '-' + month + '-' + day;
+        const dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
         return dir;
     }
 
@@ -594,7 +594,7 @@ function __generateUtil() {
         // Remark: gpu memory and worker memory need to be scaled with *1024, for some of the amount capabilities, the unit displayed on the UI is different
         // then the unit used within template, so use this factor to scale the input values.
 
-        var hostRequirements = {
+        const hostRequirements = {
             "attributes": [{
                 "name": "attr.worker.os.family",
                 "anyOf": [
@@ -658,7 +658,7 @@ function __generateUtil() {
         }
 
         if (obj instanceof Array) {
-            var copyArray = [];
+            const copyArray = [];
             for (var i = 0; i < obj.length; i++) {
                 copyArray[i] = deepCopy(obj[i]);
             }
@@ -666,7 +666,7 @@ function __generateUtil() {
         }
 
         if (obj instanceof Object) {
-            var copyObject = {};
+            const copyObject = {};
             for (var key in obj) {
                 if (obj.hasOwnProperty(key)) {
                     copyObject[key] = deepCopy(obj[key]);
@@ -684,10 +684,10 @@ function __generateUtil() {
          */
         // If submit layers pressed -> itemName is not comp name and therefore comp will not be found with render command
         // Check if itemName is an available comp in the project, if not, it is a layer submission
-        var comp = itemName;
-        var compList = [];
+        const comp = itemName;
+        const compList = [];
         for (var i = 1; i <= app.project.rootFolder.items.length; i++) {
-            var item = app.project.rootFolder.items[i];
+            const item = app.project.rootFolder.items[i];
 
             if (item instanceof CompItem) {
                 compList.push(app.project.activeItem.name);
@@ -700,7 +700,7 @@ function __generateUtil() {
     }
 
     function normalizePath(path) {
-        var _file = new File(path);
+        const _file = new File(path);
         if (system.osName == "MacOS") {
             _file.changePath(_file.fsName.replace(/\\/g, "/"));
             return _file.fsName;
@@ -715,7 +715,7 @@ function __generateUtil() {
     }
 
     function removeIllegalCharacters(inputString) {
-        var outputString = inputString.replace(/[.\-\s]/g, "_");
+        const outputString = inputString.replace(/[.\-\s]/g, "_");
 
         return outputString;
     }
@@ -724,8 +724,7 @@ function __generateUtil() {
      * Replace %20 percentage back to space from the file name for Windows os.
      */
     function removePercentageFromFileName(fileName) {
-        var fileName = fileName.replace(/%20/g, " ");
-        return fileName;
+        return fileName.replace(/%20/g, " ");
     }
 
     function getUserDirectory() {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -107,10 +107,10 @@ function adcAlert(message, errorIcon) {
     alert(message, "Deadline Cloud Submitter", errorIcon);
 }
 
-function validateType(item, item_type) {
-    var actual_type = typeof item;
-    if (actual_type !== item_type) {
-        throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
+function validateType(item, itemType) {
+    var actualType = typeof item;
+    if (actualType !== itemType) {
+        throw new Error("Object has type " + actualType + " instead of desired type " + itemType);
     }
 }
 
@@ -152,17 +152,17 @@ function __generateUtil() {
         app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
-    function getBoolSetting(sectionName, keyName, default_value) {
+    function getBoolSetting(sectionName, keyName, defaultValue) {
         /**
          * Gets boolean value from app settings, or sets it to the default value if no setting exists.
-         * Set default_value to undefined to error on missing setting
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + "does not exist!");
             }
-            saveBoolSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "default_value");
+            saveBoolSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + "defaultValue");
         }
         return parseBool(app.settings.getSetting(sectionName, keyName));
     }
@@ -175,24 +175,24 @@ function __generateUtil() {
         app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
-    function getNumberSetting(sectionName, keyName, default_value) {
+    function getNumberSetting(sectionName, keyName, defaultValue) {
         /**
-         * Gets number value from app settings, or sets default_value if setting does not exist
-         * Set default_value to undefined to error on missing setting
+         * Gets number value from app settings, or sets defaultValue if setting does not exist
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            saveNumberSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+            saveNumberSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            saveNumberSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
+            saveNumberSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + defaultValue);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
     }
@@ -207,15 +207,15 @@ function __generateUtil() {
 
     function getStringSetting(sectionName, keyName, defaultValue) {
         /**
-         * Gets string value from app settings, or sets default_value if setting does not exist
-         * Set default_value to undefined to error on missing setting
+         * Gets string value from app settings, or sets defaultValue if setting does not exist
+         * Set defaultValue to undefined to error on missing setting
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
-            if (default_value === undefined) {
+            if (defaultValue === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            setStringSetting(sectionName, keyName, default_value);
-            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
+            setStringSetting(sectionName, keyName, defaultValue);
+            logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + defaultValue);
         }
         return app.settings.getSetting(sectionName, keyName)
     }
@@ -655,10 +655,10 @@ function __generateUtil() {
         return folder;
     }
 
-    function getPartialExportDir(job_history_dir) {
+    function getPartialExportDir(jobHistoryDir) {
         /**
          * Creates string with correct name and format to be used in job history directory creation.
-         * @param {string} job_history_dir: Directory where job bundles is written to on submission.
+         * @param {string} jobHistoryDir: Directory where job bundles is written to on submission.
          * Returns partial job history directory.
          */
         const currentDate = new Date();
@@ -669,7 +669,7 @@ function __generateUtil() {
         // Create the formatted string
         const formattedYearMonth = year + '-' + month;
         const formattedDate = year + '-' + month + '-' + day;
-        const dir = job_history_dir + "//" + formattedYearMonth + "//" + formattedDate + "-";
+        const dir = jobHistoryDir + "//" + formattedYearMonth + "//" + formattedDate + "-";
         return dir;
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -108,7 +108,7 @@ function adcAlert(message, errorIcon) {
 }
 
 function validateType(item, item_type) {
-    actual_type = typeof item;
+    var actual_type = typeof item;
     if (actual_type !== item_type) {
         throw new Error("Object has type " + actual_type + " instead of desired type " + item_type);
     }
@@ -148,8 +148,8 @@ function __generateUtil() {
         /**
          * Sets boolean value in app settings
          */
-        validateType(value, "boolean")
-        app.settings.saveSetting(sectionName, keyName, value.toString())
+        validateType(value, "boolean");
+        app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
     function getBoolSetting(sectionName, keyName, default_value) {
@@ -171,8 +171,8 @@ function __generateUtil() {
         /**
          * Sets integer value in app settings
          */
-        validateType(value, "number")
-        app.settings.saveSetting(sectionName, keyName, value.toString())
+        validateType(value, "number");
+        app.settings.saveSetting(sectionName, keyName, value.toString());
     }
 
     function getNumberSetting(sectionName, keyName, default_value) {
@@ -182,16 +182,16 @@ function __generateUtil() {
          */
         if (!app.settings.haveSetting(sectionName, keyName)) {
             if (default_value === undefined) {
-                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!")
+                throw new Error("Setting at " + sectionName + ":" + keyName + " does not exist!");
             }
-            saveNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
         if (isNaN(Number(app.settings.getSetting(sectionName, keyName)))) {
             if (default_value === undefined) {
                 throw new Error("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number!");
             }
-            saveNumberSetting(sectionName, keyName, default_value)
+            saveNumberSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " is " + app.settings.getSetting(sectionName, keyName) + ", which cannot be parsed as a Number. Using default value of " + default_value);
         }
         return Number(app.settings.getSetting(sectionName, keyName));
@@ -206,7 +206,7 @@ function __generateUtil() {
     }
 
     function getStringSetting(sectionName, keyName, defaultValue) {
-         /**
+        /**
          * Gets string value from app settings, or sets default_value if setting does not exist
          * Set default_value to undefined to error on missing setting
          */
@@ -217,7 +217,7 @@ function __generateUtil() {
             setStringSetting(sectionName, keyName, default_value);
             logger.warning("Setting at " + sectionName + ":" + keyName + " does not exist, using default value of " + default_value);
         }
-        return app.settings.getSetting(sectionName, keyName) 
+        return app.settings.getSetting(sectionName, keyName)
     }
 
     function trimIllegalChars(stringToTrim) {
@@ -311,7 +311,7 @@ function __generateUtil() {
          */
         maxValue.text = maxValue.text.replace(/[^\d]/g, '');
         if (parseInt(maxValue.text) < parseInt(minValue.text)) {
-            maxValue.text = minValue.text
+            maxValue.text = minValue.text;
         }
     }
 
@@ -489,10 +489,10 @@ function __generateUtil() {
         _makeBootstrapBatFile(tempBootstrapBatFile, tempBatFile);
         // Wrapped command with error code output
         cmd = cmd + " > " + tempOutputFile.fsName;
-        cmd += "\nIF %ERRORLEVEL% NEQ 0 ("
-        cmd += "\n echo ERROR CODE: %ERRORLEVEL% >> " + tempOutputFile.fsName
-        cmd += "\n)"
-        cmd += "\nexit"
+        cmd += "\nIF %ERRORLEVEL% NEQ 0 (";
+        cmd += "\n echo ERROR CODE: %ERRORLEVEL% >> " + tempOutputFile.fsName;
+        cmd += "\n)";
+        cmd += "\nexit";
         tempBatFile.open("w");
         tempBatFile.writeln(cmd);
         tempBatFile.close();
@@ -508,7 +508,7 @@ function __generateUtil() {
     }
 
     function _makeBootstrapBatFile(bootstrapFile, tempFile) {
-        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit"
+        const _cmd = "@echo off" + "\nstart /min /wait " + tempFile.fsName + "\nexit";
         bootstrapFile.open("w");
         bootstrapFile.writeln(_cmd);
         bootstrapFile.close();
@@ -545,7 +545,7 @@ function __generateUtil() {
             }
         }
         result = "";
-        message = cmd + " Successful."
+        message = cmd + " Successful.";
         return {
             "return_code": return_code,
             "message": message,
@@ -632,14 +632,14 @@ function __generateUtil() {
         var maxSeqNumber = 0;
         var folderName = "";
         for (var idx = 0; idx < subFolders.length; idx++) {
-            folderName = subFolders[idx].fullName
-            const match = folderName.match(regex)
+            folderName = subFolders[idx].fullName;
+            const match = folderName.match(regex);
             if (!match) {
                 continue;
             }
             const seqNr = parseInt(match[1]) // Convert first capture group to int
             if (seqNr > maxSeqNumber) {
-                maxSeqNumber = seqNr
+                maxSeqNumber = seqNr;
             }
         }
         // 2. Create new export directory with next sequence number
@@ -813,7 +813,7 @@ function __generateUtil() {
     function getUserDirectory() {
         /* Return OS specific user home directory. */
         if (system.osName == "MacOS") {
-            return $.getenv("HOME")
+            return $.getenv("HOME");
         }
         // Windows:
         return $.getenv("USERPROFILE");
@@ -823,7 +823,7 @@ function __generateUtil() {
         /* Return After Effects version as float. */
         const versionAsString = app.version.substring(0, 4);
         const version = parseFloat(versionAsString);
-        return version
+        return version;
     }
 
     function calculateFrameRange(rqi) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -971,6 +971,7 @@ function __generateUtil() {
         var metadata = new XMPMeta(app.project.xmpPacket);
         var paths = []
         var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
+        var property;
         while (property = iterator.next()) {
             paths.push(property.path);
         }


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/206

### What was the problem/requirement? (What/Why)
If you wished to submit multiple compositions at once as separate steps, this was not currently possible.
### What was the solution? (How)
Refactor and add support to the submitter to allow for this feature to be possible.

I've attempted to keep the commits fairly granular so that reviewers can follow the train of thought throughout the process of the changes. I can squash changes as needed.
### What is the impact of this change?
The logic around the job template has gotten more complex as we now have to generate a job template.
We have tried to make this easier by providing "fragments" of the templates that are used to generate the final template.
### How was this change tested?
- [x] Testing using SMF from a Windows AE 25.3 client.
- [x] Tested using SMF from a MacOS AE 25.3 client
- [x] Testing using SMF from a Windows AE 25.2 client.
- [x] Tested using SMF from a MacOS AE 25.2 client
- [x] Testing using SMF from a Windows AE 24.6 client.
- [x] Tested using SMF from a MacOS AE 24.6 client
#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

### Was this change documented?
Not documented.

### Is this a breaking change?

 Yes. The code structure has changed enough that this is breaking. We are also now generating the job bundles so this is breaking


---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
