### PR TITLE
fix: fix a regression bug in multi-popup aggregation

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1848,14 +1848,14 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     if (validExtension) {
         return {
             "isExtensionSupported": true,
-            "fontPostScriptName": fontPostScriptName,    
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     } else {
         return {
             "isExtensionSupported": false,
-            "fontPostScriptName": fontPostScriptName,
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     }
 }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1635,6 +1635,9 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
  **/
 function getFontsFromFile() {
     var fontLocations = [];
+    var unsupportedFonts = {}; // using this object as a set because AE doesn't support sets
+    var unsupportedFontList = [];
+    var fontsWithoutLocation = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
@@ -1643,19 +1646,37 @@ function getFontsFromFile() {
             var fontPostScriptName = font.postScriptName;
             var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
-                adcAlert(
-                    "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
-                    "Please install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
-                );
+                fontsWithoutLocation.push(fontPostScriptName);
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
-            if (fontName) {
-                fontLocations.push([fontName, fontLocation]);
+            var fontDetails = getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName);
+            if (fontDetails["isExtensionSupported"]) {
+                fontLocations.push([fontDetails.fontName, fontLocation]);
+            } else {
+                unsupportedFonts[font.familyName + fontDetails.fileExtension] = true;
             }
         }
     } else {
         fontLocations = getFontsFromFileLegacy();
+    }
+
+    for (var key in unsupportedFonts) {
+        unsupportedFontList.push(key);
+    }
+    if (unsupportedFontList.length > 0) {
+        adcAlert(
+            "Font(s) detected with unsupported extension(s) \n"
+            + unsupportedFontList.join(", \n") +
+            "\n\nThese font(s) won't be added to the job.", false
+        );
+    }
+
+    if (fontsWithoutLocation.length > 0) {
+        adcAlert(
+            "The path to the below font(s) couldn't be identified. \n\n" + 
+            fontsWithoutLocation.join(", ") + "\n" +
+            "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
+        );
     }
 
     return fontLocations;
@@ -1794,6 +1815,49 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     }
 
     return fontName;
+}
+
+
+/**
+ * Generates a font filename based on the font name and the extension of the font filename
+ * and whether the extension is supported
+ * @return an object with the font filename and extension validity
+ **/
+function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
+    var fileExtension = "";
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
+
+    var validExtension = true;
+    const fontExtensions = [".otf", ".ttf"];
+
+    // Windows also supports .fon files
+    const os = $.os.toLowerCase();
+    if (os.indexOf("windows") !== -1) {
+        fontExtensions.push(".fon");
+    }
+
+    // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
+    if (extensionRegex.test(fontLocation)) {
+        fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
+        const fontExtensionsAsString = fontExtensions.toString();
+        if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
+            validExtension = false;
+        }
+    }
+    if (validExtension) {
+        return {
+            "isExtensionSupported": true,
+            "fontPostScriptName": fontPostScriptName,    
+            "fileExtension": fileExtension
+        };
+    } else {
+        return {
+            "isExtensionSupported": false,
+            "fontPostScriptName": fontPostScriptName,
+            "fileExtension": fileExtension
+        };
+    }
 }
 
 /**

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -201,6 +201,9 @@ function findJobAttachments(rootComp, ignoreMissingDependencies) {
  **/
 function getFontsFromFile() {
     var fontLocations = [];
+    var unsupportedFonts = {}; // using this object as a set because AE doesn't support sets
+    var unsupportedFontList = [];
+    var fontsWithoutLocation = [];
     // app.project.usedFonts was introduced in 24.5. Fall back to scanning text layers if version is older
     if (dcUtil.getAEVersion() >= 24.5) {
         const usedList = app.project.usedFonts;
@@ -209,19 +212,37 @@ function getFontsFromFile() {
             var fontPostScriptName = font.postScriptName;
             var fontLocation = font.location || getLocationForFont(fontPostScriptName);
             if (!fontLocation) {
-                adcAlert(
-                    "The path to the font " + fontPostScriptName + " couldn't be identified.\n" +
-                    "Please install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
-                );
+                fontsWithoutLocation.push(fontPostScriptName);
                 continue;
             }
-            var fontName = createFontFilename(fontLocation, fontPostScriptName);
-            if (fontName) {
-                fontLocations.push([fontName, fontLocation]);
+            var fontDetails = getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName);
+            if (fontDetails["isExtensionSupported"]) {
+                fontLocations.push([fontDetails.fontName, fontLocation]);
+            } else {
+                unsupportedFonts[font.familyName + fontDetails.fileExtension] = true;
             }
         }
     } else {
         fontLocations = getFontsFromFileLegacy();
+    }
+
+    for (var key in unsupportedFonts) {
+        unsupportedFontList.push(key);
+    }
+    if (unsupportedFontList.length > 0) {
+        adcAlert(
+            "Font(s) detected with unsupported extension(s) \n"
+            + unsupportedFontList.join(", \n") +
+            "\n\nThese font(s) won't be added to the job.", false
+        );
+    }
+
+    if (fontsWithoutLocation.length > 0) {
+        adcAlert(
+            "The path to the below font(s) couldn't be identified. \n\n" + 
+            fontsWithoutLocation.join(", ") + "\n" +
+            "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
+        );
     }
 
     return fontLocations;
@@ -360,6 +381,49 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     }
 
     return fontName;
