### PR TITLE
fix: update start and end frame to reflect frame numbers accurately

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,7 +107,7 @@ Default Windows InstallBuilder path: `"C:\\Program Files\\InstallBuilder Enterpr
 ### Build the installer
 
 ```bash
-hatch run installer:build-installer --local-dev-build --platform <PLATFORM> [--install-builder-location <LOCATION> --output-dir <DIR>]
+hatch run installer:build-installer --local-dev --platform <PLATFORM> [--install-builder-path <LOCATION> --output-dir <DIR>]
 ```
 Use the default locations listed above under Preqrequisites as guidance. For Platform, your options are Windows or MacOS. For local dev, remove `--output-dir` and specify `--local-dev` flag instead.
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -756,8 +756,7 @@ function __generateUtil() {
          */
         const startFrame = Number(rqi.comp.displayStartFrame);
         // Calculate number of frames using timeSpanDuration and frameRate
-        const timeSpanDuration = rqi.timeSpanDuration || rqi.comp.duration;
-        const numFrames = Math.floor(timeSpanDuration * rqi.comp.frameRate);
+        const numFrames = Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate);
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -754,9 +754,9 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-        const startFrame = Number(rqi.comp.displayStartFrame);
-        // Calculate number of frames using timeSpanDuration and frameRate
-        const numFrames = Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate);
+         // NOTE: we're not using displayStartFrame since it is rounded up
+        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -22,19 +22,6 @@ function writeFile(filePath, fileContents) {
     return;
 }
 
-function timeToFrames(time, fps) {
-    //temporarily change display format so we can convert seconds to frames
-    //We could perform the math ourselves, but using After Effects's internal methods ensure that we don't lose precision due to floating point errors
-    var prevFrameDisplay = app.project.timeDisplayType;
-    var prevFeetFrames = app.project.framesUseFeetFrames;
-    app.project.timeDisplayType = TimeDisplayType.FRAMES;
-    app.project.framesUseFeetFrames = false;
-    var frame = timeToCurrentFormat(time, fps, false);
-    app.project.timeDisplayType = prevFrameDisplay;
-    app.project.framesUseFeetFrames = prevFeetFrames;
-    return frame;
-}
-
 function sanitizeOutputs(outputPaths) {
     var sanitized = [];
     var sanitizedPath = "";
@@ -761,6 +748,24 @@ function __generateUtil() {
         return version
     }
 
+    function calculateFrameRange(rqi) {
+        /**
+         * Calculate start and end frames for a render queue item using render settings
+         * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
+         * @returns {Object} Object containing startFrame and endFrame
+         */
+        const startFrame = Number(rqi.comp.displayStartFrame);
+        // Calculate number of frames using timeSpanDuration and frameRate
+        const timeSpanDuration = rqi.timeSpanDuration || rqi.comp.duration;
+        const numFrames = Math.floor(timeSpanDuration * rqi.comp.frameRate);
+        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+
+        return {
+            startFrame: startFrame,
+            endFrame: endFrame
+        };
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -794,7 +799,8 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder
+        "getTempFolder": getTempFolder,
+        "calculateFrameRange": calculateFrameRange
     }
 }
 
@@ -1646,20 +1652,10 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             logger.debug("outputFolder is: " + outputFolder, submitBundleFile);
         }
     }
-    var renderSettings = rqi.getSettings(GetSettingsFormat.STRING_SETTABLE);
-    var startFrame = Number(
-        timeToFrames(
-            Number(renderSettings["Time Span Start"]),
-            Number(renderSettings["Use this frame rate"])
-        )
-    );
-    var endFrame =
-        Number(
-            timeToFrames(
-                Number(renderSettings["Time Span End"]),
-                Number(renderSettings["Use this frame rate"])
-            )
-        ) - 1; // end frame is inclusive so we subtract 1
+    // Calculate frame range using the utility function
+    const frameRange = dcUtil.calculateFrameRange(rqi);
+    const startFrame = frameRange.startFrame;
+    const endFrame = frameRange.endFrame;
 
     var dependencies = findJobAttachments(rqi.comp); // list of filenames
     var compName = dcUtil.removeIllegalCharacters(rqi.comp.name);
@@ -2684,9 +2680,10 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             item.subItems[0].text = rqi.comp.name;
-            var renderSettings = rqi.getSettings(GetSettingsFormat.STRING_SETTABLE);
-            var startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
-            var endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+            // Calculate frame range using the utility function
+            var frameRange = dcUtil.calculateFrameRange(rqi);
+            var startFrame = frameRange.startFrame;
+            var endFrame = frameRange.endFrame;
             item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -111,20 +111,10 @@ function SubmitSelection(selection, framesPerTask, multiFrameRendering, maxCpuUs
             logger.debug("outputFolder is: " + outputFolder, submitBundleFile);
         }
     }
-    var renderSettings = rqi.getSettings(GetSettingsFormat.STRING_SETTABLE);
-    var startFrame = Number(
-        timeToFrames(
-            Number(renderSettings["Time Span Start"]),
-            Number(renderSettings["Use this frame rate"])
-        )
-    );
-    var endFrame =
-        Number(
-            timeToFrames(
-                Number(renderSettings["Time Span End"]),
-                Number(renderSettings["Use this frame rate"])
-            )
-        ) - 1; // end frame is inclusive so we subtract 1
+    // Calculate frame range using the utility function
+    const frameRange = dcUtil.calculateFrameRange(rqi);
+    const startFrame = frameRange.startFrame;
+    const endFrame = frameRange.endFrame;
 
     var dependencies = findJobAttachments(rqi.comp); // list of filenames
     var compName = dcUtil.removeIllegalCharacters(rqi.comp.name);

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -261,9 +261,10 @@ function buildUI(thisObj) {
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
             item.subItems[0].text = rqi.comp.name;
-            var renderSettings = rqi.getSettings(GetSettingsFormat.STRING_SETTABLE);
-            var startFrame = Number(timeToFrames(Number(renderSettings["Time Span Start"]), Number(renderSettings["Use this frame rate"])));
-            var endFrame = Number(timeToFrames(Number(renderSettings["Time Span End"]), Number(renderSettings["Use this frame rate"]))) - 1; //end frame is inclusive so we subtract 1
+            // Calculate frame range using the utility function
+            var frameRange = dcUtil.calculateFrameRange(rqi);
+            var startFrame = frameRange.startFrame;
+            var endFrame = frameRange.endFrame;
             item.subItems[1].text = startFrame == endFrame ? startFrame.toString() : startFrame + "-" + endFrame;
             if (rqi.numOutputModules <= 0) {
                 item.subItems[2].text = "<not set>";

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -752,8 +752,7 @@ function __generateUtil() {
          */
         const startFrame = Number(rqi.comp.displayStartFrame);
         // Calculate number of frames using timeSpanDuration and frameRate
-        const timeSpanDuration = rqi.timeSpanDuration || rqi.comp.duration;
-        const numFrames = Math.floor(timeSpanDuration * rqi.comp.frameRate);
+        const numFrames = Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate);
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -18,19 +18,6 @@ function writeFile(filePath, fileContents) {
     return;
 }
 
-function timeToFrames(time, fps) {
-    //temporarily change display format so we can convert seconds to frames
-    //We could perform the math ourselves, but using After Effects's internal methods ensure that we don't lose precision due to floating point errors
-    var prevFrameDisplay = app.project.timeDisplayType;
-    var prevFeetFrames = app.project.framesUseFeetFrames;
-    app.project.timeDisplayType = TimeDisplayType.FRAMES;
-    app.project.framesUseFeetFrames = false;
-    var frame = timeToCurrentFormat(time, fps, false);
-    app.project.timeDisplayType = prevFrameDisplay;
-    app.project.framesUseFeetFrames = prevFeetFrames;
-    return frame;
-}
-
 function sanitizeOutputs(outputPaths) {
     var sanitized = [];
     var sanitizedPath = "";
@@ -757,6 +744,24 @@ function __generateUtil() {
         return version
     }
 
+    function calculateFrameRange(rqi) {
+        /**
+         * Calculate start and end frames for a render queue item using render settings
+         * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
+         * @returns {Object} Object containing startFrame and endFrame
+         */
+        const startFrame = Number(rqi.comp.displayStartFrame);
+        // Calculate number of frames using timeSpanDuration and frameRate
+        const timeSpanDuration = rqi.timeSpanDuration || rqi.comp.duration;
+        const numFrames = Math.floor(timeSpanDuration * rqi.comp.frameRate);
+        const endFrame = startFrame + numFrames - 1; // end frame is inclusive
+
+        return {
+            startFrame: startFrame,
+            endFrame: endFrame
+        };
+    }
+
     return {
         "invertObject": invertObject,
         "toBooleanString": toBooleanString,
@@ -790,7 +795,8 @@ function __generateUtil() {
         "getTempFile": getTempFile,
         "getUserDirectory": getUserDirectory,
         "getAEVersion": getAEVersion,
-        "getTempFolder": getTempFolder
+        "getTempFolder": getTempFolder,
+        "calculateFrameRange": calculateFrameRange
     }
 }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -750,9 +750,9 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-        const startFrame = Number(rqi.comp.displayStartFrame);
-        // Calculate number of frames using timeSpanDuration and frameRate
-        const numFrames = Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate);
+         // NOTE: we're not using displayStartFrame since it is rounded up
+        const startFrame = Number(Math.floor(rqi.comp.displayStartTime * rqi.comp.frameRate));
+        const numFrames = Number(Math.floor(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 
         return {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When customers would submit jobs that started with a non-zero frame number, the corresponding start frame number would still be 0. For example, if a composition was 100-399, it would show as 0-299 or something like that. This would cause problems when trying to inspect the output of specific frames.

### What was the solution? (How)
Fix our logic for getting start and end frames so that the numbers are reflected accurately in the submitter and on the Deadline Cloud Monitor.

### What is the impact of this change?
Resulting submitter view
<img width="467" height="487" alt="Screenshot 2025-07-18 at 4 31 03 PM" src="https://github.com/user-attachments/assets/13f68d91-2805-4fe5-a644-ec7184b3eba1" />

The starting number used to be all zeroes but now it reflects the start frame of the composition accurately. When I submitted one of them, the tasks look like this:

<img width="1190" height="591" alt="Screenshot 2025-07-18 at 4 30 15 PM" src="https://github.com/user-attachments/assets/ed719a8a-dced-494c-93bd-069a74905a2f" />

### How was this change tested?
Submitted jobs on Mac and Windows After Effects 25.2 and 24.6, verified it all works. 

Here were some cases I ran and submitted as PNG sequences:
- Job with 100-399 frames submitter with 24fps, 23.5fps, 23.75fps
- Job with 1-300 frame at 24fps
- Job with 0-299 frame at 24fps

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

### Was this change documented?
No need

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
