### PR TITLE
fix: moved font search logic to get_user_fonts.py to permanently prevent JSON size overflow issues that crashes After Effects

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1717,74 +1717,42 @@ function getPythonExecutable() {
 }
 
 /**
- * Scans user font paths for user-installed fonts and parses their name metadata.
- * @return Font metadata object, or null if there was an error
+ * Gets the path to a user-installed font whose PostScript name is fontPostScriptName.
+ * @return The path to that font file or null if the path was not found
  **/
-function getFontPaths() {
-    var errorMessage = "";
-    // Ensure Python exists and is at least version 3
-    const pythonExecutable = getPythonExecutable();
-    if (!pythonExecutable) {
-        return null;
-    }
-    const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-    const scriptFile = new File(scriptPath);
-    if (!scriptFile.exists) {
-        errorMessage =
-            "Error: Missing font script at " + scriptFile.fsName + "\n" +
-            "\n" +
-            "Please ensure that the Deadline Cloud Submitter is installed correctly.";
-        adcAlert(errorMessage, true);
-        return null;
-    }
-
-    var output = {};
+function getLocationForFont(fontPostScriptName) {
     try {
-        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
-        output = JSON.parse(outputRaw);
+        const pythonExecutable = getPythonExecutable();
+        if (!pythonExecutable) {
+            return null;
+        }
+        
+        const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
+        const scriptFile = new File(scriptPath);
+        if (!scriptFile.exists) {
+            adcAlert(
+                "Error: Missing font script at " + scriptFile.fsName + "\n" +
+                "\n" +
+                "Please ensure that the Deadline Cloud Submitter is installed correctly.",
+                true
+            );
+            return null;
+        }
+        
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
+        // Clean the output by removing all whitespace characters
+        var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+        return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
-        logger.debug("Command output: " + output, jobTemplateHelperFile);
         adcAlert(
             "Error when finding fonts:\n" +
             "\n" +
             e.message,
             true
         );
-    }
-    if ("error" in output) {
-        adcAlert(
-            output["error"],
-            true
-        );
         return null;
     }
-    return output;
-}
-
-/**
- * Gets the path to a user-installed font whose PostScript name is fontPostScriptName.
- * @return The path to that font file or null if the path was not found
- **/
-function getLocationForFont(fontPostScriptName) {
-    var fontPath = null;
-    try {
-        // Get user-installed fonts
-        const fontPaths = getFontPaths();
-        if (!fontPaths) {
-            return null;
-        }
-        for (var path in fontPaths) {
-            if (fontPaths[path]["postscript_name"] == fontPostScriptName) {
-                // Found path that matches the given font's name
-                fontPath = path;
-                break;
-            }
-        }
-    } catch (e) {
-        logger.error(e.message, jobTemplateHelperFile);
-    }
-    return fontPath;
 }
 
 /**
@@ -1922,9 +1890,18 @@ function generateFontReferences(fontPaths) {
         var fontName = fontPaths[i][0];
         var fontLocation = fontPaths[i][1];
 
-        var fontFile = File(fontLocation);
+        // Normalize the font path for ExtendScript compatibility
+        var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
+        var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        
+        // Debug information
+        adcAlert("Debug: original=" + fontLocation + ", normalized=" + normalizedFontLocation + ", exists=" + fontFile.exists);
+        
         var fontCopied = fontFile.copy(_tempFontPath);
+        
+        adcAlert("Debug: fontCopied=" + fontCopied + ", error=" + fontFile.error);
+        
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1895,12 +1895,7 @@ function generateFontReferences(fontPaths) {
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
         
-        // Debug information
-        adcAlert("Debug: original=" + fontLocation + ", normalized=" + normalizedFontLocation + ", exists=" + fontFile.exists);
-        
         var fontCopied = fontFile.copy(_tempFontPath);
-        
-        adcAlert("Debug: fontCopied=" + fontCopied + ", error=" + fontFile.error);
         
         // Check if font file was actually copied.
         if (fontCopied) {

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -1,38 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""
-Collects font name metadata from user-installed fonts. Output as JSON.
-"""
-
-import json
 import os
 import sys
-import traceback
 
 try:
     from fontTools import ttLib
 except ModuleNotFoundError:
-    # Attempt to install fonttools automatically
-    try:
-        print("fonttools module not found. Attempting to install...")
-        import subprocess
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "fonttools"])
-        print("fonttools installed successfully. Importing...")
-        from fontTools import ttLib
-    except Exception:
-        print(json.dumps({
-            "message": "Unable to install fonttools module. Please install manually with 'pip install fonttools' and try again.",
-            "error": traceback.format_exc()
-        }))
-        sys.exit(1)
-except Exception as e:
-    print(json.dumps({
-        "error": traceback.format_exc()
-    }))
-    sys.exit(1)
+    import subprocess
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "fonttools"])
+    from fontTools import ttLib
 
-
-# Font locations to search on Windows
+# Font locations to search
 SEARCH_PATHS = [
     "%APPDATA%/Adobe/CoreSync/plugins/livetype",
     "%APPDATA%/Adobe/User Owned Fonts",
@@ -41,7 +19,6 @@ SEARCH_PATHS = [
 ]
 
 if sys.platform == "darwin":
-    # Font locations to search on Mac
     SEARCH_PATHS = [
         "~/Library/Application Support/Adobe/CoreSync/plugins/livetype",
         "~/Library/Application Support/Adobe/User Owned Fonts",
@@ -49,136 +26,39 @@ if sys.platform == "darwin":
         "/Library/Fonts"
     ]
 
-
-# Supported font file extensions
 FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
-
-# Table indices from https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html
-TTF_FAMILY_NAME = 1
-TTF_STYLE = 2
-TTF_FULL_NAME = 4
 TTF_POSTSCRIPT_NAME = 6
 
 
-def get_font(font_path):
-    """
-    Collect font metadata from the given font file.
-    Returns a dictionary of metadata.
-    """
-
-    result = {}
-
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit(1)
+    
+    target_postscript_name = sys.argv[1]
+    
     try:
-        t = ttLib.TTFont(font_path)
-    except Exception as e:
-        if verbose:
-            print(traceback.format_exc())
-        return result
-
-    # Collect name metadata from the name table
-    names_table = t["name"].names
-    raw_table = {}
-    try:
-        raw_table = {i:str(names_table[i]) for i in range(0, len(names_table))}
-    except Exception:
-        if verbose:
-            print(traceback.format_exc())
-        return result
-
-    try:
-        result[font_path] = {
-            "postscript_name": str(names_table[TTF_POSTSCRIPT_NAME])
-            # Removed other fields to minimize JSON size for Adobe After Effects
-        }
-    except Exception:
-        if verbose:
-            print(traceback.format_exc())
-        return result
-
-    return result
-
-
-def get_fonts(root_path, verbose=None):
-    """
-    Collect font metadata from all font files under the specified root_path.
-    Returns a dictionary with file paths as the keys.
-    """
-
-    result = {}
-
-    try:
-        if not os.path.exists(root_path):
-            return result
-    except Exception:
-        if verbose:
-            print(traceback.format_exc())
-        return result
-
-    try:
-        for path, dirs, files in os.walk(root_path):
-            for file in files:
-                _, ext = os.path.splitext(file)
-                if ext.lower() not in FONT_EXTENSIONS:
-                    continue
-
-                font_path = path + "/" + file
-                if sys.platform == "win32":
-                    font_path = font_path.replace("\\", "/")
-                else:
-                    pass
-
-                if verbose:
-                    print(f"font_path: {font_path}")
-
-                font_data = {}
-                try:
-                    font_data = get_font(font_path)
-                    result.update(font_data)
-                except Exception:
-                    if verbose:
-                        print(traceback.format_exc())
-                    continue
-    except Exception:
-        if verbose:
-            print(traceback.format_exc())
-    return result
-
-
-def search_for_fonts(search_paths, verbose=None):
-    """
-    Searches the given paths recursively for font files and collects
-    their metadata.
-    Returns a dictionary with file paths as the keys.
-    """
-
-    fonts = {}
-
-    for search_path in search_paths:
-        search_root = os.path.normpath(os.path.expandvars(os.path.expanduser(search_path)))
-        try:
+        for search_path in SEARCH_PATHS:
+            search_root = os.path.normpath(os.path.expandvars(os.path.expanduser(search_path)))
             if not os.path.exists(search_root):
                 continue
-        except Exception:
-            if verbose:
-                print(traceback.format_exc())
-            continue
-
-        if verbose:
-            print(f"search_root: {search_root}")
-
-        font_results = get_fonts(search_root, verbose=verbose)
-        fonts.update(font_results)
-
-    return fonts
-
-
-if __name__ == "__main__":
-    verbose = False
-    result = []
-    try:
-        result = search_for_fonts(SEARCH_PATHS, verbose=verbose)
-        print(json.dumps(result))
+                
+            for path, dirs, files in os.walk(search_root):
+                for file in files:
+                    _, ext = os.path.splitext(file)
+                    if ext.lower() not in FONT_EXTENSIONS:
+                        continue
+                    
+                    font_path = os.path.join(path, file)
+                    try:
+                        t = ttLib.TTFont(font_path)
+                        names_table = t["name"].names
+                        postscript_name = str(names_table[TTF_POSTSCRIPT_NAME])
+                        if postscript_name == target_postscript_name:
+                            print(font_path)
+                            sys.exit(0)
+                    except Exception:
+                        continue
+        sys.exit(1)
     except Exception:
-        if verbose:
-            print(traceback.format_exc())
+        sys.exit(1)
 

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -32,22 +32,23 @@ TTF_POSTSCRIPT_NAME = 6
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
+        print("Missing font name argument")
         sys.exit(1)
-    
+
     target_postscript_name = sys.argv[1]
-    
+
     try:
         for search_path in SEARCH_PATHS:
             search_root = os.path.normpath(os.path.expandvars(os.path.expanduser(search_path)))
             if not os.path.exists(search_root):
                 continue
-                
+
             for path, dirs, files in os.walk(search_root):
                 for file in files:
                     _, ext = os.path.splitext(file)
                     if ext.lower() not in FONT_EXTENSIONS:
                         continue
-                    
+
                     font_path = os.path.join(path, file)
                     try:
                         t = ttLib.TTFont(font_path)
@@ -58,7 +59,9 @@ if __name__ == "__main__":
                             sys.exit(0)
                     except Exception:
                         continue
+        print(f"Font file {target_postscript_name} is missing")
         sys.exit(1)
-    except Exception:
+    except Exception as e:
+        print(f"An error occurred: {e}")
         sys.exit(1)
 

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -12,12 +12,18 @@ import traceback
 try:
     from fontTools import ttLib
 except ModuleNotFoundError:
-    error_msg = "Error: The fonttools module was not found.\n"
-    error_msg += "Please install fonttools by running:\n\npip install fonttools"
-    print(json.dumps({
-        "error": error_msg
-    }))
-    sys.exit(1)
+    # Attempt to install fonttools automatically
+    try:
+        print("fonttools module not found. Attempting to install...")
+        import subprocess
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "fonttools"])
+        print("fonttools installed successfully. Importing...")
+        from fontTools import ttLib
+    except Exception:
+        print(json.dumps({
+            "error": traceback.format_exc()
+        }))
+        sys.exit(1)
 except Exception as e:
     print(json.dumps({
         "error": traceback.format_exc()
@@ -79,11 +85,8 @@ def get_font(font_path):
 
     try:
         result[font_path] = {
-            "family_name": str(names_table[TTF_FAMILY_NAME]),
-            "style": str(names_table[TTF_STYLE]),
-            "full_name": str(names_table[TTF_FULL_NAME]),
-            "postscript_name": str(names_table[TTF_POSTSCRIPT_NAME]),
-            "raw": raw_table
+            "postscript_name": str(names_table[TTF_POSTSCRIPT_NAME])
+            # Removed other fields to minimize JSON size for Adobe After Effects
         }
     except Exception:
         if verbose:

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:
         from fontTools import ttLib
     except Exception:
         print(json.dumps({
+            "message": "Unable to install fonttools module. Please install manually with 'pip install fonttools' and try again.",
             "error": traceback.format_exc()
         }))
         sys.exit(1)

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -35,7 +35,8 @@ except Exception as e:
 SEARCH_PATHS = [
     "%APPDATA%/Adobe/CoreSync/plugins/livetype",
     "%APPDATA%/Adobe/User Owned Fonts",
-    "%LOCALAPPDATA%/Microsoft/Windows/Fonts"
+    "%LOCALAPPDATA%/Microsoft/Windows/Fonts",
+    "%WINDIR%/Fonts",
 ]
 
 if sys.platform == "darwin":

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -283,74 +283,42 @@ function getPythonExecutable() {
 }
 
 /**
- * Scans user font paths for user-installed fonts and parses their name metadata.
- * @return Font metadata object, or null if there was an error
+ * Gets the path to a user-installed font whose PostScript name is fontPostScriptName.
+ * @return The path to that font file or null if the path was not found
  **/
-function getFontPaths() {
-    var errorMessage = "";
-    // Ensure Python exists and is at least version 3
-    const pythonExecutable = getPythonExecutable();
-    if (!pythonExecutable) {
-        return null;
-    }
-    const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-    const scriptFile = new File(scriptPath);
-    if (!scriptFile.exists) {
-        errorMessage =
-            "Error: Missing font script at " + scriptFile.fsName + "\n" +
-            "\n" +
-            "Please ensure that the Deadline Cloud Submitter is installed correctly.";
-        adcAlert(errorMessage, true);
-        return null;
-    }
-
-    var output = {};
+function getLocationForFont(fontPostScriptName) {
     try {
-        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\"");
-        output = JSON.parse(outputRaw);
+        const pythonExecutable = getPythonExecutable();
+        if (!pythonExecutable) {
+            return null;
+        }
+        
+        const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
+        const scriptFile = new File(scriptPath);
+        if (!scriptFile.exists) {
+            adcAlert(
+                "Error: Missing font script at " + scriptFile.fsName + "\n" +
+                "\n" +
+                "Please ensure that the Deadline Cloud Submitter is installed correctly.",
+                true
+            );
+            return null;
+        }
+        
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
+        // Clean the output by removing all whitespace characters
+        var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+        return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
-        logger.debug("Command output: " + output, jobTemplateHelperFile);
         adcAlert(
             "Error when finding fonts:\n" +
             "\n" +
             e.message,
             true
         );
-    }
-    if ("error" in output) {
-        adcAlert(
-            output["error"],
-            true
-        );
         return null;
     }
-    return output;
-}
-
-/**
- * Gets the path to a user-installed font whose PostScript name is fontPostScriptName.
- * @return The path to that font file or null if the path was not found
- **/
-function getLocationForFont(fontPostScriptName) {
-    var fontPath = null;
-    try {
-        // Get user-installed fonts
-        const fontPaths = getFontPaths();
-        if (!fontPaths) {
-            return null;
-        }
-        for (var path in fontPaths) {
-            if (fontPaths[path]["postscript_name"] == fontPostScriptName) {
-                // Found path that matches the given font's name
-                fontPath = path;
-                break;
-            }
-        }
-    } catch (e) {
-        logger.error(e.message, jobTemplateHelperFile);
-    }
-    return fontPath;
 }
 
 /**
@@ -488,9 +456,18 @@ function generateFontReferences(fontPaths) {
         var fontName = fontPaths[i][0];
         var fontLocation = fontPaths[i][1];
 
-        var fontFile = File(fontLocation);
+        // Normalize the font path for ExtendScript compatibility
+        var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
+        var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
+        
+        // Debug information
+        adcAlert("Debug: original=" + fontLocation + ", normalized=" + normalizedFontLocation + ", exists=" + fontFile.exists);
+        
         var fontCopied = fontFile.copy(_tempFontPath);
+        
+        adcAlert("Debug: fontCopied=" + fontCopied + ", error=" + fontFile.error);
+        
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -461,12 +461,7 @@ function generateFontReferences(fontPaths) {
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
         
-        // Debug information
-        adcAlert("Debug: original=" + fontLocation + ", normalized=" + normalizedFontLocation + ", exists=" + fontFile.exists);
-        
         var fontCopied = fontFile.copy(_tempFontPath);
-        
-        adcAlert("Debug: fontCopied=" + fontCopied + ", error=" + fontFile.error);
         
         // Check if font file was actually copied.
         if (fontCopied) {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On the rare case that the font used in an Adobe After Effects composition does not have its file location defined in the composition, the `get_user_fonts.py` script serves as a backup that gets all of the font files in the artist's machine and returns a JSON object to the After Effects submitter, which then iterates through the returned JSON object to get the target font's file path.

The problem is, the JSON object returned from the python file is massive and if an artist were to have a extremely high number of fonts on their machine, then After Effects will take forever to accept the JSON object and sometimes even crashes. 

### What was the solution? (How)
To prevent this issue of returning a super large JSON object from the Python file that crashes After Effects, I moved the font file searching logic to the Python file itself and that file will just return the font file path that was found. 

### What is the impact of this change?
Prevents AE crashes

### How was this change tested?
Tested on AE 24/25 on Mac and AE 24/25 on Windows with the fallback script forced to run by removing the usage of `font.location`, and verified it worked on all OS and versions and jobs succeeded.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
No

### Is this a breaking change?
No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
_delete text ending here_

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