+}
+
+
+/**
+ * Generates a font filename based on the font name and the extension of the font filename
+ * and whether the extension is supported
+ * @return an object with the font filename and extension validity
+ **/
+function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
+    var fileExtension = "";
+    const lastDotIndex = fontLocation.lastIndexOf('.');
+    const extensionRegex = /\.[a-zA-Z]+$/;
+
+    var validExtension = true;
+    const fontExtensions = [".otf", ".ttf"];
+
+    // Windows also supports .fon files
+    const os = $.os.toLowerCase();
+    if (os.indexOf("windows") !== -1) {
+        fontExtensions.push(".fon");
+    }
+
+    // Some Adobe Fonts files have a dot followed by numbers as its name with no extension (e.g. ".52741")
+    if (extensionRegex.test(fontLocation)) {
+        fileExtension = fontLocation.substring(lastDotIndex).toLowerCase();
+        const fontExtensionsAsString = fontExtensions.toString();
+        if (fontExtensionsAsString.indexOf(fileExtension) == -1) {
+            validExtension = false;
+        }
+    }
+    if (validExtension) {
+        return {
+            "isExtensionSupported": true,
+            "fontPostScriptName": fontPostScriptName,    
+            "fileExtension": fileExtension
+        };
+    } else {
+        return {
+            "isExtensionSupported": false,
+            "fontPostScriptName": fontPostScriptName,
+            "fileExtension": fileExtension
+        };
+    }
 }
 
 /**

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -414,14 +414,14 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     if (validExtension) {
         return {
             "isExtensionSupported": true,
-            "fontPostScriptName": fontPostScriptName,    
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     } else {
         return {
             "isExtensionSupported": false,
-            "fontPostScriptName": fontPostScriptName,
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     }
 }


### PR DESCRIPTION
Fixes: Tracked internally

### What was the problem/requirement? (What/Why)

In an [earlier PR](https://github.com/aws-deadline/deadline-cloud-for-after-effects/pull/257/files) to fix multiple popups per font issue, we introduced a regression which was caught by @viknith during testing for one of the positive scenarios. This was due to field refactoring in a function return value in the revised PR.

This was causing valid fonts not be collected by submitter

### What was the solution? (How)

Fixed the return value so that the valid fonts are collected by submitter

### What is the impact of this change?

Bug fix. Submitter collects all valid fonts for job attachments.

### How was this change tested?

Created a comp with valid and invalid fonts and it showed popup for invalid fonts and collected valid fonts as job attachments.

<img width="540" height="624" alt="Screenshot 2025-10-16 at 11 29 18 AM" src="https://github.com/user-attachments/assets/82370ebb-0c26-4213-aef1-cc79a3d07b54" />



#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes


### Was this change documented?
NA

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
