### PR TITLE
fix: improve fallback get_user_fonts.py script to handle finding .ttc font files and searching an additional font folder path on macOS

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -609,8 +609,8 @@ function __generateUtil() {
 
     /**
      * Extracts frame number, prefix, and suffix for single frame in image sequence.
-     * @param {string} fileName 
-     * @returns Object containing prefix, name, and suffix 
+     * @param {string} fileName
+     * @returns Object containing prefix, name, and suffix
      */
     function getImageSequenceInformation(fileName) {
         var regex = /^(.*?)(\d*)(\D*)$/;
@@ -1747,7 +1747,7 @@ function getLocationForFont(fontPostScriptName) {
         if (!pythonExecutable) {
             return null;
         }
-        
+
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const scriptFile = new File(scriptPath);
         if (!scriptFile.exists) {
@@ -1759,10 +1759,19 @@ function getLocationForFont(fontPostScriptName) {
             );
             return null;
         }
-        
+
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        if (cleanOutput === "FONT_NOT_FOUND") {
+            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
+            return null;
+        } else if (cleanOutput === "FONT_ERROR") {
+            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+            return null;
+        }
+
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -1958,9 +1967,9 @@ function generateFontReferences(fontPaths) {
         var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        
+
         var fontCopied = fontFile.copy(_tempFontPath);
-        
+
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -5,10 +5,12 @@ import sys
 
 try:
     from fontTools import ttLib
+    from fontTools.ttLib.ttCollection import TTCollection
 except ModuleNotFoundError:
     import subprocess
     subprocess.check_call([sys.executable, "-m", "pip", "install", "fonttools"])
     from fontTools import ttLib
+    from fontTools.ttLib.ttCollection import TTCollection
 
 # Font locations to search
 SEARCH_PATHS = [
@@ -23,10 +25,11 @@ if sys.platform == "darwin":
         "~/Library/Application Support/Adobe/CoreSync/plugins/livetype",
         "~/Library/Application Support/Adobe/User Owned Fonts",
         "~/Library/Fonts",
-        "/Library/Fonts"
+        "/Library/Fonts",
+        "/System/Library/Fonts",
     ]
 
-FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
+FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ".ttc", ""]
 TTF_POSTSCRIPT_NAME = 6
 
 
@@ -51,17 +54,35 @@ if __name__ == "__main__":
 
                     font_path = os.path.join(path, file)
                     try:
-                        t = ttLib.TTFont(font_path)
-                        names_table = t["name"].names
-                        postscript_name = str(names_table[TTF_POSTSCRIPT_NAME])
-                        if postscript_name == target_postscript_name:
-                            print(font_path)
-                            sys.exit(0)
+                        if ext.lower() == ".ttc":
+                            # TTC file - check all fonts in the collection
+                            ttc = TTCollection(font_path)
+                            for font_index in range(len(ttc)):
+                                font = ttc[font_index]
+                                names_table = font["name"].names
+                                for name_record in names_table:
+                                    if name_record.nameID == TTF_POSTSCRIPT_NAME:
+                                        postscript_name = str(name_record)
+                                        if postscript_name == target_postscript_name:
+                                            print(font_path)
+                                            sys.exit(0)
+                                        break
+                        else:
+                            # Single font file
+                            t = ttLib.TTFont(font_path)
+                            names_table = t["name"].names
+                            for name_record in names_table:
+                                if name_record.nameID == TTF_POSTSCRIPT_NAME:
+                                    postscript_name = str(name_record)
+                                    if postscript_name == target_postscript_name:
+                                        print(font_path)
+                                        sys.exit(0)
+                                    break
                     except Exception:
                         continue
-        print(f"Font file {target_postscript_name} is missing")
+        print("FONT_NOT_FOUND")
         sys.exit(1)
     except Exception as e:
-        print(f"An error occurred: {e}")
+        print("FONT_ERROR")
         sys.exit(1)
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -6,3 +6,4 @@ black == 25.*
 ruff == 0.14.*
 twine == 6.*
 types-pyyaml == 6.*
+fonttools == 4.*

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -313,7 +313,6 @@ function getLocationForFont(fontPostScriptName) {
         if (!pythonExecutable) {
             return null;
         }
-        
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const scriptFile = new File(scriptPath);
         if (!scriptFile.exists) {
@@ -325,10 +324,18 @@ function getLocationForFont(fontPostScriptName) {
             );
             return null;
         }
-        
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        if (cleanOutput === "FONT_NOT_FOUND") {
+            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
+            return null;
+        } else if (cleanOutput === "FONT_ERROR") {
+            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+            return null;
+        }
+
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -524,9 +531,7 @@ function generateFontReferences(fontPaths) {
         var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        
         var fontCopied = fontFile.copy(_tempFontPath);
-        
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/test/unit/test_font_detection.py
+++ b/test/unit/test_font_detection.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Cross-platform fonts
+CROSS_PLATFORM_FONTS = [
+    "ArialMT",
+    "TimesNewRomanPSMT",
+    "Calibri"
+]
+
+# macOS-specific fonts
+MACOS_FONTS = ["Helvetica"]
+
+# Get fonts for current platform
+COMMON_FONTS = CROSS_PLATFORM_FONTS + (MACOS_FONTS if platform.system() == "Darwin" else [])
+
+def get_font_script_path():
+    """Get path to get_user_fonts.py script"""
+    project_root = Path(__file__).parent.parent.parent
+    return project_root / "dist" / "DeadlineCloudSubmitter_Assets" / "JobTemplate" / "scripts" / "get_user_fonts.py"
+
+@pytest.mark.parametrize("postscript_name", COMMON_FONTS)
+def test_font_detection(postscript_name):
+    """Test that get_user_fonts.py can find common fonts by PostScript name"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path), postscript_name],
+        capture_output=True,
+        text=True
+    )
+
+    # Should either find font (exit 0) or not find it (exit 1)
+    # Just verify script runs without crashing
+    assert result.returncode in [0, 1], f"Script crashed for {postscript_name}: {result.stderr}"
+
+    if result.returncode == 0:
+        # If found, should output a file path
+        assert result.stdout.strip(), f"No output for found font {postscript_name}"
+
+def test_missing_font():
+    """Test that script exits with error for non-existent font"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path), "NonExistentFont123"],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 1
+    assert "FONT_NOT_FOUND" in result.stdout
+
+def test_script_no_args():
+    """Test that script exits with error when no font name provided"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path)],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 1
+    assert "Missing font name argument" in result.stdout


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There was another location on macOS machines with font files in it that were not being searched in the get_user_fonts.py fallback search script. Additionally, if a customer was using a .ttc font in their composition and the fallback script was run, the fallback script wouldn't be able to identify the font file used in the composition and thus wouldn't be able to warn the artist about using an incompatible font.

### What was the solution? (How)
Added the additional font folder location and improved fallback script to handle searching for .ttc files

### What is the impact of this change?
Better fallback mechanism.

### How was this change tested?
On macOS AE24.6 and AE 25.5, I attempted to submit a job on macOS and forced the fallback script to be run by doing a manual code change. I verified the script worked and was able to find the font Helvetica.ttc which it couldn't find before, and a warning correctly surfaced to me that Helvetica.ttc was not a supported file type. There's another font called TamilSangamMN that wasn't being identified before but now it's being identified properly.

Then I wrote unit tests which passed on macOS. However, I'm unable to run the unit tests on Windows at this time due to technical issues, still troubleshooting.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
No

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
