### PR TITLE
fix: resolves issue in saveStringMetadata function

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -302,7 +302,7 @@ function __generateUtil() {
          * Sets string in app settings
          */
         validateType(value, "string");
-        saveToMetadata(keyName, defaultValue, XMPConst.STRING);
+        saveToMetadata(keyName, value, XMPConst.STRING);
     }
 
     function getStringMetadata(keyName, defaultValue) {

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -298,7 +298,7 @@ function __generateUtil() {
          * Sets string in app settings
          */
         validateType(value, "string");
-        saveToMetadata(keyName, defaultValue, XMPConst.STRING);
+        saveToMetadata(keyName, value, XMPConst.STRING);
     }
 
     function getStringMetadata(keyName, defaultValue) {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the recent change to add multicomp, there was a small bug missing that only impacted users that were rendering on After Effects versions that our submitter doesn't support. The variable name was named incorrectly that caused the issue, and it was causing the GUI submitter to not open.

### What was the solution? (How)
Fix the variable name reference.

### What is the impact of this change?
Unblocks artists using unsupported versions of AE on SMF.

### How was this change tested?
Tested change, the submitter opens like it's supposed to now.

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
