### PR TITLE
fix: bug fix for valid fonts not being collected

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1848,14 +1848,14 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     if (validExtension) {
         return {
             "isExtensionSupported": true,
-            "fontPostScriptName": fontPostScriptName,    
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     } else {
         return {
             "isExtensionSupported": false,
-            "fontPostScriptName": fontPostScriptName,
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     }
 }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -414,14 +414,14 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     if (validExtension) {
         return {
             "isExtensionSupported": true,
-            "fontPostScriptName": fontPostScriptName,    
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     } else {
         return {
             "isExtensionSupported": false,
-            "fontPostScriptName": fontPostScriptName,
-            "fileExtension": fileExtension
+            "fileExtension": fileExtension,
+            "fontName": fontPostScriptName + fileExtension
         };
     }
 }


### PR DESCRIPTION
Fixes: Tracked internally

### What was the problem/requirement? (What/Why)

In an [earlier PR](https://github.com/aws-deadline/deadline-cloud-for-after-effects/pull/257/files) to fix multiple popups per font issue, we introduced a regression which was caught by @viknith during testing for one of the positive scenarios. This was due to field refactoring in a function return value in the revised PR.

This was causing valid fonts not be collected by submitter

### What was the solution? (How)

Fixed the return value so that the valid fonts are collected by submitter

### What is the impact of this change?

Bug fix. Submitter collects all valid fonts for job attachments.

### How was this change tested?

Created a comp with valid and invalid fonts and it showed popup for invalid fonts and collected valid fonts as job attachments.

<img width="540" height="624" alt="Screenshot 2025-10-16 at 11 29 18 AM" src="https://github.com/user-attachments/assets/82370ebb-0c26-4213-aef1-cc79a3d07b54" />



#### If you modified source files, did you run the Python script to update the files under the dist folder?
Yes


### Was this change documented?
NA

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
