### PR TITLE
fix: sanitize parameter names to comply with open-jd specification

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2011,6 +2011,8 @@ function generateParameterName(index, compName, parameter) {
     }
     index = index.toString();
     compName = compName.substring(0, 15);
+    // replace non-alphanumeric characters to comply with OpenJD
+    compName = compName.replace(/[^a-zA-Z0-9]/g, '_');
     return "_" + index + "_" + compName + parameter;
 }
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2028,6 +2028,8 @@ function generatePrettyParameterName(index, compName, parameter) {
     if (compName.length >= maxLength) {
         compName = compName.substring(0, maxLength - 3) + "...";
     }
+    // replace non-alphanumeric characters to comply with OpenJD
+    compName = compName.replace(/[^a-zA-Z0-9]/g, '_');
     return "(" + index + "_" + compName + ") " + parameter;
 }
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -120,6 +120,8 @@ function generatePrettyParameterName(index, compName, parameter) {
     if (compName.length >= maxLength) {
         compName = compName.substring(0, maxLength - 3) + "...";
     }
+    // replace non-alphanumeric characters to comply with OpenJD
+    compName = compName.replace(/[^a-zA-Z0-9]/g, '_');
     return "(" + index + "_" + compName + ") " + parameter;
 }
 

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -103,6 +103,8 @@ function generateParameterName(index, compName, parameter) {
     }
     index = index.toString();
     compName = compName.substring(0, 15);
+    // replace non-alphanumeric characters to comply with OpenJD
+    compName = compName.replace(/[^a-zA-Z0-9]/g, '_');
     return "_" + index + "_" + compName + parameter;
 }
 


### PR DESCRIPTION
Fixes: Tracked in internal ticket.

### What was the problem/requirement? (What/Why)

Customers who use special characters like `\`, `=`, `+` are seeing job creation failures when submitting AE jobs through submitter. 

OpenJD doesn't support non-alphanumeric characters in parameters 

### What was the solution? (How)
We string-manipulate the compName to generate the parameterName already. We extended the manipulation to replace special characters with `_`

### What is the impact of this change?
Customers will be unblocked to use their own naming conventions for compositions which can include special characters

### How was this change tested?

1. Reproduced the issue by creating a composition in AE with name: `=FIRST\SECOND/=THIRD+A-B=C`. The job submission failed before adding my changes with regex error
```
Error occurred: An error occurred (ValidationException) when calling the CreateJob operation: Could not decode job template. Error: '7 validation errors for JobTemplate
parameterDefinitions[3] -> INT -> name:
	String should match pattern '(?-m:^[A-Za-z_][A-Za-z0-9_]*\z)'
```
2. Made the fixes and built the scripts
  ```
  python jsxbundler.py --source src/OpenAESubmitter.jsx --destination dist/DeadlineCloudSubmitter.jsx
  ```
3. Copied the plugin files to my AE ScriptUIPanels directory. Submitted a test render with comp name like below
4. Re-ran the job and verified that the job is successful and outputs are saved correctly on my mac. 

Testing Windows is pending. (This fix is not platform dependent though)

#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
NA

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
NA

### Was this change documented?
Bug fix. Code is commented with reason for the change.

- Did you update all relevant docstrings for functions that you modified? Yes
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change? NA

### Is this a breaking change?

No

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
