### PR TITLE
fix: update the font manager python to skip the font copy if the file exis…

### DIFF
--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/font_manager.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/font_manager.py
@@ -32,13 +32,16 @@ INSTALL_SCOPE_USER = "USER"
 INSTALL_SCOPE_SYSTEM = "SYSTEM"
 
 FONT_LOCATION_SYSTEM = os.path.join(os.environ.get("SystemRoot"), "Fonts")
-FONT_LOCATION_USER = os.path.join(os.environ.get("LocalAppData"), "Microsoft", "Windows", "Fonts")
+FONT_LOCATION_USER = os.path.join(
+    os.environ.get("LocalAppData"), "Microsoft", "Windows", "Fonts"
+)
 
 # Font extensions supported in gdi32.AddFontResourceW
 # OpenType fonts without an extension can also be installed (e.g. Adobe Fonts)
 FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
 
 logger = logging.getLogger(__name__)
+
 
 def find_fonts(session_dir):
     """
@@ -64,7 +67,9 @@ def find_fonts(session_dir):
                     break
 
         if not full_sub_dir:
-            logger.debug(f"Couldn't recursively find tempFonts in subfolder: {subfolder}")
+            logger.debug(
+                f"Couldn't recursively find tempFonts in subfolder: {subfolder}"
+            )
             continue
 
         for file_name in os.listdir(full_sub_dir):
@@ -74,7 +79,9 @@ def find_fonts(session_dir):
                 logger.debug(f"Adding: {full_assetpath}")
                 fonts.add(full_assetpath)
             else:
-                logger.warning(f"A file that is not a supported font was found in the tempFonts folder: {full_assetpath}")
+                logger.warning(
+                    f"A file that is not a supported font was found in the tempFonts folder: {full_assetpath}"
+                )
     return fonts
 
 
@@ -92,9 +99,13 @@ def get_font_name(dst_path):
 
         # Try to get the font's real name
         cb = wintypes.DWORD()
-        if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), None, GFRI_DESCRIPTION):
+        if gdi32.GetFontResourceInfoW(
+            filename, ctypes.byref(cb), None, GFRI_DESCRIPTION
+        ):
             buf = (ctypes.c_wchar * cb.value)()
-            if gdi32.GetFontResourceInfoW(filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION):
+            if gdi32.GetFontResourceInfoW(
+                filename, ctypes.byref(cb), buf, GFRI_DESCRIPTION
+            ):
                 fontname = buf.value
         is_truetype = wintypes.BOOL()
         cb.value = ctypes.sizeof(is_truetype)
@@ -134,6 +145,71 @@ def install_font(src_path, scope=INSTALL_SCOPE_USER):
         dst_path = os.path.join(dst_dir, os.path.basename(src_path))
 
         # Copy the font to the Windows Fonts folder
+        if os.path.exists(dst_path):
+            logger.info(f"Font file already exists at {dst_path}")
+
+            # Check if file is locked by trying to open it in "r+b" mode
+            try:
+                # Try to open the file to see if it's locked
+                with open(dst_path, "r+b") as f:
+                    pass  # File is not locked
+                logger.info(
+                    f"Font file at {dst_path} is not locked, proceeding with copy"
+                )
+            except (IOError, PermissionError):
+                logger.info(
+                    f"Font file at {dst_path} appears to be locked by another process"
+                )
+
+                # On Windows, implement approach to deal with locked files
+                import time
+
+                max_attempts = 3
+                attempts = 0
+                success = False
+
+                while attempts < max_attempts and not success:
+                    try:
+                        # Try to release resource through garbage collection
+                        import gc
+
+                        gc.collect()
+                        # Try copying with a different method
+                        with open(src_path, "rb") as src_file:
+                            with open(dst_path, "wb") as dst_file:
+                                dst_file.write(src_file.read())
+                        success = True
+                    except (IOError, PermissionError):
+                        # Wait with exponential backoff
+                        wait_time = 2**attempts
+                        logger.info(
+                            f"Attempt {attempts+1} failed, waiting {wait_time} seconds before retry"
+                        )
+                        time.sleep(wait_time)
+                        attempts += 1
+
+                if not success:
+                    # If we still can't copy the file, check if the file content is the same
+                    try:
+                        import filecmp
+
+                        if filecmp.cmp(src_path, dst_path):
+                            logger.info(
+                                "Source and destination files have identical content, continuing"
+                            )
+                            success = True
+                        else:
+                            # Different file with same name - this is a problem
+                            raise PermissionError(
+                                f"Could not copy {src_path} to {dst_path} after multiple attempts"
+                            )
+                    except:
+                        # If we can't compare files, we need to alert about the issue
+                        logger.warning(
+                            f"Could not copy or verify {src_path}, but existing file found at {dst_path}"
+                        )
+        else:
+        # Destination doesn't exist, proceed with regular copy
         shutil.copy(src_path, dst_path)
 
         # Load the font in the current session, remove font when loading fails
@@ -151,7 +227,9 @@ def install_font(src_path, scope=INSTALL_SCOPE_USER):
         fontname = get_font_name(dst_path)
 
         # Creates registry if it doesn't exist, opens when it does exist
-        with winreg.CreateKeyEx(registry_scope, FONTS_REG_PATH, 0, access= winreg.KEY_SET_VALUE) as key:
+        with winreg.CreateKeyEx(
+            registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE
+        ) as key:
             winreg.SetValueEx(key, fontname, 0, winreg.REG_SZ, filename)
     except Exception:
         return False, traceback.format_exc()
@@ -178,7 +256,9 @@ def uninstall_font(src_path, scope=INSTALL_SCOPE_USER):
         # Remove the fontname/filename from the registry
         fontname = get_font_name(dst_path)
 
-        with winreg.OpenKey(registry_scope, FONTS_REG_PATH, 0, access= winreg.KEY_SET_VALUE) as key:
+        with winreg.OpenKey(
+            registry_scope, FONTS_REG_PATH, 0, access=winreg.KEY_SET_VALUE
+        ) as key:
             winreg.DeleteValue(key, fontname)
 
         # Unload the font in the current session
@@ -243,7 +323,7 @@ def setup_logger():
     Does a basic setup for a logger
     """
     logger.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(levelname)s:%(message)s')
