### PR TITLE
fix: aggregate font errors into single popup for submission

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1635,6 +1635,9 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
  **/
 function getFontsFromFile() {
     var fontLocations = [];
+    var unsupportedFonts = {}; // using this object as a set because AE doesn't support sets
+    var unsupportedFontList = [];
+    var fontsWithoutLocation = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
@@ -1643,19 +1646,37 @@ function getFontsFromFile() {
             var fontPostScriptName = font.postScriptName;
             var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
-                adcAlert(
-                    "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
-                    "Please install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
-                );
+                fontsWithoutLocation.push(fontPostScriptName);
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
-            if (fontName) {
-                fontLocations.push([fontName, fontLocation]);
+            var fontDetails = getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName);
+            if (fontDetails["isExtensionSupported"]) {
+                fontLocations.push([fontDetails.fontName, fontLocation]);
+            } else {
+                unsupportedFonts[font.familyName + fontDetails.fileExtension] = true;
             }
         }
     } else {
         fontLocations = getFontsFromFileLegacy();
+    }
+
+    for (var key in unsupportedFonts) {
+        unsupportedFontList.push(key);
+    }
+    if (unsupportedFontList.length > 0) {
+        adcAlert(
+            "Font(s) detected with unsupported extension(s) \n"
+            + unsupportedFontList.join(", \n") +
+            "\n\nThese font(s) won't be added to the job.", false
+        );
+    }
+
+    if (fontsWithoutLocation.length > 0) {
+        adcAlert(
+            "The path to the below font(s) couldn't be identified. \n\n" + 
+            fontsWithoutLocation.join(", ") + "\n" +
+            "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
+        );
     }
 
     return fontLocations;
@@ -1794,6 +1815,49 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     }
 
     return fontName;
+}
+
+
+/**
+ * Generates a font filename based on the font name and the extension of the font filename
+ * and whether the extension is supported
+ * @return an object with the font filename and extension validity
+ **/
+function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
+    var fileExtension = "";
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
+
+    var validExtension = true;
+    const fontExtensions = [".otf", ".ttf"];
+
+    // Windows also supports .fon files
+    const os = $.os.toLowerCase();
+    if (os.indexOf("windows") !== -1) {
+        fontExtensions.push(".fon");
+    }
+
+    // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
+    if (extensionRegex.test(fontLocation)) {
+        fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
+        const fontExtensionsAsString = fontExtensions.toString();
+        if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
+            validExtension = false;
+        }
+    }
+    if (validExtension) {
+        return {
+            "isExtensionSupported": true,
+            "fontPostScriptName": fontPostScriptName,    
+            "fileExtension": fileExtension
+        };
+    } else {
+        return {
+            "isExtensionSupported": false,
+            "fontPostScriptName": fontPostScriptName,
+            "fileExtension": fileExtension
+        };
+    }
 }
 
 /**

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -201,6 +201,9 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
  **/
 function getFontsFromFile() {
     var fontLocations = [];
+    var unsupportedFonts = {}; // using this object as a set because AE doesn't support sets
+    var unsupportedFontList = [];
+    var fontsWithoutLocation = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
@@ -209,19 +212,37 @@ function getFontsFromFile() {
             var fontPostScriptName = font.postScriptName;
             var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
-                adcAlert(
-                    "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
-                    "Please install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
-                );
+                fontsWithoutLocation.push(fontPostScriptName);
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
-            if (fontName) {
-                fontLocations.push([fontName, fontLocation]);
+            var fontDetails = getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName);
+            if (fontDetails["isExtensionSupported"]) {
+                fontLocations.push([fontDetails.fontName, fontLocation]);
+            } else {
+                unsupportedFonts[font.familyName + fontDetails.fileExtension] = true;
             }
         }
     } else {
         fontLocations = getFontsFromFileLegacy();
+    }
+
+    for (var key in unsupportedFonts) {
+        unsupportedFontList.push(key);
+    }
+    if (unsupportedFontList.length > 0) {
+        adcAlert(
+            "Font(s) detected with unsupported extension(s) \n"
+            + unsupportedFontList.join(", \n") +
+            "\n\nThese font(s) won't be added to the job.", false
+        );
+    }
+
+    if (fontsWithoutLocation.length > 0) {
+        adcAlert(
+            "The path to the below font(s) couldn't be identified. \n\n" + 
+            fontsWithoutLocation.join(", ") + "\n" +
+            "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
+        );
     }
 
     return fontLocations;
@@ -360,6 +381,49 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     }
 
     return fontName;
+}
+
+
+/**
+ * Generates a font filename based on the font name and the extension of the font filename
+ * and whether the extension is supported
+ * @return an object with the font filename and extension validity
+ **/
+function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
+    var fileExtension = "";
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
+
+    var validExtension = true;
+    const fontExtensions = [".otf", ".ttf"];
+
+    // Windows also supports .fon files
+    const os = $.os.toLowerCase();
+    if (os.indexOf("windows") !== -1) {
+        fontExtensions.push(".fon");
+    }
+
+    // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
+    if (extensionRegex.test(fontLocation)) {
+        fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
+        const fontExtensionsAsString = fontExtensions.toString();
+        if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
+            validExtension = false;
+        }
+    }
+    if (validExtension) {
+        return {
+            "isExtensionSupported": true,
+            "fontPostScriptName": fontPostScriptName,    
+            "fileExtension": fileExtension
+        };
+    } else {
+        return {
+            "isExtensionSupported": false,
+            "fontPostScriptName": fontPostScriptName,
+            "fileExtension": fileExtension
+        };
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes:  Tracked internally

### What was the problem/requirement? (What/Why)
Current AE submitter shows one popup per font issue detected on user's workstation. This hinders their submission workflow when the number of unsupported/location-not-found fonts are high in number. We need to show a single popup.

### What was the solution? (How)

Aggregated all errors into one popup per issue type for non-legacy AE versions. 

1. Created a separate method for handling error messages in non-legacy versions.
2. Retained multiple popup experience in legacy versions of AE(<24.5) to bias for action and resolve immediate user issues.

Took @viknith 's advice to aggregate by font family in new PR

### What is the impact of this change?
Users just need to acknowledge one popup before submission per issue type.

### How was this change tested?
1. Reproduced the issue on AE 25.5 by creating a composition with 3 ttc type fonts and submitting. (3 popups shown).
4. Fixed the submitter and retried the submission. Verified that all errors are aggregated into single popup.


<img width="647" height="723" alt="multipopup issue" src="https://github.com/user-attachments/assets/1f359855-db8f-44b2-a9db-5d0b855b61a1" />


#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
NA

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

NA
### Was this change documented?
NA

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
