### PR TITLE
fix: added missing build changes to DeadlineCloudSubmitter.jsx

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1577,10 +1577,11 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             "This may result in compatibility issues or failed jobs.\n\nDon't show this warning again for version " + currentVersion + "?";
 
             // Provide warning, and if acknowledged, store their current version and warning preference. Otherwise, block job submission.
+            app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
             if (confirm(versionMismatchWarningMessage)) {
                 app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "true");
-                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION, currentVersion.toString());
             } else {
+                app.settings.saveSetting(DEADLINECLOUD_SUBMITTER_SETTINGS, DEADLINECLOUD_IGNORE_VERSION_WARNING, "false");
                 return;
             }
         } else {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Forgot to run `python jsxbundler.py --source src/OpenAESubmitter.jsx --destination dist/DeadlineCloudSubmitter.jsx` to update the JSX submitter file

### What was the solution? (How)
Run it and merge it.

### What is the impact of this change?
Adds missing code change

### How was this change tested?
Job submission succeeded from 25.3 and 24.6. I verified that for 25.3, the version filled in was 25, but for 24.6 it was filled in as 24.6.

### Was this change documented?

No

### Is this a breaking change?

No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
