### PR TITLE
chore: fix release notes update from CHANGELOG changes

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - run: |
          :
-          
+
   Release:
     needs: [TagRelease, IsCondaReady]
     runs-on: ubuntu-latest
@@ -65,7 +65,13 @@ jobs:
           ref: ${{env.TAG}}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
-
+      - name: Generate Release Notes
+        run: |
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
       - name: PushRelease
         env:
           GH_TOKEN: ${{ secrets.CI_TOKEN }}


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/209

### What was the problem/requirement? (What/Why)
When we do a Github release, the release notes are not updated with what's in the CHANGELOG.md

### What was the solution? (How)
Fix that

### What is the impact of this change?
Removes operator intervention needed to update our release notes

### How was this change tested?
Made a test version of this workflow and verified that it worked in my personal Github repo, example here: https://github.com/viknith/deadline-cloud-for-after-effects/releases/tag/0.2.7

### Is this a breaking change?
No


---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
