### PR TITLE
ci: move installer build/release in release workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -27,20 +27,22 @@ jobs:
     with:
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
 
-  BuildAndStageInstallers:
-    needs: TagRelease
-    uses: aws-deadline/.github/.github/workflows/reusable_build_and_stage_installers.yml@mainline
+  BuildInstaller:
+    needs: [TagRelease]
+    uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
     secrets: inherit
     permissions:
       id-token: write
       contents: read
     with:
-      project_name: ${{ github.event.repository.name }}
-      tag: ${{ needs.TagRelease.outputs.tag }}
+      ref_type: tags
+      ref: ${{ needs.TagRelease.outputs.tag }}
       oses: "['Windows', 'MacOS']"
+      environment: release
+      project_name: ${{ github.event.repository.name }}
 
   IsCondaReady:
-    needs: BuildAndStageInstallers
+    needs: BuildInstaller
     runs-on: ubuntu-latest
     environment: release
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
@@ -48,8 +50,20 @@ jobs:
       - run: |
          :
 
-  Release:
+  ReleaseInstaller:
     needs: [TagRelease, IsCondaReady]
+    uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      oses: "['Windows', 'MacOS']"
+      project_name: ${{ github.event.repository.name }}
+          
+  Release:
+    needs: [TagRelease, ReleaseInstaller]
     runs-on: ubuntu-latest
     name: Release
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to build the installers and only release them after conda testing has been completed.

### What was the solution? (How)
Use the [reusable_build_installers.yml](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_build_installers.yml) prior to `IsCondaReady` to only build the installers. After the `IsCondaReady` step use [reusable_release_installers.yml](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_release_installers.yml) to release the installers.

### What is the impact of this change?
Re-orders the release process to better align with development needs.

### How was this change tested?

https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/16326741245

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*