+    formatter = logging.Formatter("%(levelname)s:%(message)s")
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are seeing customers hitting font installation failure with error
```
2025/05/27 13:58:18-07:00     shutil.copy(src_path, dst_path)
2025/05/27 13:58:18-07:00   File "C:\Program Files\Python311\Lib\shutil.py", line 431, in copy
2025/05/27 13:58:18-07:00     copyfile(src, dst, follow_symlinks=follow_symlinks)
2025/05/27 13:58:18-07:00   File "C:\Program Files\Python311\Lib\shutil.py", line 258, in copyfile
2025/05/27 13:58:18-07:00     with open(dst, 'wb') as fdst:
2025/05/27 13:58:18-07:00          ^^^^^^^^^^^^^^^
2025/05/27 13:58:18-07:00 PermissionError: [Errno 13] Permission denied:
```
It seems the font file was hold by another process in the worker so the copy failed.


### What was the solution? (How)
- If the destination file doesn't exist, perform a normal copy
- If the destination file exists:
    - First try to open the file to check if it's locked
    - If the file is locked, make multiple attempts to copy with exponential backoff
    - If copying still fails, compare the source and destination files
    - If the files are identical, proceed with installation
    - If the files are different, raise an error
### What is the impact of this change?
Hope to resolve intermitent installation failure.
### How was this change tested?
I submitted a test job holding the font file open by a keep running subprocess and then cancel the main job to allow the second AE job using the font file starts. 
```
# file_holder.py
import os
import sys
import time
import shutil
import subprocess
import logging

# Setup logging
logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
logger = logging.getLogger(__name__)

def main():
    # Check if a font path was provided as an argument
    if len(sys.argv) < 2:
        logger.error("No font file path provided. Usage: python file_holder.py <font_file_path>")
        sys.exit(1)
    
    # Get the source font path from command line arguments
    src_font_path = sys.argv[1]
    if not os.path.exists(src_font_path):
        logger.error(f"Font file not found: {src_font_path}")
        sys.exit(1)
        
    # Define the destination path
    dst_font_path = r"C:\Users\job-user\AppData\Local\Microsoft\Windows\Fonts\Avantt-Bold.otf"
    
    # Ensure the directory exists
    os.makedirs(os.path.dirname(dst_font_path), exist_ok=True)
    
    logger.info(f"Parent process started with PID: {os.getpid()}")
    logger.info(f"Source font path: {src_font_path}")
    logger.info(f"Destination font path: {dst_font_path}")
    
    # Copy the font file
    try:
        shutil.copy(src_font_path, dst_font_path)
        logger.info(f"Font copied successfully to {dst_font_path}")
    except Exception as e:
        # If the file already exists, continue
        if os.path.exists(dst_font_path):
            logger.info(f"Font file already exists at {dst_font_path}, continuing...")
        else:
            logger.error(f"Failed to copy font: {str(e)}")
            sys.exit(1)
    
    # Create the child process script that will keep the file open
    child_script = f"""
import os
import sys
import time
import logging

# Setup logging
logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
logger = logging.getLogger(__name__)

# Open the font file and keep it open
font_path = r"{dst_font_path}"
logger.info(f"Child process started with PID: {{os.getpid()}}")
logger.info(f"Opening and holding font file: {{font_path}}")

try:
    f = open(font_path, 'rb+')
    logger.info(f"File opened successfully")
    
    # Write a marker to show we have the file open
    try:
        # Attempt to write at the end of the file without changing content
        f.seek(0, 2)  # Move to end of file
        position = f.tell()
        logger.info(f"File position before write: {{position}}")
        
        # No actual write, just demonstration that we could
        # Writing to a font file could corrupt it, so we just hold it open
        
        logger.info(f"File held open by PID: {{os.getpid()}}")
        
        while True:
            logger.info(f"Still holding file open at {{time.strftime('%H:%M:%S')}}")
            time.sleep(30)  # Log every 30 seconds that we're still running
            
    except Exception as e:
        logger.error(f"Error while holding file: {{str(e)}}")
except Exception as e:
    logger.error(f"Failed to open file: {{str(e)}}")
    sys.exit(1)
"""
    
    # Write the child script to a file
    child_script_path = os.path.join(os.path.dirname(dst_font_path), "child_script.py")
    with open(child_script_path, "w") as script_file:
        script_file.write(child_script)
    
    logger.info(f"Created child script at: {child_script_path}")
    
    # Launch the child process with a new process group so it doesn't receive signals from the parent
    log_file = os.path.join(os.path.dirname(dst_font_path), "child_output.log")
    logger.info(f"Child process logs will be written to: {log_file}")
    
    subprocess.Popen([sys.executable, child_script_path], 
                    start_new_session=True,  # This ensures the child doesn't get the parent's signals
                    stdout=open(log_file, 'w'),
                    stderr=subprocess.STDOUT)
    
    logger.info("Child process spawned, parent will continue running...")
    logger.info(f"To verify: check if file {dst_font_path} is still open after job termination")
    logger.info("You can use Process Explorer or handle.exe on Windows to check open handles")
    
    # Parent process continues running so the job doesn't end immediately
    # This will be terminated when the job is canceled with TERMINATE mode
    logger.info("Parent process running indefinitely...")
    # while True:
    #     time.sleep(60)
    #     logger.info("Parent process still running...")

if __name__ == "__main__":
    main()
```

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

### Was this change documented?

_delete text starting here_

- Did you update all relevant docstrings for functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?

  _delete text ending here_

### Is this a breaking change?
N/A

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
