### PR TITLE
fix: resolve security risk with regex

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -968,9 +968,7 @@ function __generateUtil() {
 
     function getXMPPathLeaf(path) {
         // The backslash is needed for this regex, so we need to skip SonarQube scan
-        // BEGIN-NOSCAN
         const regex = /xmp:([^\/]+)$/;
-        // END-NOSCAN
         return regex.exec(path)[1];
     }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -967,7 +967,10 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
+        // The backslash is needed for this regex, so we need to skip SonarQube scan
+        // BEGIN-NOSCAN
         const regex = /xmp:([^\/]+)$/;
+        // END-NOSCAN
         return regex.exec(path)[1];
     }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -967,7 +967,7 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
-        const regex = /.*xmp:(.*)/;
+        const regex = /xmp:([^\/]+)$/
         return regex.exec(path)[1];
     }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -967,7 +967,7 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
-        const regex = /xmp:([^\/]+)$/
+        const regex = /xmp:([^\/]+)$/;
         return regex.exec(path)[1];
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -963,7 +963,7 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
-        const regex = /xmp:([^\/]+)$/
+        const regex = /xmp:([^\/]+)$/;
         return regex.exec(path)[1];
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -963,7 +963,7 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
-        const regex = /.*xmp:(.*)/;
+        const regex = /xmp:([^\/]+)$/
         return regex.exec(path)[1];
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -963,7 +963,10 @@ function __generateUtil() {
     }
 
     function getXMPPathLeaf(path) {
+        // The backslash is needed for this regex, so we need to skip SonarQube scan
+        // BEGIN-NOSCAN
         const regex = /xmp:([^\/]+)$/;
+        // END-NOSCAN
         return regex.exec(path)[1];
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -964,9 +964,7 @@ function __generateUtil() {
 
     function getXMPPathLeaf(path) {
         // The backslash is needed for this regex, so we need to skip SonarQube scan
-        // BEGIN-NOSCAN
         const regex = /xmp:([^\/]+)$/;
-        // END-NOSCAN
         return regex.exec(path)[1];
     }
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Security finding was in our GH workflow

### What was the solution? (How)
Fixed our regex to not use `.*` to minimize issues

### What is the impact of this change?
Resolves our workflow error. Tested on Windows and Mac, AE 24 and 25

### How was this change tested?
Used submitter, verified that our sticky settings were working and being set in the job template correctly.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes


### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
