### PR TITLE
feat: Ignore Missing Dependencies

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -48,6 +48,9 @@ if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
 if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
     const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
 }
+if (typeof DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES === "undefined") {
+    const DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES = "ignoreMissingDependencies";
+}
 if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
     const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
 }
@@ -68,6 +71,9 @@ if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
 }
 if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
+if (typeof DEFAULT_IGNORE_MISSING_DEPENDENCIES === "undefined") {
+    const DEFAULT_IGNORE_MISSING_DEPENDENCIES = false;
 }
 
 var FootageTypes = {
@@ -1381,33 +1387,41 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.name = name;
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
-    this.framesPerTask = function() {
+    this.framesPerTask = function () {
         return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
-    this.setFramesPerTask = function(value) {
+    this.setFramesPerTask = function (value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
-    this.multiFrameRendering = function() {
+    this.multiFrameRendering = function () {
         return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
-    this.setMultiFrameRendering = function(value) {
+    this.setMultiFrameRendering = function (value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
         dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
-    this.maxCpuUsagePercentage = function() {
+    this.maxCpuUsagePercentage = function () {
         return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
-    this.setMaxCpuUsagePercentage = function(value) {
+    this.setMaxCpuUsagePercentage = function (value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
+
+    this.ignoreMissingDependencies = function () {
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
+    }
+    this.setIgnoreMissingDependencies = function (value) {
+        logger.warning("(" + this.name + ") Setting ignoreMissingDependencies to " + value)
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
+    }
 }
 
-UiSettingsState.prototype.get = function(RQIID) {
+UiSettingsState.prototype.get = function (RQIID) {
     /**
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */
@@ -1496,11 +1510,14 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
  * More efficient than just iterating through items in the project when
  * there is a lot of unused footage in the project
  **/
-function findJobAttachments(rootComp) {
+function findJobAttachments(rootComp, ignoreMissingDependencies) {
     if (rootComp == null) {
         return [];
     }
-    var attachments = [];
+    if (ignoreMissingDependencies === undefined) {
+        ignoreMissingDependencies = false;
+    }
+    const attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
@@ -1526,7 +1543,8 @@ function findJobAttachments(rootComp) {
                     src instanceof FootageItem &&
                     src.mainSource instanceof FileSource
                 ) {
-                    if (src.footageMissing) {
+                    // We only care if the footage is missing when ignoreMissingDependencies is false
+                    if (src.footageMissing && !ignoreMissingDependencies) {
                         if (shouldShowPopup) {
                             adcAlert(
                                 "Missing Footage: " +
@@ -1552,7 +1570,8 @@ function findJobAttachments(rootComp) {
         // Notify the user if any fonts are missing or are substituted during the session.
         // A substituted font is a font that was already missing when the project is opened.
         // A missing font is a font that went missing (e.g. font was uninstalled) while the project was open.
-        if (app.fonts.missingOrSubstitutedFonts != "") {
+        //  Again only only care if ignoreMissingDependencies is false
+        if (app.fonts.missingOrSubstitutedFonts != "" && !ignoreMissingDependencies) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }
         // Formatting collected fonts
@@ -2253,6 +2272,7 @@ function SubmitSelection(selection, selectionSettings) {
         var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
         var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
         var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
+        var stepIgnoreMissingDependencies = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).ignoreMissingDependencies();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -2268,7 +2288,7 @@ function SubmitSelection(selection, selectionSettings) {
         var startFrame = frameRange.startFrame;
         var endFrame = frameRange.endFrame;
 
-        var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
+        var dependencies = findJobAttachments(renderQueueItem.comp, stepIgnoreMissingDependencies); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
@@ -3114,6 +3134,27 @@ function buildUI(thisObj) {
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
+    // Ignore Missing Dependencies GUI
+    const ignoreMissingDepsGroup = perCompSettingsGroup.add("group", undefined, "");
+    ignoreMissingDepsGroup.orientation = "column";
+    ignoreMissingDepsGroup.alignment = ['fill', 'top'];
+    ignoreMissingDepsGroup.alignChildren = ['left', 'center'];
+
+    const ignoreMissingDepsCheckBox = ignoreMissingDepsGroup.add("checkbox", undefined, "Ignore Missing Dependencies");
+    ignoreMissingDepsGroup.orientation = "column";
+
+    // Ignore Missing Dependencies Checkbox
+    function onIgnoreMissingDepsCheckBoxClicked() {
+        if (list.selection == null) {
+            return;
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
+        }
+    }
+    ignoreMissingDepsCheckBox.onClick = onIgnoreMissingDepsCheckBoxClicked;
+
     function isRenderQueueItemImageOutput(renderQueueItem) {
         if (renderQueueItem.numOutputModules === 1) {
             const outputModule = renderQueueItem.outputModule(1).file;
@@ -3303,6 +3344,7 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = "";
+            ignoreMissingDepsCheckBox.value = false;
 
             if (selection === null) {
                 submitButton.enabled = false;
@@ -3336,6 +3378,8 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.onChange();
             mfrCheckBox.value = settings.multiFrameRendering();
             mfrCheckBox.onClick();
+            ignoreMissingDepsCheckBox.value = settings.ignoreMissingDependencies();
+            ignoreMissingDepsCheckBox.onClick();
         }
         list.onChange = onSelectionChange;
         list.selection = null;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1524,7 +1524,7 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
     if (ignoreMissingDependencies === undefined) {
         ignoreMissingDependencies = false;
     }
-    const attachments = [];
+    var attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1577,7 +1577,7 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
         // Notify the user if any fonts are missing or are substituted during the session.
         // A substituted font is a font that was already missing when the project is opened.
         // A missing font is a font that went missing (e.g. font was uninstalled) while the project was open.
-        //  Again only only care if ignoreMissingDependencies is false
+        //  Again only care if ignoreMissingDependencies is false
         if (app.fonts.missingOrSubstitutedFonts != "" && !ignoreMissingDependencies) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1447,6 +1447,7 @@ function generateParameterValues(
     chunkSize,
     multiFrameRendering,
     maxCpuUsagePercentage,
+    ignoreMissingDependencies,
     prefix
 ) {
     const parameterValuesList = [{
@@ -1481,6 +1482,12 @@ function generateParameterValues(
             name: prefix + "_ChunkSize",
             value: chunkSize,
         });
+    }
+    if (ignoreMissingDependencies) {
+        parameterValuesList.push({
+            name: prefix + "_IgnoreMissingDependencies",
+            value: ignoreMissingDependencies === true ? "ON" : "OFF",
+        })
     }
     return {
         parameterValues: parameterValuesList
@@ -2317,6 +2324,7 @@ function SubmitSelection(selection, selectionSettings) {
             stepFramesPerTask,
             stepMultiFrameRendering,
             stepMaxCpuUsagePercentage,
+            stepIgnoreMissingDependencies,
             generateParameterName(renderQueueIndex, compName, "")
         );
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1512,6 +1512,71 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
     };
 }
 
+function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
+    if (layer == null || !(layer instanceof AVLayer) || layer.source == null) {
+        return {
+            queue: queue,
+            exploredItems: exploredItems,
+            attachments: attachments,
+            shouldShowPopup: shouldShowPopup
+        }
+    }
+    var src = layer.source;
+    if (src.id in exploredItems) {
+        return {
+            queue: queue,
+            exploredItems: exploredItems,
+            attachments: attachments,
+            shouldShowPopup: shouldShowPopup
+        }
+    }
+    exploredItems[src.id] = true;
+    if (src instanceof CompItem) {
+        queue.push(src);
+    } else if (src instanceof FootageItem && src.mainSource instanceof FileSource) {
+        // We only care if the footage is missing when ignoreMissingDependencies is false
+        if (src.footageMissing && !ignoreMissingDependencies) {
+            if (shouldShowPopup) {
+                adcAlert(
+                    "Missing Footage: " +
+                    src.name +
+                    " (" +
+                    src.missingFootagePath +
+                    ")",
+                    false
+                );
+                shouldShowPopup = false;
+            }
+        } else {
+            attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
+        }
+    }
+    return {
+        queue: queue,
+        exploredItems: exploredItems,
+        attachments: attachments,
+        shouldShowPopup: shouldShowPopup
+    }
+}
+
+function processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies) {
+    var comp = queue.pop();
+    var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
+    for (var i = 1; i <= comp.numLayers; i++) {
+        var layer = comp.layer(i);
+        var result = processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup);
+        queue = result.queue;
+        exploredItems = result.exploredItems;
+        attachments = result.attachments;
+        shouldShowPopup = result.shouldShowPopup;
+    }
+    return {
+        queue: queue,
+        exploredItems: exploredItems,
+        attachments: attachments,
+    }
+}
+
 /**
  * Breadth first sweep through the root composition to find all footage and font references
  * More efficient than just iterating through items in the project when
@@ -1525,50 +1590,15 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
         ignoreMissingDependencies = false;
     }
     var attachments = [];
-    const exploredItems = {}; // using this object as a set because AE doesn't support sets
+    var exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
-    const queue = [rootComp];
+    var queue = [rootComp];
     while (queue.length > 0) {
-        var comp = queue.pop();
-        var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
-        for (var i = 1; i <= comp.numLayers; i++) {
-            var layer = comp.layer(i);
-            if (
-                layer != null &&
-                layer instanceof AVLayer &&
-                layer.source != null
-            ) {
-                var src = layer.source;
-                if (src.id in exploredItems) {
-                    continue;
-                }
-                exploredItems[src.id] = true;
-                if (src instanceof CompItem) {
-                    queue.push(src);
-                } else if (
-                    src instanceof FootageItem &&
-                    src.mainSource instanceof FileSource
-                ) {
-                    // We only care if the footage is missing when ignoreMissingDependencies is false
-                    if (src.footageMissing && !ignoreMissingDependencies) {
-                        if (shouldShowPopup) {
-                            adcAlert(
-                                "Missing Footage: " +
-                                src.name +
-                                " (" +
-                                src.missingFootagePath +
-                                ")",
-                                false
-                            );
-                            shouldShowPopup = false;
-                        }
-                    } else {
-                        attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
-                    }
-                }
-            }
-        }
+        var result = processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies);
+        queue = result.queue;
+        exploredItems = result.exploredItems;
+        attachments = result.attachments;
     }
 
     const fontsInProject = getFontsFromFile();

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1512,6 +1512,10 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
     };
 }
 
+/**
+ * Helper for recursive job attachment search in findJobAttachments.
+ * Updates the queue, exploredItems list, and attachments list after processing a single AV layer.
+ */
 function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
     if (layer == null || !(layer instanceof AVLayer) || layer.source == null) {
         return {
@@ -1559,6 +1563,10 @@ function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingD
     }
 }
 
+/**
+ * Helper for recursive job attachment search in findJobAttachments.
+ * Updates the queue, exploredItems list, and attachments list after recursively processing all layers in a comp.
+ */
 function processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies) {
     var comp = queue.pop();
     var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
@@ -111,6 +111,21 @@
       "default": 90
     },
     {
+      "name": "IgnoreMissingDependencies",
+      "type": "STRING",
+      "default": "OFF",
+      "allowedValues": [
+        "ON",
+        "OFF"
+      ],
+      "userInterface": {
+        "control": "DROPDOWN_LIST",
+        "label": "Ignore Missing Dependencies",
+        "groupLabel": "Ignore Missing Dependencies"
+      },
+      "description": "Missing dependencies rendering settings"
+    },
+    {
       "name": "JobScriptDir",
       "description": "Directory containing embedded scripts.",
       "userInterface": {

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
@@ -123,7 +123,7 @@
         "label": "Ignore Missing Dependencies",
         "groupLabel": "Ignore Missing Dependencies"
       },
-      "description": "Missing dependencies rendering settings"
+      "description": "Allows render to continue without failing if referenced files are missing."
     },
     {
       "name": "JobScriptDir",

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
@@ -101,6 +101,21 @@
       "default": 90
     },
     {
+      "name": "IgnoreMissingDependencies",
+      "type": "STRING",
+      "default": "OFF",
+      "allowedValues": [
+        "ON",
+        "OFF"
+      ],
+      "userInterface": {
+        "control": "DROPDOWN_LIST",
+        "label": "Ignore Missing Dependencies",
+        "groupLabel": "Ignore Missing Dependencies"
+      },
+      "description": "Missing dependencies rendering settings"
+    },
+    {
       "name": "JobScriptDir",
       "description": "Directory containing embedded scripts.",
       "userInterface": {

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
@@ -113,7 +113,7 @@
         "label": "Ignore Missing Dependencies",
         "groupLabel": "Ignore Missing Dependencies"
       },
-      "description": "Missing dependencies rendering settings"
+      "description": "Allows render to continue without failing if referenced files are missing."
     },
     {
       "name": "JobScriptDir",

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
@@ -37,6 +37,7 @@ def main():
         default=90,
         help="Specifies the desired maximum CPU percentage power to use during rendering. Value is ignored if MFR is OFF",
     )
+    parser.add_argument("--ignore-missing-dependencies", type=str, default="OFF", help="Missing dependencies checking")
 
     args = parser.parse_args()
     print(f"Args: {args}", flush=True)
@@ -88,6 +89,8 @@ def main():
         args.multi_frame_rendering,
         str(args.max_cpu_usage_percentage),
     ]
+    if args.ignore_missing_dependencies == "ON":
+        render_args.append("-continueOnMissingFootage")
 
     if "," not in args.outputpath:
         render_args.extend(["-output", f'"{args.outputpath}"'])

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_image_fragment.json
@@ -39,7 +39,9 @@
               "--multi-frame-rendering",
               "{{Param.MultiFrameRendering}}",
               "--max-cpu-usage-percentage",
-              "{{Param.MaxCpuUsagePercentage}}"
+              "{{Param.MaxCpuUsagePercentage}}",
+              "--ignore-missing-dependencies",
+              "{{Param.IgnoreMissingDependencies}}"
             ]
           }
         }

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/step_video_fragment.json
@@ -26,7 +26,9 @@
               "--multi-frame-rendering",
               "{{Param.MultiFrameRendering}}",
               "--max-cpu-usage-percentage",
-              "{{Param.MaxCpuUsagePercentage}}"
+              "{{Param.MaxCpuUsagePercentage}}",
+              "--ignore-missing-dependencies",
+              "{{Param.IgnoreMissingDependencies}}"
             ]
           }
         }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -78,6 +78,71 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
     };
 }
 
+function processAVLayer(queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
+    if (layer == null || !(layer instanceof AVLayer) || layer.source == null) {
+        return {
+            queue: queue,
+            exploredItems: exploredItems,
+            attachments: attachments,
+            shouldShowPopup: shouldShowPopup
+        }
+    }
+    var src = layer.source;
+    if (src.id in exploredItems) {
+        return {
+            queue: queue,
+            exploredItems: exploredItems,
+            attachments: attachments,
+            shouldShowPopup: shouldShowPopup
+        }
+    }
+    exploredItems[src.id] = true;
+    if (src instanceof CompItem) {
+        queue.push(src);
+    } else if (src instanceof FootageItem && src.mainSource instanceof FileSource) {
+        // We only care if the footage is missing when ignoreMissingDependencies is false
+        if (src.footageMissing && !ignoreMissingDependencies) {
+            if (shouldShowPopup) {
+                adcAlert(
+                    "Missing Footage: " +
+                    src.name +
+                    " (" +
+                    src.missingFootagePath +
+                    ")",
+                    false
+                );
+                shouldShowPopup = false;
+            }
+        } else {
+            attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
+        }
+    }
+    return {
+        queue: queue,
+        exploredItems: exploredItems,
+        attachments: attachments,
+        shouldShowPopup: shouldShowPopup
+    }
+}
+
+function processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies) {
+    var comp = queue.pop();
+    var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
+    for (var i = 1; i <= comp.numLayers; i++) {
+        var layer = comp.layer(i);
+        var result = processAVLayer(queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup);
+        queue = result.queue;
+        exploredItems = result.exploredItems;
+        attachments = result.attachments;
+        shouldShowPopup = result.shouldShowPopup;
+    }
+    return {
+        queue: queue,
+        exploredItems: exploredItems,
+        attachments: attachments,
+    }
+}
+
 /**
  * Breadth first sweep through the root composition to find all footage and font references
  * More efficient than just iterating through items in the project when
@@ -91,50 +156,15 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
         ignoreMissingDependencies = false;
     }
     var attachments = [];
-    const exploredItems = {}; // using this object as a set because AE doesn't support sets
+    var exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
-    const queue = [rootComp];
+    var queue = [rootComp];
     while (queue.length > 0) {
-        var comp = queue.pop();
-        var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
-        for (var i = 1; i <= comp.numLayers; i++) {
-            var layer = comp.layer(i);
-            if (
-                layer != null &&
-                layer instanceof AVLayer &&
-                layer.source != null
-            ) {
-                var src = layer.source;
-                if (src.id in exploredItems) {
-                    continue;
-                }
-                exploredItems[src.id] = true;
-                if (src instanceof CompItem) {
-                    queue.push(src);
-                } else if (
-                    src instanceof FootageItem &&
-                    src.mainSource instanceof FileSource
-                ) {
-                    // We only care if the footage is missing when ignoreMissingDependencies is false
-                    if (src.footageMissing && !ignoreMissingDependencies) {
-                        if (shouldShowPopup) {
-                            adcAlert(
-                                "Missing Footage: " +
-                                src.name +
-                                " (" +
-                                src.missingFootagePath +
-                                ")",
-                                false
-                            );
-                            shouldShowPopup = false;
-                        }
-                    } else {
-                        attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
-                    }
-                }
-            }
-        }
+        var result = processJobAttachmentLayer(queue, exploredItems, attachments, ignoreMissingDependencies);
+        queue = result.queue;
+        exploredItems = result.exploredItems;
+        attachments = queue.attachments;
     }
 
     const fontsInProject = getFontsFromFile();

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -90,7 +90,7 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
     if (ignoreMissingDependencies === undefined) {
         ignoreMissingDependencies = false;
     }
-    const attachments = [];
+    var attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -78,7 +78,7 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
     };
 }
 
-function processAVLayer(queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
+function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
     if (layer == null || !(layer instanceof AVLayer) || layer.source == null) {
         return {
             queue: queue,
@@ -130,7 +130,7 @@ function processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissi
     var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media
     for (var i = 1; i <= comp.numLayers; i++) {
         var layer = comp.layer(i);
-        var result = processAVLayer(queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup);
+        var result = processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup);
         queue = result.queue;
         exploredItems = result.exploredItems;
         attachments = result.attachments;
@@ -161,10 +161,10 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
     exploredItems[rootComp.id] = true;
     var queue = [rootComp];
     while (queue.length > 0) {
-        var result = processJobAttachmentLayer(queue, exploredItems, attachments, ignoreMissingDependencies);
+        var result = processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies);
         queue = result.queue;
         exploredItems = result.exploredItems;
-        attachments = queue.attachments;
+        attachments = result.attachments;
     }
 
     const fontsInProject = getFontsFromFile();

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -143,7 +143,7 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
         // Notify the user if any fonts are missing or are substituted during the session.
         // A substituted font is a font that was already missing when the project is opened.
         // A missing font is a font that went missing (e.g. font was uninstalled) while the project was open.
-        //  Again only only care if ignoreMissingDependencies is false
+        //  Again only care if ignoreMissingDependencies is false
         if (app.fonts.missingOrSubstitutedFonts != "" && !ignoreMissingDependencies) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -76,11 +76,14 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
  * More efficient than just iterating through items in the project when
  * there is a lot of unused footage in the project
  **/
-function findJobAttachments(rootComp) {
+function findJobAttachments(rootComp, ignoreMissingDependencies) {
     if (rootComp == null) {
         return [];
     }
-    var attachments = [];
+    if (ignoreMissingDependencies === undefined) {
+        ignoreMissingDependencies = false;
+    }
+    const attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
@@ -106,7 +109,8 @@ function findJobAttachments(rootComp) {
                     src instanceof FootageItem &&
                     src.mainSource instanceof FileSource
                 ) {
-                    if (src.footageMissing) {
+                    // We only care if the footage is missing when ignoreMissingDependencies is false
+                    if (src.footageMissing && !ignoreMissingDependencies) {
                         if (shouldShowPopup) {
                             adcAlert(
                                 "Missing Footage: " +
@@ -132,7 +136,8 @@ function findJobAttachments(rootComp) {
         // Notify the user if any fonts are missing or are substituted during the session.
         // A substituted font is a font that was already missing when the project is opened.
         // A missing font is a font that went missing (e.g. font was uninstalled) while the project was open.
-        if (app.fonts.missingOrSubstitutedFonts != "") {
+        //  Again only only care if ignoreMissingDependencies is false
+        if (app.fonts.missingOrSubstitutedFonts != "" && !ignoreMissingDependencies) {
             adcAlert("Missing fonts in project: " + (app.fonts.missingOrSubstitutedFonts).toString(), false);
         }
         // Formatting collected fonts

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -13,6 +13,7 @@ function generateParameterValues(
     chunkSize,
     multiFrameRendering,
     maxCpuUsagePercentage,
+    ignoreMissingDependencies,
     prefix
 ) {
     const parameterValuesList = [{
@@ -47,6 +48,12 @@ function generateParameterValues(
             name: prefix + "_ChunkSize",
             value: chunkSize,
         });
+    }
+    if (ignoreMissingDependencies) {
+        parameterValuesList.push({
+            name: prefix + "_IgnoreMissingDependencies",
+            value: ignoreMissingDependencies === true ? "ON" : "OFF",
+        })
     }
     return {
         parameterValues: parameterValuesList

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -78,6 +78,10 @@ function jobAttachmentsJson(inputFiles, outputFolder) {
     };
 }
 
+/**
+ * Helper for recursive job attachment search in findJobAttachments.
+ * Updates the queue, exploredItems list, and attachments list after processing a single AV layer.
+ */
 function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingDependencies, shouldShowPopup) {
     if (layer == null || !(layer instanceof AVLayer) || layer.source == null) {
         return {
@@ -125,6 +129,10 @@ function processAVLayer(layer, queue, exploredItems, attachments, ignoreMissingD
     }
 }
 
+/**
+ * Helper for recursive job attachment search in findJobAttachments.
+ * Updates the queue, exploredItems list, and attachments list after recursively processing all layers in a comp.
+ */
 function processJobAttachmentComp(queue, exploredItems, attachments, ignoreMissingDependencies) {
     var comp = queue.pop();
     var shouldShowPopup = true; // only show the popup once per comp so the user doesn't get spammed if there's a lot of missing media

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -426,6 +426,7 @@ function SubmitSelection(selection, selectionSettings) {
             stepFramesPerTask,
             stepMultiFrameRendering,
             stepMaxCpuUsagePercentage,
+            stepIgnoreMissingDependencies,
             generateParameterName(renderQueueIndex, compName, "")
         );
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -381,6 +381,7 @@ function SubmitSelection(selection, selectionSettings) {
         var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
         var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
         var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
+        var stepIgnoreMissingDependencies = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).ignoreMissingDependencies();
 
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
@@ -396,7 +397,7 @@ function SubmitSelection(selection, selectionSettings) {
         var startFrame = frameRange.startFrame;
         var endFrame = frameRange.endFrame;
 
-        var dependencies = findJobAttachments(renderQueueItem.comp); // list of filenames
+        var dependencies = findJobAttachments(renderQueueItem.comp, stepIgnoreMissingDependencies); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -146,6 +146,27 @@ function buildUI(thisObj) {
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
+    // Ignore Missing Dependencies GUI
+    const ignoreMissingDepsGroup = perCompSettingsGroup.add("group", undefined, "");
+    ignoreMissingDepsGroup.orientation = "column";
+    ignoreMissingDepsGroup.alignment = ['fill', 'top'];
+    ignoreMissingDepsGroup.alignChildren = ['left', 'center'];
+
+    const ignoreMissingDepsCheckBox = ignoreMissingDepsGroup.add("checkbox", undefined, "Ignore Missing Dependencies");
+    ignoreMissingDepsGroup.orientation = "column";
+
+    // Ignore Missing Dependencies Checkbox
+    function onIgnoreMissingDepsCheckBoxClicked() {
+        if (list.selection == null) {
+            return;
+        }
+        const selectionItem = dcUtil.getSelection(list);
+        if (selectionItem) {
+            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
+        }
+    }
+    ignoreMissingDepsCheckBox.onClick = onIgnoreMissingDepsCheckBoxClicked;
+
     function isRenderQueueItemImageOutput(renderQueueItem) {
         if (renderQueueItem.numOutputModules === 1) {
             const outputModule = renderQueueItem.outputModule(1).file;
@@ -335,6 +356,7 @@ function buildUI(thisObj) {
             framesPerTaskTextBox.text = "";
             mfrCheckBox.value = false;
             maxCpuUsagePercentageTextBox.text = "";
+            ignoreMissingDepsCheckBox.value = false;
 
             if (selection === null) {
                 submitButton.enabled = false;
@@ -368,6 +390,8 @@ function buildUI(thisObj) {
             maxCpuUsagePercentageTextBox.onChange();
             mfrCheckBox.value = settings.multiFrameRendering();
             mfrCheckBox.onClick();
+            ignoreMissingDepsCheckBox.value = settings.ignoreMissingDependencies();
+            ignoreMissingDepsCheckBox.onClick();
         }
         list.onChange = onSelectionChange;
         list.selection = null;

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -51,33 +51,41 @@ function UiSettingsStore(xmpPathPrefix, name) {
     this.name = name;
     this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
 
-    this.framesPerTask = function() {
+    this.framesPerTask = function () {
         return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
-    this.setFramesPerTask = function(value) {
+    this.setFramesPerTask = function (value) {
         logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
-    this.multiFrameRendering = function() {
+    this.multiFrameRendering = function () {
         return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
-    this.setMultiFrameRendering = function(value) {
+    this.setMultiFrameRendering = function (value) {
         logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
         dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
-    this.maxCpuUsagePercentage = function() {
+    this.maxCpuUsagePercentage = function () {
         return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
 
     }
-    this.setMaxCpuUsagePercentage = function(value) {
+    this.setMaxCpuUsagePercentage = function (value) {
         logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
+
+    this.ignoreMissingDependencies = function () {
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
+    }
+    this.setIgnoreMissingDependencies = function (value) {
+        logger.warning("(" + this.name + ") Setting ignoreMissingDependencies to " + value)
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
+    }
 }
 
-UiSettingsState.prototype.get = function(RQIID) {
+UiSettingsState.prototype.get = function (RQIID) {
     /**
      * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
      */

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -44,6 +44,9 @@ if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_HOURS === "undefined") {
 if (typeof DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES === "undefined") {
     const DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES = "taskRunTimeoutMinutes";
 }
+if (typeof DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES === "undefined") {
+    const DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES = "ignoreMissingDependencies";
+}
 if (typeof DEFAULT_TASK_RUN_TIMEOUT_ENABLED === "undefined") {
     const DEFAULT_TASK_RUN_TIMEOUT_ENABLED = true;
 }
@@ -64,6 +67,9 @@ if (typeof DEFAULT_MULTI_FRAME_RENDERING === "undefined") {
 }
 if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
+}
+if (typeof DEFAULT_IGNORE_MISSING_DEPENDENCIES === "undefined") {
+    const DEFAULT_IGNORE_MISSING_DEPENDENCIES = false;
 }
 
 var FootageTypes = {


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/211

### What was the problem/requirement? (What/Why)
If you would like to submit your composition and ignore any warnings about missing dependencies, this was not currently possible. Currently the popup comes up letting you know that the file is missing but we wish to optionally silence this popup.

In addition, this PR passes `-continueOnMissingFootage` on the worker side if you have ignored missing footage.
### What was the solution? (How)
Build upon the work of #207 and add a new UI element "Ignore Missing Dependencies" to control the strict existence checking of asset references before adding them to the job

This PR is built on top of #207 so the raw lines of code look higher until that PR is merged.
See [Ahuge - #29](https://github.com/Ahuge/deadline-cloud-for-after-effects/pull/29) for a PR of just the two branches in my repo
### What is the impact of this change?
Additional option in the UI that will silence the existing popup when checked.

This UI option also drives a step parameter that sets `-continueOnMissingFootage` on the aerender launch command.

### How was this change tested?
- [x] Testing using SMF from a Windows AE 25.3 client.
- [x] Tested using SMF from a MacOS AE 25.3 client
- [X] Testing using SMF from a Windows AE 24.6 client.
- [x] Tested using SMF from a MacOS AE 24.6 client
#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

### Was this change documented?
Not documented.

### Is this a breaking change?

I don't believe so, by default the new feature is not enabled.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
