### PR TITLE
fix: Only the first frame from an image sequence gets included in Job Attachments

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -77,7 +77,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = new RegExp("(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)", "i")
+const ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -340,7 +340,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function() {
+        textObj.onChange = function () {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -349,7 +349,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function() {
+        sliderObj.onChange = function () {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -587,33 +587,28 @@ function __generateUtil() {
     }
 
     function filePathsFromFootageItem(footageItem) {
-        var paths = [];
+        const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
-            var source = footageItem.mainSource;
-            var frameCount = footageItem.duration / footageItem.frameDuration;
-            var firstFrame = new File(source.file.fsName).fsName;
+            const source = footageItem.mainSource;
+            const frameCount = footageItem.duration / footageItem.frameDuration;
+            const firstFrame = new File(source.file.fsName).fsName;
             logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
-            var firstFramePattern = firstFrame.replace(new RegExp("[0-9]", "g"), "[0-9]").replace(new RegExp("\\\\", "g"), "\\\\");
-            var firstFrameRegex = new RegExp(firstFramePattern);
+            const firstFramePattern = firstFrame.replace(/\d/g, "\\d").replace(/\\\\/g, "\\\\");
+            const firstFrameRegex = new RegExp(firstFramePattern);
             logger.debug("  Regex pattern: " + firstFramePattern);
             var containingFolder = source.file.parent;
-
             function matchFilePattern(fileFolderObj) {
-                var fsName = fileFolderObj.fsName;
-                var result = fsName.match(firstFrameRegex);
-                return result
+                return fileFolderObj.fsName.match(firstFrameRegex);
             }
-            var containingFiles = containingFolder.getFiles(matchFilePattern).sort();
+            const containingFiles = containingFolder.getFiles(matchFilePattern).sort();
             logger.debug("  Pattern matched " + containingFiles.length + " files");
             var firstFrameFound = false;
             var indexOffset = 0;
             for (var index = 0; index < containingFiles.length; index++) {
                 var filePath = new File(containingFiles[index]).fsName;
-                if (firstFrameFound) {
-                    if ((index - indexOffset) < frameCount) {
-                        logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                        paths.push(filePath);
-                    }
+                if (firstFrameFound && ((index - indexOffset) < frameCount)) {
+                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                    paths.push(filePath);
                 }
                 if (filePath === firstFrame) {
                     firstFrameFound = true;
@@ -622,10 +617,8 @@ function __generateUtil() {
                     paths.push(filePath);
                 }
             }
-        } else {
-            if (footageItem.mainSource instanceof FileSource) {
-                paths.push(footageItem.mainSource.file.fsName);
-            }
+        } else if (footageItem.mainSource instanceof FileSource) {
+            paths.push(footageItem.mainSource.file.fsName);
         }
         return paths;
     }
@@ -843,43 +836,43 @@ function __generateUtil() {
 
         var hostRequirements = {
             "attributes": [{
-                    "name": "attr.worker.os.family",
-                    "anyOf": [
-                        osGroup.OSDropdownList.selection.text.toLowerCase()
-                    ]
-                },
-                {
-                    "name": "attr.worker.cpu.arch",
-                    "anyOf": [
-                        cpuArchGroup.cpuDropdownList.selection.text
-                    ]
-                }
+                "name": "attr.worker.os.family",
+                "anyOf": [
+                    osGroup.OSDropdownList.selection.text.toLowerCase()
+                ]
+            },
+            {
+                "name": "attr.worker.cpu.arch",
+                "anyOf": [
+                    cpuArchGroup.cpuDropdownList.selection.text
+                ]
+            }
             ],
             "amounts": [{
-                    "name": "amount.worker.vcpu",
-                    "min": parseInt(cpuGroup.cpuMinText.text),
-                    "max": parseInt(cpuGroup.cpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.memory",
-                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.gpu",
-                    "min": parseInt(gpuGroup.gpuMinText.text),
-                    "max": parseInt(gpuGroup.gpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.gpu.memory",
-                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.disk.scratch",
-                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-                }
+                "name": "amount.worker.vcpu",
+                "min": parseInt(cpuGroup.cpuMinText.text),
+                "max": parseInt(cpuGroup.cpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.memory",
+                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.gpu",
+                "min": parseInt(gpuGroup.gpuMinText.text),
+                "max": parseInt(gpuGroup.gpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.gpu.memory",
+                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.disk.scratch",
+                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+            }
             ]
         }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -77,7 +77,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-const ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
+var ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -587,7 +587,7 @@ function __generateUtil() {
     }
 
     /**
-     * Extracts image 
+     * Extracts frame number, prefix, and suffix for single frame in image sequence.
      * @param {string} fileName 
      * @returns Object containing prefix, name, and suffix 
      */

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -77,7 +77,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
+var ImageExtensionRegex = /(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -608,7 +608,7 @@ function __generateUtil() {
             const frameCount = footageItem.duration / footageItem.frameDuration;
             const firstFrameName = new File(source.file.fsName).fsName;
             const firstFrameInfo = getImageSequenceInformation(firstFrameName);
-            const firstFrameNumber = firstFrameInfo.frame; 
+            const firstFrameNumber = firstFrameInfo.frame;
             const lastFrameNumber = firstFrameNumber + frameCount;
             logger.debug("Processing ImageSequence with range (" + firstFrameNumber + "-" + lastFrameNumber + ") and with name \"" + firstFrameName + "\"");
             var containingFolder = source.file.parent;
@@ -994,8 +994,8 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
-        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate));
+        const numFrames = Number(Math.ceil(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {
@@ -1003,6 +1003,7 @@ function __generateUtil() {
             endFrame: endFrame
         };
     }
+
 
     function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
         /**
@@ -1108,6 +1109,7 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
+        "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -77,7 +77,6 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = /(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -568,6 +567,22 @@ function __generateUtil() {
         return _cachedTempFolder;
     }
 
+    // File extensions from supported AE file formats list at: https://helpx.adobe.com/after-effects/kb/supported-file-formats.html
+    function isVideo(extension) {
+        const videoExtensions = ["r3d", "crm", "mxf", "hevc", "3gp", "3g2", "amc", "swf", "flv", "f4v", "gif", "m2ts", "m4v", "mpg", "mpe", "mpa", "mod", "m2p", "m2v", "m2a", "m2t", "mp4", "omf", "mov", "avi", "wmv", "wma", "asf", "asx"];
+        return videoExtensions.indexOf(extension) >= 0;
+    }
+
+    function isAudio(extension) {
+        const audioExtensions = ["aac", "m4a", "aif", "aiff", "mp3", "mpeg", "mpg", "mpa", "mpe", "wav", "bwf"];
+        return audioExtensions.indexOf(extension) >= 0;
+    }
+
+    function isImage(extension) {
+        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "gif", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
+        return frameExtensions.indexOf(extension) >= 0;
+    }
+
     // Return the `FootageTypes` value for the passed footageItem
     function determineFootageType(footageItem) {
         if (footageItem.hasVideo) {
@@ -575,7 +590,7 @@ function __generateUtil() {
             var extension = filePath.substr(filePath.lastIndexOf(".") + 1, filePath.length).toLowerCase();
             if (footageItem.mainSource.isStill) {
                 return FootageTypes.Image
-            } else if (extension.match(ImageExtensionRegex)) {
+            } else if (isImage(extension)) {
                 return FootageTypes.ImageSequence
             } else {
                 return FootageTypes.Video
@@ -1120,7 +1135,11 @@ function __generateUtil() {
         "metadataKeyExists": metadataKeyExists,
         "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
-        "getFilePathsFromFootageItem": getFilePathsFromFootageItem
+        "getFilePathsFromFootageItem": getFilePathsFromFootageItem,
+        "isVideo": isVideo,
+        "isAudio": isAudio,
+        "isImage": isImage
+
     }
 }
 
@@ -1417,25 +1436,25 @@ function generateParameterValues(
     prefix
 ) {
     const parameterValuesList = [{
-            name: prefix + "_RenderQueueIndex",
-            value: renderQueueIndex,
-        },
-        {
-            name: prefix + "_OutputDir",
-            value: outputDir,
-        },
-        {
-            name: prefix + "_OutputFileName",
-            value: outputFileName,
-        },
-        {
-            name: prefix + "_Frames",
-            value: startFrame.toString() + "-" + endFrame.toString(),
-        },
-        {
-            name: prefix + "_MultiFrameRendering",
-            value: multiFrameRendering === true ? "ON" : "OFF",
-        },
+        name: prefix + "_RenderQueueIndex",
+        value: renderQueueIndex,
+    },
+    {
+        name: prefix + "_OutputDir",
+        value: outputDir,
+    },
+    {
+        name: prefix + "_OutputFileName",
+        value: outputFileName,
+    },
+    {
+        name: prefix + "_Frames",
+        value: startFrame.toString() + "-" + endFrame.toString(),
+    },
+    {
+        name: prefix + "_MultiFrameRendering",
+        value: multiFrameRendering === true ? "ON" : "OFF",
+    },
     ];
     if (maxCpuUsagePercentage) {
         parameterValuesList.push({
@@ -1851,22 +1870,6 @@ function generateFontReferences(fontPaths) {
 }
 
 
-function isVideoOutput(extension) {
-    const VideoOutputExtensions = ["avi", "mp4", "mov"];
-    return VideoOutputExtensions.indexOf(extension) >= 0;
-}
-
-function isAudioOutput(extension) {
-    const AudioOutputExtensions = ["aif", "mp3", "wav"];
-    return AudioOutputExtensions.indexOf(extension) >= 0;
-}
-
-function isImageOutput(extension) {
-    const FrameOutputExtensions = ["dpx", "iff", "jpg", "jpeg", "exr", "png", "psd", "hdr", "sgi", "tif", "tiff", "tga"];
-    return FrameOutputExtensions.indexOf(extension) >= 0;
-}
-
-
 var JobParams = [
     "JobScriptDir",
     "CondaPackages",
@@ -2162,74 +2165,74 @@ function SubmitSelection(selection, selectionSettings) {
     };
     const jobParameterDefinitions = {
         "parameterDefinitions": [{
-                "name": "ProjectFile",
-                "type": "PATH",
-                "objectType": "FILE",
-                "dataFlow": "IN",
-                "userInterface": {
-                    "control": "CHOOSE_INPUT_FILE",
-                    "label": "Project file",
-                    "groupLabel": "Source",
-                    "fileFilters": [{
-                            "label": "After Effects project files",
-                            "patterns": [
-                                "*.aep",
-                                "*.aepx"
-                            ]
-                        },
-                        {
-                            "label": "All Files",
-                            "patterns": [
-                                "*"
-                            ]
-                        }
+            "name": "ProjectFile",
+            "type": "PATH",
+            "objectType": "FILE",
+            "dataFlow": "IN",
+            "userInterface": {
+                "control": "CHOOSE_INPUT_FILE",
+                "label": "Project file",
+                "groupLabel": "Source",
+                "fileFilters": [{
+                    "label": "After Effects project files",
+                    "patterns": [
+                        "*.aep",
+                        "*.aepx"
                     ]
                 },
-                "description": "The After Effects project file to render."
+                {
+                    "label": "All Files",
+                    "patterns": [
+                        "*"
+                    ]
+                }
+                ]
             },
-            {
-                "name": "JobScriptDir",
-                "description": "Directory containing embedded scripts.",
-                "userInterface": {
-                    "control": "HIDDEN"
-                },
-                "type": "PATH",
-                "objectType": "DIRECTORY",
-                "dataFlow": "IN",
-                "default": "scripts"
+            "description": "The After Effects project file to render."
+        },
+        {
+            "name": "JobScriptDir",
+            "description": "Directory containing embedded scripts.",
+            "userInterface": {
+                "control": "HIDDEN"
             },
-            {
-                "name": "CondaPackages",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "HIDDEN"
-                },
-                "default": "aftereffects=" + aftereffectsCondaVersion,
-                "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
-            }
+            "type": "PATH",
+            "objectType": "DIRECTORY",
+            "dataFlow": "IN",
+            "default": "scripts"
+        },
+        {
+            "name": "CondaPackages",
+            "type": "STRING",
+            "userInterface": {
+                "control": "HIDDEN"
+            },
+            "default": "aftereffects=" + aftereffectsCondaVersion,
+            "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        }
         ]
     }
     const jobParameterValues = {
         parameterValues: [{
-                name: "deadline:targetTaskRunStatus",
-                value: "READY",
-            },
-            {
-                name: "deadline:maxFailedTasksCount",
-                value: 20,
-            },
-            {
-                name: "deadline:maxRetriesPerTask",
-                value: 5,
-            },
-            {
-                name: "deadline:priority",
-                value: 50,
-            },
-            {
-                name: "ProjectFile",
-                value: app.project.file.fsName,
-            },
+            name: "deadline:targetTaskRunStatus",
+            value: "READY",
+        },
+        {
+            name: "deadline:maxFailedTasksCount",
+            value: 20,
+        },
+        {
+            name: "deadline:maxRetriesPerTask",
+            value: 5,
+        },
+        {
+            name: "deadline:priority",
+            value: 50,
+        },
+        {
+            name: "ProjectFile",
+            value: app.project.file.fsName,
+        },
         ]
     }
 
@@ -2272,7 +2275,7 @@ function SubmitSelection(selection, selectionSettings) {
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
         var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        var isImageSeq = isImageOutput(extension);
+        var isImageSeq = dcUtil.isImage(extension);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
@@ -2985,7 +2988,7 @@ function buildUI(thisObj) {
     logoText.graphics.font = arialBold24Font;
     const headerButtonGroup = root.add("group");
     const focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
-    focusRenderQueueButton.onClick = function() {
+    focusRenderQueueButton.onClick = function () {
         // we quickly toggle the window to make sure it gains focus
         // sometimes this causes a flicker
         app.project.renderQueue.showWindow(false);
@@ -3117,7 +3120,7 @@ function buildUI(thisObj) {
             if (outputModule != null) {
                 const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
                 const extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
+                return dcUtil.isImage(extension);
             }
         }
         return false;
@@ -3223,7 +3226,7 @@ function buildUI(thisObj) {
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
     const submitButton = controlsGroup.add("button", undefined, "Submit");
-    submitButton.onClick = function() {
+    submitButton.onClick = function () {
         if (getPythonExecutable()) {
             if (list.selection === null) {
                 return;
@@ -3345,13 +3348,13 @@ function buildUI(thisObj) {
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
-    refreshButton.onClick = function() {
+    refreshButton.onClick = function () {
         updateList();
     }
 
     submitterPanel.layout.layout(true);
 
-    submitterPanel.onResizing = function() {
+    submitterPanel.onResizing = function () {
         this.layout.resize();
     }
     if (!(thisObj instanceof Panel)) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -601,7 +601,7 @@ function __generateUtil() {
         }
     }
 
-    function filePathsFromFootageItem(footageItem) {
+    function getFilePathsFromFootageItem(footageItem) {
         const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
             const source = footageItem.mainSource;
@@ -1120,7 +1120,7 @@ function __generateUtil() {
         "metadataKeyExists": metadataKeyExists,
         "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
-        "filePathsFromFootageItem": filePathsFromFootageItem
+        "getFilePathsFromFootageItem": getFilePathsFromFootageItem
     }
 }
 
@@ -1520,7 +1520,7 @@ function findJobAttachments(rootComp) {
                             shouldShowPopup = false;
                         }
                     } else {
-                        attachments = attachments.concat(dcUtil.filePathsFromFootageItem(src));
+                        attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
                     }
                 }
             }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -592,7 +592,7 @@ function __generateUtil() {
      * @returns Object containing prefix, name, and suffix 
      */
     function getImageSequenceInformation(fileName) {
-        var regex = /^(.*?)(\d*)(\D*?)$/;
+        var regex = /^(.*?)(\d*)(\D*)$/;
         var match = fileName.match(regex);
         return {
             prefix: match[1],

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -70,6 +70,15 @@ if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
 }
 
+var FootageTypes = {
+    Image: 0,
+    ImageSequence: 1,
+    Video: 2,
+    Audio: 3,
+    Unknown: 4
+}
+var ImageExtensionRegex = new RegExp("(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)", "i")
+
 function readFile(filePath) {
     const f = new File(filePath);
     f.encoding = "UTF-8";
@@ -331,7 +340,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function () {
+        textObj.onChange = function() {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -340,7 +349,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function () {
+        sliderObj.onChange = function() {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -559,6 +568,68 @@ function __generateUtil() {
         return _cachedTempFolder;
     }
 
+    // Return the `FootageTypes` value for the passed footageItem
+    function determineFootageType(footageItem) {
+        if (footageItem.hasVideo) {
+            var filePath = File.decode(footageItem.mainSource.file);
+            var extension = filePath.substr(filePath.lastIndexOf(".") + 1, filePath.length).toLowerCase();
+            if (footageItem.mainSource.isStill) {
+                return FootageTypes.Image
+            } else if (extension.match(ImageExtensionRegex)) {
+                return FootageTypes.ImageSequence
+            } else {
+                return FootageTypes.Video
+            }
+        } else if (footageItem.hasAudio) {
+            return FootageTypes.Audio
+        }
+        return FootageTypes.Unknown
+    }
+
+    function filePathsFromFootageItem(footageItem) {
+        var paths = [];
+        if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
+            var source = footageItem.mainSource;
+            var frameCount = footageItem.duration / footageItem.frameDuration;
+            var firstFrame = new File(source.file.fsName).fsName;
+            logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
+            var firstFramePattern = firstFrame.replace(new RegExp("[0-9]", "g"), "[0-9]").replace(new RegExp("\\\\", "g"), "\\\\");
+            var firstFrameRegex = new RegExp(firstFramePattern);
+            logger.debug("  Regex pattern: " + firstFramePattern);
+            var containingFolder = source.file.parent;
+
+            function matchFilePattern(fileFolderObj) {
+                var fsName = fileFolderObj.fsName;
+                var result = fsName.match(firstFrameRegex);
+                return result
+            }
+            var containingFiles = containingFolder.getFiles(matchFilePattern).sort();
+            logger.debug("  Pattern matched " + containingFiles.length + " files");
+            var firstFrameFound = false;
+            var indexOffset = 0;
+            for (var index = 0; index < containingFiles.length; index++) {
+                var filePath = new File(containingFiles[index]).fsName;
+                if (firstFrameFound) {
+                    if ((index - indexOffset) < frameCount) {
+                        logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                        paths.push(filePath);
+                    }
+                }
+                if (filePath === firstFrame) {
+                    firstFrameFound = true;
+                    indexOffset = index;
+                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                    paths.push(filePath);
+                }
+            }
+        } else {
+            if (footageItem.mainSource instanceof FileSource) {
+                paths.push(footageItem.mainSource.file.fsName);
+            }
+        }
+        return paths;
+    }
+
     function wrappedCallSystem(cmd) {
         /**
          * Wraps system.callSystem command as required to get output from it.
@@ -772,43 +843,43 @@ function __generateUtil() {
 
         var hostRequirements = {
             "attributes": [{
-                "name": "attr.worker.os.family",
-                "anyOf": [
-                    osGroup.OSDropdownList.selection.text.toLowerCase()
-                ]
-            },
-            {
-                "name": "attr.worker.cpu.arch",
-                "anyOf": [
-                    cpuArchGroup.cpuDropdownList.selection.text
-                ]
-            }
+                    "name": "attr.worker.os.family",
+                    "anyOf": [
+                        osGroup.OSDropdownList.selection.text.toLowerCase()
+                    ]
+                },
+                {
+                    "name": "attr.worker.cpu.arch",
+                    "anyOf": [
+                        cpuArchGroup.cpuDropdownList.selection.text
+                    ]
+                }
             ],
             "amounts": [{
-                "name": "amount.worker.vcpu",
-                "min": parseInt(cpuGroup.cpuMinText.text),
-                "max": parseInt(cpuGroup.cpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.memory",
-                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.gpu",
-                "min": parseInt(gpuGroup.gpuMinText.text),
-                "max": parseInt(gpuGroup.gpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.gpu.memory",
-                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.disk.scratch",
-                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-            }
+                    "name": "amount.worker.vcpu",
+                    "min": parseInt(cpuGroup.cpuMinText.text),
+                    "max": parseInt(cpuGroup.cpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.memory",
+                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.gpu",
+                    "min": parseInt(gpuGroup.gpuMinText.text),
+                    "max": parseInt(gpuGroup.gpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.gpu.memory",
+                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.disk.scratch",
+                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+                }
             ]
         }
 
@@ -990,7 +1061,7 @@ function __generateUtil() {
             for (var j = 0; j < ids.length; j++) {
                 var renderQueueID = ids[j];
                 if (getXMPPathLeaf(currentPath) === renderQueueID) {
-                    presentInArray=true;
+                    presentInArray = true;
                     break;
                 }
             }
@@ -1040,7 +1111,6 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
@@ -1049,7 +1119,9 @@ function __generateUtil() {
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists,
-        "deleteUnusedMetadata": deleteUnusedMetadata
+        "deleteUnusedMetadata": deleteUnusedMetadata,
+        "determineFootageType": determineFootageType,
+        "filePathsFromFootageItem": filePathsFromFootageItem
     }
 }
 
@@ -1410,7 +1482,7 @@ function findJobAttachments(rootComp) {
     if (rootComp == null) {
         return [];
     }
-    const attachments = [];
+    var attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
@@ -1449,7 +1521,7 @@ function findJobAttachments(rootComp) {
                             shouldShowPopup = false;
                         }
                     } else {
-                        attachments.push(src.file.fsName);
+                        attachments = attachments.concat(dcUtil.filePathsFromFootageItem(src));
                     }
                 }
             }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -586,35 +586,39 @@ function __generateUtil() {
         return FootageTypes.Unknown
     }
 
+    /**
+     * Extracts image 
+     * @param {string} fileName 
+     * @returns Object containing prefix, name, and suffix 
+     */
+    function getImageSequenceInformation(fileName) {
+        var regex = /^(.*?)(\d*)(\D*?)$/;
+        var match = fileName.match(regex);
+        return {
+            prefix: match[1],
+            frame: parseInt(match[2], 10),
+            suffix: match[3]
+        }
+    }
+
     function filePathsFromFootageItem(footageItem) {
         const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
             const source = footageItem.mainSource;
             const frameCount = footageItem.duration / footageItem.frameDuration;
-            const firstFrame = new File(source.file.fsName).fsName;
-            logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
-            const firstFramePattern = firstFrame.replace(/\d/g, "\\d").replace(/\\\\/g, "\\\\");
-            const firstFrameRegex = new RegExp(firstFramePattern);
-            logger.debug("  Regex pattern: " + firstFramePattern);
+            const firstFrameName = new File(source.file.fsName).fsName;
+            const firstFrameInfo = getImageSequenceInformation(firstFrameName);
+            const firstFrameNumber = firstFrameInfo.frame; 
+            const lastFrameNumber = firstFrameNumber + frameCount;
+            logger.debug("Processing ImageSequence with range (" + firstFrameNumber + "-" + lastFrameNumber + ") and with name \"" + firstFrameName + "\"");
             var containingFolder = source.file.parent;
-            function matchFilePattern(fileFolderObj) {
-                return fileFolderObj.fsName.match(firstFrameRegex);
-            }
-            const containingFiles = containingFolder.getFiles(matchFilePattern).sort();
-            logger.debug("  Pattern matched " + containingFiles.length + " files");
-            var firstFrameFound = false;
-            var indexOffset = 0;
-            for (var index = 0; index < containingFiles.length; index++) {
-                var filePath = new File(containingFiles[index]).fsName;
-                if (firstFrameFound && ((index - indexOffset) < frameCount)) {
-                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                    paths.push(filePath);
-                }
-                if (filePath === firstFrame) {
-                    firstFrameFound = true;
-                    indexOffset = index;
-                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                    paths.push(filePath);
+            var containingFiles = containingFolder.getFiles();
+            for (var i = 0; i < containingFiles.length; i++) {
+                var currentFrameFile = new File(containingFiles[i]).fsName;
+                var currentFrameInfo = getImageSequenceInformation(currentFrameFile);
+                if (currentFrameInfo.prefix === firstFrameInfo.prefix && currentFrameInfo.suffix === firstFrameInfo.suffix && currentFrameInfo.frame <= lastFrameNumber && currentFrameInfo.frame >= firstFrameNumber) {
+                    logger.debug("Adding frame " + currentFrameFile + "to paths");
+                    paths.push(currentFrameFile);
                 }
             }
         } else if (footageItem.mainSource instanceof FileSource) {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -76,7 +76,7 @@ var FootageTypes = {
     Video: 2,
     Audio: 3,
     Unknown: 4
-}
+};
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -80,7 +80,7 @@ function findJobAttachments(rootComp) {
     if (rootComp == null) {
         return [];
     }
-    const attachments = [];
+    var attachments = [];
     const exploredItems = {}; // using this object as a set because AE doesn't support sets
     attachments.push(app.project.file.fsName);
     exploredItems[rootComp.id] = true;
@@ -119,7 +119,7 @@ function findJobAttachments(rootComp) {
                             shouldShowPopup = false;
                         }
                     } else {
-                        attachments.push(src.file.fsName);
+                        attachments = attachments.concat(dcUtil.filePathsFromFootageItem(src));
                     }
                 }
             }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -16,25 +16,25 @@ function generateParameterValues(
     prefix
 ) {
     const parameterValuesList = [{
-            name: prefix + "_RenderQueueIndex",
-            value: renderQueueIndex,
-        },
-        {
-            name: prefix + "_OutputDir",
-            value: outputDir,
-        },
-        {
-            name: prefix + "_OutputFileName",
-            value: outputFileName,
-        },
-        {
-            name: prefix + "_Frames",
-            value: startFrame.toString() + "-" + endFrame.toString(),
-        },
-        {
-            name: prefix + "_MultiFrameRendering",
-            value: multiFrameRendering === true ? "ON" : "OFF",
-        },
+        name: prefix + "_RenderQueueIndex",
+        value: renderQueueIndex,
+    },
+    {
+        name: prefix + "_OutputDir",
+        value: outputDir,
+    },
+    {
+        name: prefix + "_OutputFileName",
+        value: outputFileName,
+    },
+    {
+        name: prefix + "_Frames",
+        value: startFrame.toString() + "-" + endFrame.toString(),
+    },
+    {
+        name: prefix + "_MultiFrameRendering",
+        value: multiFrameRendering === true ? "ON" : "OFF",
+    },
     ];
     if (maxCpuUsagePercentage) {
         parameterValuesList.push({
@@ -447,20 +447,4 @@ function generateFontReferences(fontPaths) {
         }
     }
     return formattedFontsPaths;
-}
-
-
-function isVideoOutput(extension) {
-    const VideoOutputExtensions = ["avi", "mp4", "mov"];
-    return VideoOutputExtensions.indexOf(extension) >= 0;
-}
-
-function isAudioOutput(extension) {
-    const AudioOutputExtensions = ["aif", "mp3", "wav"];
-    return AudioOutputExtensions.indexOf(extension) >= 0;
-}
-
-function isImageOutput(extension) {
-    const FrameOutputExtensions = ["dpx", "iff", "jpg", "jpeg", "exr", "png", "psd", "hdr", "sgi", "tif", "tiff", "tga"];
-    return FrameOutputExtensions.indexOf(extension) >= 0;
 }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -119,7 +119,7 @@ function findJobAttachments(rootComp) {
                             shouldShowPopup = false;
                         }
                     } else {
-                        attachments = attachments.concat(dcUtil.filePathsFromFootageItem(src));
+                        attachments = attachments.concat(dcUtil.getFilePathsFromFootageItem(src));
                     }
                 }
             }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -293,74 +293,74 @@ function SubmitSelection(selection, selectionSettings) {
     };
     const jobParameterDefinitions = {
         "parameterDefinitions": [{
-                "name": "ProjectFile",
-                "type": "PATH",
-                "objectType": "FILE",
-                "dataFlow": "IN",
-                "userInterface": {
-                    "control": "CHOOSE_INPUT_FILE",
-                    "label": "Project file",
-                    "groupLabel": "Source",
-                    "fileFilters": [{
-                            "label": "After Effects project files",
-                            "patterns": [
-                                "*.aep",
-                                "*.aepx"
-                            ]
-                        },
-                        {
-                            "label": "All Files",
-                            "patterns": [
-                                "*"
-                            ]
-                        }
+            "name": "ProjectFile",
+            "type": "PATH",
+            "objectType": "FILE",
+            "dataFlow": "IN",
+            "userInterface": {
+                "control": "CHOOSE_INPUT_FILE",
+                "label": "Project file",
+                "groupLabel": "Source",
+                "fileFilters": [{
+                    "label": "After Effects project files",
+                    "patterns": [
+                        "*.aep",
+                        "*.aepx"
                     ]
                 },
-                "description": "The After Effects project file to render."
+                {
+                    "label": "All Files",
+                    "patterns": [
+                        "*"
+                    ]
+                }
+                ]
             },
-            {
-                "name": "JobScriptDir",
-                "description": "Directory containing embedded scripts.",
-                "userInterface": {
-                    "control": "HIDDEN"
-                },
-                "type": "PATH",
-                "objectType": "DIRECTORY",
-                "dataFlow": "IN",
-                "default": "scripts"
+            "description": "The After Effects project file to render."
+        },
+        {
+            "name": "JobScriptDir",
+            "description": "Directory containing embedded scripts.",
+            "userInterface": {
+                "control": "HIDDEN"
             },
-            {
-                "name": "CondaPackages",
-                "type": "STRING",
-                "userInterface": {
-                    "control": "HIDDEN"
-                },
-                "default": "aftereffects=" + aftereffectsCondaVersion,
-                "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
-            }
+            "type": "PATH",
+            "objectType": "DIRECTORY",
+            "dataFlow": "IN",
+            "default": "scripts"
+        },
+        {
+            "name": "CondaPackages",
+            "type": "STRING",
+            "userInterface": {
+                "control": "HIDDEN"
+            },
+            "default": "aftereffects=" + aftereffectsCondaVersion,
+            "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        }
         ]
     }
     const jobParameterValues = {
         parameterValues: [{
-                name: "deadline:targetTaskRunStatus",
-                value: "READY",
-            },
-            {
-                name: "deadline:maxFailedTasksCount",
-                value: 20,
-            },
-            {
-                name: "deadline:maxRetriesPerTask",
-                value: 5,
-            },
-            {
-                name: "deadline:priority",
-                value: 50,
-            },
-            {
-                name: "ProjectFile",
-                value: app.project.file.fsName,
-            },
+            name: "deadline:targetTaskRunStatus",
+            value: "READY",
+        },
+        {
+            name: "deadline:maxFailedTasksCount",
+            value: 20,
+        },
+        {
+            name: "deadline:maxRetriesPerTask",
+            value: 5,
+        },
+        {
+            name: "deadline:priority",
+            value: 50,
+        },
+        {
+            name: "ProjectFile",
+            value: app.project.file.fsName,
+        },
         ]
     }
 
@@ -403,7 +403,7 @@ function SubmitSelection(selection, selectionSettings) {
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
         var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        var isImageSeq = isImageOutput(extension);
+        var isImageSeq = dcUtil.isImage(extension);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -20,7 +20,7 @@ function buildUI(thisObj) {
     logoText.graphics.font = arialBold24Font;
     const headerButtonGroup = root.add("group");
     const focusRenderQueueButton = headerButtonGroup.add("button", undefined, "Open Render Queue");
-    focusRenderQueueButton.onClick = function() {
+    focusRenderQueueButton.onClick = function () {
         // we quickly toggle the window to make sure it gains focus
         // sometimes this causes a flicker
         app.project.renderQueue.showWindow(false);
@@ -152,7 +152,7 @@ function buildUI(thisObj) {
             if (outputModule != null) {
                 const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
                 const extension = getFileExtension(outputFileNameNoRegex);
-                return isImageOutput(extension);
+                return dcUtil.isImage(extension);
             }
         }
         return false;
@@ -258,7 +258,7 @@ function buildUI(thisObj) {
     taskRunMinutesInput.onChange = onTaskRunMinutesChanged;
 
     const submitButton = controlsGroup.add("button", undefined, "Submit");
-    submitButton.onClick = function() {
+    submitButton.onClick = function () {
         if (getPythonExecutable()) {
             if (list.selection === null) {
                 return;
@@ -380,13 +380,13 @@ function buildUI(thisObj) {
         const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
         framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
     }
-    refreshButton.onClick = function() {
+    refreshButton.onClick = function () {
         updateList();
     }
 
     submitterPanel.layout.layout(true);
 
-    submitterPanel.onResizing = function() {
+    submitterPanel.onResizing = function () {
         this.layout.resize();
     }
     if (!(thisObj instanceof Panel)) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -66,6 +66,15 @@ if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
     const DEFAULT_MAX_CPU_USAGE_PERCENTAGE = 90;
 }
 
+var FootageTypes = {
+    Image: 0,
+    ImageSequence: 1,
+    Video: 2,
+    Audio: 3,
+    Unknown: 4
+}
+var ImageExtensionRegex = new RegExp("(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)", "i")
+
 function readFile(filePath) {
     const f = new File(filePath);
     f.encoding = "UTF-8";
@@ -327,7 +336,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function () {
+        textObj.onChange = function() {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -336,7 +345,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function () {
+        sliderObj.onChange = function() {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -555,6 +564,68 @@ function __generateUtil() {
         return _cachedTempFolder;
     }
 
+    // Return the `FootageTypes` value for the passed footageItem
+    function determineFootageType(footageItem) {
+        if (footageItem.hasVideo) {
+            var filePath = File.decode(footageItem.mainSource.file);
+            var extension = filePath.substr(filePath.lastIndexOf(".") + 1, filePath.length).toLowerCase();
+            if (footageItem.mainSource.isStill) {
+                return FootageTypes.Image
+            } else if (extension.match(ImageExtensionRegex)) {
+                return FootageTypes.ImageSequence
+            } else {
+                return FootageTypes.Video
+            }
+        } else if (footageItem.hasAudio) {
+            return FootageTypes.Audio
+        }
+        return FootageTypes.Unknown
+    }
+
+    function filePathsFromFootageItem(footageItem) {
+        var paths = [];
+        if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
+            var source = footageItem.mainSource;
+            var frameCount = footageItem.duration / footageItem.frameDuration;
+            var firstFrame = new File(source.file.fsName).fsName;
+            logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
+            var firstFramePattern = firstFrame.replace(new RegExp("[0-9]", "g"), "[0-9]").replace(new RegExp("\\\\", "g"), "\\\\");
+            var firstFrameRegex = new RegExp(firstFramePattern);
+            logger.debug("  Regex pattern: " + firstFramePattern);
+            var containingFolder = source.file.parent;
+
+            function matchFilePattern(fileFolderObj) {
+                var fsName = fileFolderObj.fsName;
+                var result = fsName.match(firstFrameRegex);
+                return result
+            }
+            var containingFiles = containingFolder.getFiles(matchFilePattern).sort();
+            logger.debug("  Pattern matched " + containingFiles.length + " files");
+            var firstFrameFound = false;
+            var indexOffset = 0;
+            for (var index = 0; index < containingFiles.length; index++) {
+                var filePath = new File(containingFiles[index]).fsName;
+                if (firstFrameFound) {
+                    if ((index - indexOffset) < frameCount) {
+                        logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                        paths.push(filePath);
+                    }
+                }
+                if (filePath === firstFrame) {
+                    firstFrameFound = true;
+                    indexOffset = index;
+                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                    paths.push(filePath);
+                }
+            }
+        } else {
+            if (footageItem.mainSource instanceof FileSource) {
+                paths.push(footageItem.mainSource.file.fsName);
+            }
+        }
+        return paths;
+    }
+
     function wrappedCallSystem(cmd) {
         /**
          * Wraps system.callSystem command as required to get output from it.
@@ -768,43 +839,43 @@ function __generateUtil() {
 
         var hostRequirements = {
             "attributes": [{
-                "name": "attr.worker.os.family",
-                "anyOf": [
-                    osGroup.OSDropdownList.selection.text.toLowerCase()
-                ]
-            },
-            {
-                "name": "attr.worker.cpu.arch",
-                "anyOf": [
-                    cpuArchGroup.cpuDropdownList.selection.text
-                ]
-            }
+                    "name": "attr.worker.os.family",
+                    "anyOf": [
+                        osGroup.OSDropdownList.selection.text.toLowerCase()
+                    ]
+                },
+                {
+                    "name": "attr.worker.cpu.arch",
+                    "anyOf": [
+                        cpuArchGroup.cpuDropdownList.selection.text
+                    ]
+                }
             ],
             "amounts": [{
-                "name": "amount.worker.vcpu",
-                "min": parseInt(cpuGroup.cpuMinText.text),
-                "max": parseInt(cpuGroup.cpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.memory",
-                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.gpu",
-                "min": parseInt(gpuGroup.gpuMinText.text),
-                "max": parseInt(gpuGroup.gpuMaxText.text)
-            },
-            {
-                "name": "amount.worker.gpu.memory",
-                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-            },
-            {
-                "name": "amount.worker.disk.scratch",
-                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-            }
+                    "name": "amount.worker.vcpu",
+                    "min": parseInt(cpuGroup.cpuMinText.text),
+                    "max": parseInt(cpuGroup.cpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.memory",
+                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.gpu",
+                    "min": parseInt(gpuGroup.gpuMinText.text),
+                    "max": parseInt(gpuGroup.gpuMaxText.text)
+                },
+                {
+                    "name": "amount.worker.gpu.memory",
+                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+                },
+                {
+                    "name": "amount.worker.disk.scratch",
+                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+                }
             ]
         }
 
@@ -986,7 +1057,7 @@ function __generateUtil() {
             for (var j = 0; j < ids.length; j++) {
                 var renderQueueID = ids[j];
                 if (getXMPPathLeaf(currentPath) === renderQueueID) {
-                    presentInArray=true;
+                    presentInArray = true;
                     break;
                 }
             }
@@ -1036,7 +1107,6 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,
@@ -1045,7 +1115,9 @@ function __generateUtil() {
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists,
-        "deleteUnusedMetadata": deleteUnusedMetadata
+        "deleteUnusedMetadata": deleteUnusedMetadata,
+        "determineFootageType": determineFootageType,
+        "filePathsFromFootageItem": filePathsFromFootageItem
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -73,7 +73,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
+var ImageExtensionRegex = /(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -582,35 +582,39 @@ function __generateUtil() {
         return FootageTypes.Unknown
     }
 
+    /**
+     * Extracts image 
+     * @param {string} fileName 
+     * @returns Object containing prefix, name, and suffix 
+     */
+    function getImageSequenceInformation(fileName) {
+        var regex = /^(.*?)(\d*)(\D*?)$/;
+        var match = fileName.match(regex);
+        return {
+            prefix: match[1],
+            frame: parseInt(match[2], 10),
+            suffix: match[3]
+        }
+    }
+
     function filePathsFromFootageItem(footageItem) {
         const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
             const source = footageItem.mainSource;
             const frameCount = footageItem.duration / footageItem.frameDuration;
-            const firstFrame = new File(source.file.fsName).fsName;
-            logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
-            const firstFramePattern = firstFrame.replace(/\d/g, "\\d").replace(/\\\\/g, "\\\\");
-            const firstFrameRegex = new RegExp(firstFramePattern);
-            logger.debug("  Regex pattern: " + firstFramePattern);
+            const firstFrameName = new File(source.file.fsName).fsName;
+            const firstFrameInfo = getImageSequenceInformation(firstFrameName);
+            const firstFrameNumber = firstFrameInfo.frame; 
+            const lastFrameNumber = firstFrameNumber + frameCount;
+            logger.debug("Processing ImageSequence with range (" + firstFrameNumber + "-" + lastFrameNumber + ") and with name \"" + firstFrameName + "\"");
             var containingFolder = source.file.parent;
-            function matchFilePattern(fileFolderObj) {
-                return fileFolderObj.fsName.match(firstFrameRegex);
-            }
-            const containingFiles = containingFolder.getFiles(matchFilePattern).sort();
-            logger.debug("  Pattern matched " + containingFiles.length + " files");
-            var firstFrameFound = false;
-            var indexOffset = 0;
-            for (var index = 0; index < containingFiles.length; index++) {
-                var filePath = new File(containingFiles[index]).fsName;
-                if (firstFrameFound && ((index - indexOffset) < frameCount)) {
-                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                    paths.push(filePath);
-                }
-                if (filePath === firstFrame) {
-                    firstFrameFound = true;
-                    indexOffset = index;
-                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                    paths.push(filePath);
+            var containingFiles = containingFolder.getFiles();
+            for (var i = 0; i < containingFiles.length; i++) {
+                var currentFrameFile = new File(containingFiles[i]).fsName;
+                var currentFrameInfo = getImageSequenceInformation(currentFrameFile);
+                if (currentFrameInfo.prefix === firstFrameInfo.prefix && currentFrameInfo.suffix === firstFrameInfo.suffix && currentFrameInfo.frame <= lastFrameNumber && currentFrameInfo.frame >= firstFrameNumber) {
+                    logger.debug("Adding frame " + currentFrameFile + "to paths");
+                    paths.push(currentFrameFile);
                 }
             }
         } else if (footageItem.mainSource instanceof FileSource) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1104,6 +1104,7 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
+        "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
         "getSelection": getSelection,

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -72,7 +72,7 @@ var FootageTypes = {
     Video: 2,
     Audio: 3,
     Unknown: 4
-}
+};
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -73,7 +73,6 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = /(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -564,6 +563,22 @@ function __generateUtil() {
         return _cachedTempFolder;
     }
 
+    // File extensions from supported AE file formats list at: https://helpx.adobe.com/after-effects/kb/supported-file-formats.html
+    function isVideo(extension) {
+        const videoExtensions = ["r3d", "crm", "mxf", "hevc", "3gp", "3g2", "amc", "swf", "flv", "f4v", "gif", "m2ts", "m4v", "mpg", "mpe", "mpa", "mod", "m2p", "m2v", "m2a", "m2t", "mp4", "omf", "mov", "avi", "wmv", "wma", "asf", "asx"];
+        return videoExtensions.indexOf(extension) >= 0;
+    }
+
+    function isAudio(extension) {
+        const audioExtensions = ["aac", "m4a", "aif", "aiff", "mp3", "mpeg", "mpg", "mpa", "mpe", "wav", "bwf"];
+        return audioExtensions.indexOf(extension) >= 0;
+    }
+
+    function isImage(extension) {
+        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "gif", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
+        return frameExtensions.indexOf(extension) >= 0;
+    }
+
     // Return the `FootageTypes` value for the passed footageItem
     function determineFootageType(footageItem) {
         if (footageItem.hasVideo) {
@@ -571,7 +586,7 @@ function __generateUtil() {
             var extension = filePath.substr(filePath.lastIndexOf(".") + 1, filePath.length).toLowerCase();
             if (footageItem.mainSource.isStill) {
                 return FootageTypes.Image
-            } else if (extension.match(ImageExtensionRegex)) {
+            } else if (isImage(extension)) {
                 return FootageTypes.ImageSequence
             } else {
                 return FootageTypes.Video
@@ -1116,7 +1131,11 @@ function __generateUtil() {
         "metadataKeyExists": metadataKeyExists,
         "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
-        "getFilePathsFromFootageItem": getFilePathsFromFootageItem
+        "getFilePathsFromFootageItem": getFilePathsFromFootageItem,
+        "isVideo": isVideo,
+        "isAudio": isAudio,
+        "isImage": isImage
+
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -583,7 +583,7 @@ function __generateUtil() {
     }
 
     /**
-     * Extracts image 
+     * Extracts frame number, prefix, and suffix for single frame in image sequence.
      * @param {string} fileName 
      * @returns Object containing prefix, name, and suffix 
      */

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -73,7 +73,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-const ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
+var ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -604,7 +604,7 @@ function __generateUtil() {
             const frameCount = footageItem.duration / footageItem.frameDuration;
             const firstFrameName = new File(source.file.fsName).fsName;
             const firstFrameInfo = getImageSequenceInformation(firstFrameName);
-            const firstFrameNumber = firstFrameInfo.frame; 
+            const firstFrameNumber = firstFrameInfo.frame;
             const lastFrameNumber = firstFrameNumber + frameCount;
             logger.debug("Processing ImageSequence with range (" + firstFrameNumber + "-" + lastFrameNumber + ") and with name \"" + firstFrameName + "\"");
             var containingFolder = source.file.parent;
@@ -990,8 +990,8 @@ function __generateUtil() {
          * @returns {Object} Object containing startFrame and endFrame
          */
         // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
-        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate));
+        const numFrames = Number(Math.ceil(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {
@@ -999,6 +999,7 @@ function __generateUtil() {
             endFrame: endFrame
         };
     }
+
 
     function validateTimeoutValues(enabled, daysInput, hoursInput, minutesInput) {
         /**

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -597,7 +597,7 @@ function __generateUtil() {
         }
     }
 
-    function filePathsFromFootageItem(footageItem) {
+    function getFilePathsFromFootageItem(footageItem) {
         const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
             const source = footageItem.mainSource;
@@ -1116,7 +1116,7 @@ function __generateUtil() {
         "metadataKeyExists": metadataKeyExists,
         "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
-        "filePathsFromFootageItem": filePathsFromFootageItem
+        "getFilePathsFromFootageItem": getFilePathsFromFootageItem
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -588,7 +588,7 @@ function __generateUtil() {
      * @returns Object containing prefix, name, and suffix 
      */
     function getImageSequenceInformation(fileName) {
-        var regex = /^(.*?)(\d*)(\D*?)$/;
+        var regex = /^(.*?)(\d*)(\D*)$/;
         var match = fileName.match(regex);
         return {
             prefix: match[1],

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -73,7 +73,7 @@ var FootageTypes = {
     Audio: 3,
     Unknown: 4
 }
-var ImageExtensionRegex = new RegExp("(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)", "i")
+const ImageExtensionRegex = /"(ai|bmp|bw|cin|cr2|crw|dcr|dng|dib|dpx|eps|erf|exr|gif|hdr|icb|iff|jpe|jpeg|jpg|mos|mrw|nef|orf|pbm|pef|pct|pcx|pdf|pic|pict|png|ps|psd|pxr|raf|raw|rgb|rgbe|rla|rle|rpf|sgi|srf|tdi|tga|tif|tiff|vda|vst|x3f|xyze)/i;
 
 function readFile(filePath) {
     const f = new File(filePath);
@@ -336,7 +336,7 @@ function __generateUtil() {
          * @param {int} minValue - Minimum value that the slider/edittext can have.
          * @param {int} maxValue - Maximum value that the slider/edittext can have
          */
-        textObj.onChange = function() {
+        textObj.onChange = function () {
             const newValue = parseFloat(textObj.text);
             if (!isNaN(newValue) && newValue >= minValue && newValue <= maxValue) {
                 sliderObj.value = newValue;
@@ -345,7 +345,7 @@ function __generateUtil() {
         }
 
 
-        sliderObj.onChange = function() {
+        sliderObj.onChange = function () {
             textObj.text = Math.round(this.value);
             logger.log("Changed sliderObject(" + sliderObj.name + ") value to: " + Math.round(this.value), scriptFileUtilName, LOG_LEVEL.DEBUG);
         }
@@ -583,33 +583,28 @@ function __generateUtil() {
     }
 
     function filePathsFromFootageItem(footageItem) {
-        var paths = [];
+        const paths = [];
         if (determineFootageType(footageItem) === FootageTypes.ImageSequence) {
-            var source = footageItem.mainSource;
-            var frameCount = footageItem.duration / footageItem.frameDuration;
-            var firstFrame = new File(source.file.fsName).fsName;
+            const source = footageItem.mainSource;
+            const frameCount = footageItem.duration / footageItem.frameDuration;
+            const firstFrame = new File(source.file.fsName).fsName;
             logger.debug("Processing ImageSequence with (" + frameCount + ") frames: " + firstFrame);
-            var firstFramePattern = firstFrame.replace(new RegExp("[0-9]", "g"), "[0-9]").replace(new RegExp("\\\\", "g"), "\\\\");
-            var firstFrameRegex = new RegExp(firstFramePattern);
+            const firstFramePattern = firstFrame.replace(/\d/g, "\\d").replace(/\\\\/g, "\\\\");
+            const firstFrameRegex = new RegExp(firstFramePattern);
             logger.debug("  Regex pattern: " + firstFramePattern);
             var containingFolder = source.file.parent;
-
             function matchFilePattern(fileFolderObj) {
-                var fsName = fileFolderObj.fsName;
-                var result = fsName.match(firstFrameRegex);
-                return result
+                return fileFolderObj.fsName.match(firstFrameRegex);
             }
-            var containingFiles = containingFolder.getFiles(matchFilePattern).sort();
+            const containingFiles = containingFolder.getFiles(matchFilePattern).sort();
             logger.debug("  Pattern matched " + containingFiles.length + " files");
             var firstFrameFound = false;
             var indexOffset = 0;
             for (var index = 0; index < containingFiles.length; index++) {
                 var filePath = new File(containingFiles[index]).fsName;
-                if (firstFrameFound) {
-                    if ((index - indexOffset) < frameCount) {
-                        logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
-                        paths.push(filePath);
-                    }
+                if (firstFrameFound && ((index - indexOffset) < frameCount)) {
+                    logger.debug("Adding frame (" + (index - indexOffset) + ") to paths: " + filePath);
+                    paths.push(filePath);
                 }
                 if (filePath === firstFrame) {
                     firstFrameFound = true;
@@ -618,10 +613,8 @@ function __generateUtil() {
                     paths.push(filePath);
                 }
             }
-        } else {
-            if (footageItem.mainSource instanceof FileSource) {
-                paths.push(footageItem.mainSource.file.fsName);
-            }
+        } else if (footageItem.mainSource instanceof FileSource) {
+            paths.push(footageItem.mainSource.file.fsName);
         }
         return paths;
     }
@@ -839,43 +832,43 @@ function __generateUtil() {
 
         var hostRequirements = {
             "attributes": [{
-                    "name": "attr.worker.os.family",
-                    "anyOf": [
-                        osGroup.OSDropdownList.selection.text.toLowerCase()
-                    ]
-                },
-                {
-                    "name": "attr.worker.cpu.arch",
-                    "anyOf": [
-                        cpuArchGroup.cpuDropdownList.selection.text
-                    ]
-                }
+                "name": "attr.worker.os.family",
+                "anyOf": [
+                    osGroup.OSDropdownList.selection.text.toLowerCase()
+                ]
+            },
+            {
+                "name": "attr.worker.cpu.arch",
+                "anyOf": [
+                    cpuArchGroup.cpuDropdownList.selection.text
+                ]
+            }
             ],
             "amounts": [{
-                    "name": "amount.worker.vcpu",
-                    "min": parseInt(cpuGroup.cpuMinText.text),
-                    "max": parseInt(cpuGroup.cpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.memory",
-                    "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
-                    "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.gpu",
-                    "min": parseInt(gpuGroup.gpuMinText.text),
-                    "max": parseInt(gpuGroup.gpuMaxText.text)
-                },
-                {
-                    "name": "amount.worker.gpu.memory",
-                    "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
-                    "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
-                },
-                {
-                    "name": "amount.worker.disk.scratch",
-                    "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
-                    "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
-                }
+                "name": "amount.worker.vcpu",
+                "min": parseInt(cpuGroup.cpuMinText.text),
+                "max": parseInt(cpuGroup.cpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.memory",
+                "min": parseInt(memoryGroup.memoryMinText.text) * 1024,
+                "max": parseInt(memoryGroup.memoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.gpu",
+                "min": parseInt(gpuGroup.gpuMinText.text),
+                "max": parseInt(gpuGroup.gpuMaxText.text)
+            },
+            {
+                "name": "amount.worker.gpu.memory",
+                "min": parseInt(gpuMemoryGroup.gpuMemoryMinText.text) * 1024,
+                "max": parseInt(gpuMemoryGroup.gpuMemoryMaxText.text) * 1024
+            },
+            {
+                "name": "amount.worker.disk.scratch",
+                "min": parseInt(scratchSpaceGroup.scratchSpaceMinText.text),
+                "max": parseInt(scratchSpaceGroup.scratchSpaceMaxText.text)
+            }
             ]
         }
 


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/213

### What was the problem/requirement? (What/Why)
Only the first frame from an image sequence gets included in Job Attachments
When you have an image sequence in your comp, it should JA the entire used sequence otherwise you get missing footage issues.

### What was the solution? (How)
Build upon the work of #207.

This updates the `findJobAttachments` function to use new logic built in `determineFootageType` and `filePathsFromFootageItem`

`determineFootageType` is a helper method used to determine the type of footage referenced. This was required because there is no native method in AE to determine if the FootageItem is an ImageSequence or Video.

`filePathsFromFootageItem` utilizes that function to implement logic against the ImageSequence footage items and gather all images in the folder from that sequence.
It takes inspiration from the `Smart Import.jsx` for resolving sequences with added logic around it to ensure that the files are part of the same sequence.
In addition to this, the function will gather the file paths starting from the first frame imported and only for the length of the FootageItem. The idea is that hopefully if your image sequence starts at frame 002 for example and is only used for 10 frames, we only upload the portion of the image sequence files on disk that are actually used in the comp.

This PR is built on top of #207 so the raw lines of code look higher until that PR is merged.
See [Ahuge - #30](https://github.com/Ahuge/deadline-cloud-for-after-effects/pull/30) for a PR of just the two branches in my repo
### What is the impact of this change?
Additional input files in the Job Attachments screen if the composition uses Image Sequences.

### How was this change tested?
- [X] Testing using SMF from a Windows AE 25.3 client.
- [x] Tested using SMF from a MacOS AE 25.3 client
- [x] Testing using SMF from a Windows AE 24.6 client.
- [x] Tested using SMF from a MacOS AE 24.6 client
#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

### Was this change documented?
Not documented as this fixes functionality that the user expected to exist

### Is this a breaking change?
I don't believe so. This corrects functionality that was missing.


### Images
#### Before:
![Job Attachments Before](https://github.com/user-attachments/assets/49f3c4f4-5846-42b5-8864-c11688fcc976)

#### After
![Job Attachments After](https://github.com/user-attachments/assets/8b2ee977-cab1-4806-93b1-2e846dfc14b5)

---




_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
