### PR TITLE
fix: fix regression of repeated popups due to unsupported AE version

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2042,7 +2042,7 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING));
     const savedVersion = dcUtil.getNumberMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -244,7 +244,7 @@ function SubmitSelection(selection, selectionSettings) {
     }
 
     // Check if warning should be shown
-    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING)) === "true";
+    const ignoreWarning = dcUtil.getBoolMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING));
     const savedVersion = dcUtil.getNumberMetadata(dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, DEADLINECLOUD_IGNORE_VERSION_WARNING_VERSION), 0);
     const currentVersion = dcUtil.getAEVersion();
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When releasing the multi-comp feature, we had a minor regression on how we handle customers that submit AE render jobs from a local AE version that we don't support on SMF. This is supposed to be a one-time popup but it regressed and became a popup that shows up on every submission, which is annoying and also inaccurate for customers on CMF using our submitter.

### What was the solution? (How)
Fix the type issue that was causing this bug.

### What is the impact of this change?
Reduced annoyance to customers

### How was this change tested?
Testing submitter on AE 25.4 which we don't support officially on SMF and after acknowledging the popup once, it didn't show up again.

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
