### PR TITLE
fix: improve get_user_fonts.py script and refactored file existence validation to minimize popups

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2196,12 +2196,17 @@ function SubmitSelection(selection, selectionSettings) {
         "step_video_fragment.json"
     ];
 
+    var missingFiles = [];
     for (var f = 0; f < requiredFiles.length; f++) {
-        var jobTemplateFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
-        if (!jobTemplateFile.exists) {
-            adcAlert("Error: Missing required file: " + requiredFiles[f], true);
-            return;
+        var requiredFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
+        if (!requiredFile.exists) {
+            missingFiles.push(requiredFiles[f]);
         }
+    }
+    
+    if (missingFiles.length > 0) {
+        adcAlert("Error: Missing required files:\n" + missingFiles.join("\n"), true);
+        return;
     }
 
     const renderQueueItems = [];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1673,7 +1673,7 @@ function getFontsFromFile() {
 
     if (fontsWithoutLocation.length > 0) {
         adcAlert(
-            "The path to the below font(s) couldn't be identified. \n\n" + 
+            "The path to the below font(s) couldn't be identified. \n\n" +
             fontsWithoutLocation.join(", ") + "\n" +
             "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
         );
@@ -1748,37 +1748,18 @@ function getLocationForFont(fontPostScriptName) {
             return null;
         }
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-        const scriptFile = new File(scriptPath);
-        if (!scriptFile.exists) {
-            adcAlert(
-                "Error: Missing font script at " + scriptFile.fsName + "\n" +
-                "\n" +
-                "Please ensure that the Deadline Cloud Submitter is installed correctly.",
-                true
-            );
-            return null;
-        }
-        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
 
-        if (cleanOutput === "FONT_NOT_FOUND") {
-            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
-            return null;
-        } else if (cleanOutput === "FONT_ERROR") {
-            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+        if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
+            logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);
             return null;
         }
 
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
-        adcAlert(
-            "Error when finding fonts:\n" +
-            "\n" +
-            e.message,
-            true
-        );
         return null;
     }
 }
@@ -2191,6 +2172,36 @@ function SubmitSelection(selection, selectionSettings) {
     if (taskTimeoutSeconds <= 0) {
         adcAlert("The following timeout value must be greater than 0: TaskRun", true);
         return;
+    }
+
+    // Check required files exist before proceeding
+    const assetsFolder = new Folder(scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate");
+    if (!assetsFolder.exists) {
+        adcAlert("Error: Missing DeadlineCloudSubmitter_Assets folder at " + assetsFolder.fsName, true);
+        return;
+    }
+
+    const requiredFiles = [
+        "scripts/get_user_fonts.py",
+        "scripts/font_manager.py",
+        "scripts/call_aerender.py",
+        "scripts/create_output_directory.py",
+        "template.json",
+        "image_template.json",
+        "video_template.json",
+        "job_environments_fragment.json",
+        "parameter_definitions_image_fragment.json",
+        "parameter_definitions_video_fragment.json",
+        "step_image_fragment.json",
+        "step_video_fragment.json"
+    ];
+
+    for (var f = 0; f < requiredFiles.length; f++) {
+        var jobTemplateFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
+        if (!jobTemplateFile.exists) {
+            adcAlert("Error: Missing required file: " + requiredFiles[f], true);
+            return;
+        }
     }
 
     const renderQueueItems = [];

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -609,8 +609,8 @@ function __generateUtil() {
 
     /**
      * Extracts frame number, prefix, and suffix for single frame in image sequence.
-     * @param {string} fileName 
-     * @returns Object containing prefix, name, and suffix 
+     * @param {string} fileName
+     * @returns Object containing prefix, name, and suffix
      */
     function getImageSequenceInformation(fileName) {
         var regex = /^(.*?)(\d*)(\D*)$/;
@@ -1747,7 +1747,7 @@ function getLocationForFont(fontPostScriptName) {
         if (!pythonExecutable) {
             return null;
         }
-        
+
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const scriptFile = new File(scriptPath);
         if (!scriptFile.exists) {
@@ -1759,10 +1759,19 @@ function getLocationForFont(fontPostScriptName) {
             );
             return null;
         }
-        
+
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        if (cleanOutput === "FONT_NOT_FOUND") {
+            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
+            return null;
+        } else if (cleanOutput === "FONT_ERROR") {
+            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+            return null;
+        }
+
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -1958,9 +1967,9 @@ function generateFontReferences(fontPaths) {
         var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        
+
         var fontCopied = fontFile.copy(_tempFontPath);
-        
+
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -609,8 +609,8 @@ function __generateUtil() {
 
     /**
      * Extracts frame number, prefix, and suffix for single frame in image sequence.
-     * @param {string} fileName
-     * @returns Object containing prefix, name, and suffix
+     * @param {string} fileName 
+     * @returns Object containing prefix, name, and suffix 
      */
     function getImageSequenceInformation(fileName) {
         var regex = /^(.*?)(\d*)(\D*)$/;
@@ -1747,7 +1747,6 @@ function getLocationForFont(fontPostScriptName) {
         if (!pythonExecutable) {
             return null;
         }
-
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const scriptFile = new File(scriptPath);
         if (!scriptFile.exists) {
@@ -1759,7 +1758,6 @@ function getLocationForFont(fontPostScriptName) {
             );
             return null;
         }
-
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
@@ -1967,9 +1965,7 @@ function generateFontReferences(fontPaths) {
         var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-
         var fontCopied = fontFile.copy(_tempFontPath);
-
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py
@@ -5,10 +5,12 @@ import sys
 
 try:
     from fontTools import ttLib
+    from fontTools.ttLib.ttCollection import TTCollection
 except ModuleNotFoundError:
     import subprocess
     subprocess.check_call([sys.executable, "-m", "pip", "install", "fonttools"])
     from fontTools import ttLib
+    from fontTools.ttLib.ttCollection import TTCollection
 
 # Font locations to search
 SEARCH_PATHS = [
@@ -23,10 +25,11 @@ if sys.platform == "darwin":
         "~/Library/Application Support/Adobe/CoreSync/plugins/livetype",
         "~/Library/Application Support/Adobe/User Owned Fonts",
         "~/Library/Fonts",
-        "/Library/Fonts"
+        "/Library/Fonts",
+        "/System/Library/Fonts",
     ]
 
-FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
+FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ".ttc", ""]
 TTF_POSTSCRIPT_NAME = 6
 
 
@@ -51,17 +54,35 @@ if __name__ == "__main__":
 
                     font_path = os.path.join(path, file)
                     try:
-                        t = ttLib.TTFont(font_path)
-                        names_table = t["name"].names
-                        postscript_name = str(names_table[TTF_POSTSCRIPT_NAME])
-                        if postscript_name == target_postscript_name:
-                            print(font_path)
-                            sys.exit(0)
+                        if ext.lower() == ".ttc":
+                            # TTC file - check all fonts in the collection
+                            ttc = TTCollection(font_path)
+                            for font_index in range(len(ttc)):
+                                font = ttc[font_index]
+                                names_table = font["name"].names
+                                for name_record in names_table:
+                                    if name_record.nameID == TTF_POSTSCRIPT_NAME:
+                                        postscript_name = str(name_record)
+                                        if postscript_name == target_postscript_name:
+                                            print(font_path)
+                                            sys.exit(0)
+                                        break
+                        else:
+                            # Single font file
+                            t = ttLib.TTFont(font_path)
+                            names_table = t["name"].names
+                            for name_record in names_table:
+                                if name_record.nameID == TTF_POSTSCRIPT_NAME:
+                                    postscript_name = str(name_record)
+                                    if postscript_name == target_postscript_name:
+                                        print(font_path)
+                                        sys.exit(0)
+                                    break
                     except Exception:
                         continue
-        print(f"Font file {target_postscript_name} is missing")
+        print("FONT_NOT_FOUND")
         sys.exit(1)
     except Exception as e:
-        print(f"An error occurred: {e}")
+        print("FONT_ERROR")
         sys.exit(1)
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -6,3 +6,4 @@ black == 25.*
 ruff == 0.14.*
 twine == 6.*
 types-pyyaml == 6.*
+fonttools == 4.*

--- a/scripts/_project.py
+++ b/scripts/_project.py
@@ -33,7 +33,9 @@ def get_project_dict(project_path: Optional[Path] = None) -> dict[str, Any]:
 
         mode = "rb"
 
-    with open(str((project_path or get_git_root()) / "pyproject.toml"), mode) as pyproject_toml:
+    with open(
+        str((project_path or get_git_root()) / "pyproject.toml"), mode
+    ) as pyproject_toml:
         return toml.load(pyproject_toml)
 
 
@@ -52,7 +54,9 @@ class Dependency:
         return self.for_pip()
 
 
-def get_dependencies(pyproject_dict: dict[str, Any], exclude_adaptor_only=True) -> list[Dependency]:
+def get_dependencies(
+    pyproject_dict: dict[str, Any], exclude_adaptor_only=True
+) -> list[Dependency]:
     if "project" not in pyproject_dict:
         raise Exception("pyproject.toml is missing project section")
     if "dependencies" not in pyproject_dict["project"]:

--- a/scripts/deps_bundle.py
+++ b/scripts/deps_bundle.py
@@ -24,7 +24,9 @@ def _get_package_version_regex(package: str) -> re.Pattern:
 def _get_package_version(package: str, install_path: Path) -> str:
     version_regex = _get_package_version_regex(package)
     pip_args = ["pip", "list", "--path", str(install_path)]
-    output = subprocess.run(pip_args, check=True, capture_output=True).stdout.decode("utf-8")
+    output = subprocess.run(pip_args, check=True, capture_output=True).stdout.decode(
+        "utf-8"
+    )
     for line in output.split("\n"):
         match = version_regex.match(line)
         if match:
@@ -32,7 +34,9 @@ def _get_package_version(package: str, install_path: Path) -> str:
     raise Exception(f"Could not find version for package {package}")
 
 
-def _build_base_environment(working_directory: Path, dependencies: list[Dependency]) -> Path:
+def _build_base_environment(
+    working_directory: Path, dependencies: list[Dependency]
+) -> Path:
     (working_directory / "base_env").mkdir()
     base_env_path = working_directory / "base_env"
     dependencies_for_pip = [d.for_pip() for d in dependencies]
@@ -48,14 +52,18 @@ def _build_base_environment(working_directory: Path, dependencies: list[Dependen
     return base_env_path
 
 
-def _download_native_dependencies(working_directory: Path, base_env: Path) -> list[Path]:
+def _download_native_dependencies(
+    working_directory: Path, base_env: Path
+) -> list[Path]:
     versioned_native_dependencies = [
         f"{package_name}=={_get_package_version(package_name, base_env)}"
         for package_name in NATIVE_DEPENDENCIES
     ]
     native_dependency_paths = []
     for version in SUPPORTED_PYTHON_VERSIONS:
-        native_dependency_path = working_directory / "native" / f"{version.replace('.', '_')}"
+        native_dependency_path = (
+            working_directory / "native" / f"{version.replace('.', '_')}"
+        )
         native_dependency_paths.append(native_dependency_path)
         native_dependency_path.mkdir(parents=True)
         native_dependency_pip_args = [
@@ -72,7 +80,9 @@ def _download_native_dependencies(working_directory: Path, base_env: Path) -> li
     return native_dependency_paths
 
 
-def _copy_native_to_base_env(base_env: Path, native_dependency_paths: list[Path]) -> None:
+def _copy_native_to_base_env(
+    base_env: Path, native_dependency_paths: list[Path]
+) -> None:
     for native_dependency_path in native_dependency_paths:
         for file in native_dependency_path.rglob("*"):
             if file.is_file():
@@ -118,7 +128,9 @@ def build_deps_bundle() -> None:
             lambda dep: not dep.name.startswith("openjd"), dependencies
         )
         base_env = _build_base_environment(working_directory, deps_noopenjd)
-        native_dependency_paths = _download_native_dependencies(working_directory, base_env)
+        native_dependency_paths = _download_native_dependencies(
+            working_directory, base_env
+        )
         _copy_native_to_base_env(base_env, native_dependency_paths)
         zip_path = _get_zip_path(working_directory, project_dict)
         _zip_bundle(base_env, zip_path)

--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -48,9 +48,15 @@ class InstallBuilderSelection:
             dest.parent.mkdir(parents=True, exist_ok=True)
             expected_bucket_owner = os.getenv("IB_SOURCE_BUCKET_OWNER")
             if not expected_bucket_owner:
-                raise ValueError("IB_SOURCE_BUCKET_OWNER environment variable is required")
-            if not (expected_bucket_owner.isdigit() and len(expected_bucket_owner) == 12):
-                raise ValueError("IB_SOURCE_BUCKET_OWNER must be a 12-digit AWS Account ID")
+                raise ValueError(
+                    "IB_SOURCE_BUCKET_OWNER environment variable is required"
+                )
+            if not (
+                expected_bucket_owner.isdigit() and len(expected_bucket_owner) == 12
+            ):
+                raise ValueError(
+                    "IB_SOURCE_BUCKET_OWNER must be a 12-digit AWS Account ID"
+                )
 
             s3.download_file(
                 self.selection.bucket,

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -313,7 +313,6 @@ function getLocationForFont(fontPostScriptName) {
         if (!pythonExecutable) {
             return null;
         }
-        
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const scriptFile = new File(scriptPath);
         if (!scriptFile.exists) {
@@ -325,10 +324,18 @@ function getLocationForFont(fontPostScriptName) {
             );
             return null;
         }
-        
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        if (cleanOutput === "FONT_NOT_FOUND") {
+            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
+            return null;
+        } else if (cleanOutput === "FONT_ERROR") {
+            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+            return null;
+        }
+
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
@@ -524,9 +531,7 @@ function generateFontReferences(fontPaths) {
         var normalizedFontLocation = fontLocation.replace(/\//g, File.fs == "Windows" ? "\\" : "/");
         var fontFile = File(normalizedFontLocation);
         var _tempFontPath = dcUtil.normPath(_tempFontsFolder + "/" + fontName);
-        
         var fontCopied = fontFile.copy(_tempFontPath);
-        
         // Check if font file was actually copied.
         if (fontCopied) {
             formattedFontsPaths.push(_tempFontPath);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -239,7 +239,7 @@ function getFontsFromFile() {
 
     if (fontsWithoutLocation.length > 0) {
         adcAlert(
-            "The path to the below font(s) couldn't be identified. \n\n" + 
+            "The path to the below font(s) couldn't be identified. \n\n" +
             fontsWithoutLocation.join(", ") + "\n" +
             "\nPlease install the font for non-Adobe apps in Creative Cloud Desktop before submitting this project.", false
         );
@@ -314,37 +314,18 @@ function getLocationForFont(fontPostScriptName) {
             return null;
         }
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
-        const scriptFile = new File(scriptPath);
-        if (!scriptFile.exists) {
-            adcAlert(
-                "Error: Missing font script at " + scriptFile.fsName + "\n" +
-                "\n" +
-                "Please ensure that the Deadline Cloud Submitter is installed correctly.",
-                true
-            );
-            return null;
-        }
-        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptFile.fsName + "\" \"" + fontPostScriptName + "\"");
+        const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
         // Clean the output by removing all whitespace characters
         var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
 
-        if (cleanOutput === "FONT_NOT_FOUND") {
-            adcAlert("Font '" + fontPostScriptName + "' could not be found on this system.", false);
-            return null;
-        } else if (cleanOutput === "FONT_ERROR") {
-            adcAlert("An error occurred while searching for font '" + fontPostScriptName + "'.", false);
+        if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
+            logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);
             return null;
         }
 
         return cleanOutput || null;
     } catch (e) {
         logger.error(e.message, jobTemplateHelperFile);
-        adcAlert(
-            "Error when finding fonts:\n" +
-            "\n" +
-            e.message,
-            true
-        );
         return null;
     }
 }

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -238,12 +238,17 @@ function SubmitSelection(selection, selectionSettings) {
         "step_video_fragment.json"
     ];
 
+    var missingFiles = [];
     for (var f = 0; f < requiredFiles.length; f++) {
-        var jobTemplateFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
-        if (!jobTemplateFile.exists) {
-            adcAlert("Error: Missing required file: " + requiredFiles[f], true);
-            return;
+        var requiredFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
+        if (!requiredFile.exists) {
+            missingFiles.push(requiredFiles[f]);
         }
+    }
+    
+    if (missingFiles.length > 0) {
+        adcAlert("Error: Missing required files:\n" + missingFiles.join("\n"), true);
+        return;
     }
 
     const renderQueueItems = [];

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -216,6 +216,36 @@ function SubmitSelection(selection, selectionSettings) {
         return;
     }
 
+    // Check required files exist before proceeding
+    const assetsFolder = new Folder(scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate");
+    if (!assetsFolder.exists) {
+        adcAlert("Error: Missing DeadlineCloudSubmitter_Assets folder at " + assetsFolder.fsName, true);
+        return;
+    }
+
+    const requiredFiles = [
+        "scripts/get_user_fonts.py",
+        "scripts/font_manager.py",
+        "scripts/call_aerender.py",
+        "scripts/create_output_directory.py",
+        "template.json",
+        "image_template.json",
+        "video_template.json",
+        "job_environments_fragment.json",
+        "parameter_definitions_image_fragment.json",
+        "parameter_definitions_video_fragment.json",
+        "step_image_fragment.json",
+        "step_video_fragment.json"
+    ];
+
+    for (var f = 0; f < requiredFiles.length; f++) {
+        var jobTemplateFile = new File(assetsFolder.fsName + "/" + requiredFiles[f]);
+        if (!jobTemplateFile.exists) {
+            adcAlert("Error: Missing required file: " + requiredFiles[f], true);
+            return;
+        }
+    }
+
     const renderQueueItems = [];
 
     // Check to make sure that all of our selection indices are correct

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -77,7 +77,7 @@ def _run_installer(installer_path, install_scope, installation_path) -> Path:
         "--after_effects_script_ui_directory_2024",
         ae2024,
         "--after_effects_script_ui_directory_2025",
-        ae2025
+        ae2025,
     ]
     subprocess.run(args, check=True, capture_output=True, text=True)
 
@@ -445,7 +445,9 @@ class TestUserInstall:
         assert not per_test_user_installation.exists()
 
 
-@pytest.mark.skipif(not _is_admin(), reason="System install tests requires admin privileges")
+@pytest.mark.skipif(
+    not _is_admin(), reason="System install tests requires admin privileges"
+)
 class TestSystemInstall:
     def test_install(self, system_installation: Path):
         # GIVEN / WHEN / THEN

--- a/test/unit/test_font_detection.py
+++ b/test/unit/test_font_detection.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Cross-platform fonts
+CROSS_PLATFORM_FONTS = [
+    "ArialMT",
+    "TimesNewRomanPSMT",
+    "Calibri"
+]
+
+# macOS-specific fonts
+MACOS_FONTS = ["Helvetica"]
+
+# Get fonts for current platform
+COMMON_FONTS = CROSS_PLATFORM_FONTS + (MACOS_FONTS if platform.system() == "Darwin" else [])
+
+def get_font_script_path():
+    """Get path to get_user_fonts.py script"""
+    project_root = Path(__file__).parent.parent.parent
+    return project_root / "dist" / "DeadlineCloudSubmitter_Assets" / "JobTemplate" / "scripts" / "get_user_fonts.py"
+
+@pytest.mark.parametrize("postscript_name", COMMON_FONTS)
+def test_font_detection(postscript_name):
+    """Test that get_user_fonts.py can find common fonts by PostScript name"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path), postscript_name],
+        capture_output=True,
+        text=True
+    )
+
+    # Should either find font (exit 0) or not find it (exit 1)
+    # Just verify script runs without crashing
+    assert result.returncode in [0, 1], f"Script crashed for {postscript_name}: {result.stderr}"
+
+    if result.returncode == 0:
+        # If found, should output a file path
+        assert result.stdout.strip(), f"No output for found font {postscript_name}"
+
+def test_missing_font():
+    """Test that script exits with error for non-existent font"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path), "NonExistentFont123"],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 1
+    assert "FONT_NOT_FOUND" in result.stdout
+
+def test_script_no_args():
+    """Test that script exits with error when no font name provided"""
+    script_path = get_font_script_path()
+
+    result = subprocess.run(
+        ["/usr/bin/python3", str(script_path)],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 1
+    assert "Missing font name argument" in result.stdout

--- a/test/unit/test_font_detection.py
+++ b/test/unit/test_font_detection.py
@@ -8,33 +8,43 @@ from pathlib import Path
 import pytest
 
 # Cross-platform fonts
-CROSS_PLATFORM_FONTS = [
-    "ArialMT",
-    "TimesNewRomanPSMT",
-    "Calibri"
-]
+CROSS_PLATFORM_FONTS = ["ArialMT", "TimesNewRomanPSMT", "Calibri"]
 
 # macOS-specific fonts
 MACOS_FONTS = ["Helvetica"]
 
 # Get fonts for current platform
-COMMON_FONTS = CROSS_PLATFORM_FONTS + (MACOS_FONTS if platform.system() == "Darwin" else [])
+COMMON_FONTS = CROSS_PLATFORM_FONTS + (
+    MACOS_FONTS if platform.system() == "Darwin" else []
+)
+
 
 def get_python_executable():
     """Detect the correct Python executable alias"""
     for alias in ["python3", "python", "py"]:
         try:
-            result = subprocess.run([alias, "--version"], capture_output=True, text=True)
+            result = subprocess.run(
+                [alias, "--version"], capture_output=True, text=True
+            )
             if result.returncode == 0 and "Python 3" in result.stdout:
                 return alias
         except FileNotFoundError:
             continue
     return sys.executable  # Fallback to current Python
 
+
 def get_font_script_path():
     """Get path to get_user_fonts.py script"""
     project_root = Path(__file__).parent.parent.parent
-    return project_root / "dist" / "DeadlineCloudSubmitter_Assets" / "JobTemplate" / "scripts" / "get_user_fonts.py"
+    return (
+        project_root
+        / "dist"
+        / "DeadlineCloudSubmitter_Assets"
+        / "JobTemplate"
+        / "scripts"
+        / "get_user_fonts.py"
+    )
+
 
 @pytest.mark.parametrize("postscript_name", COMMON_FONTS)
 def test_font_detection(postscript_name):
@@ -43,18 +53,20 @@ def test_font_detection(postscript_name):
     python_exec = get_python_executable()
 
     result = subprocess.run(
-        [python_exec, str(script_path), postscript_name],
-        capture_output=True,
-        text=True
+        [python_exec, str(script_path), postscript_name], capture_output=True, text=True
     )
 
     # Should either find font (exit 0) or not find it (exit 1)
     # Just verify script runs without crashing
-    assert result.returncode in [0, 1], f"Script crashed for {postscript_name}: {result.stderr}"
+    assert result.returncode in [
+        0,
+        1,
+    ], f"Script crashed for {postscript_name}: {result.stderr}"
 
     if result.returncode == 0:
         # If found, should output a file path
         assert result.stdout.strip(), f"No output for found font {postscript_name}"
+
 
 def test_missing_font():
     """Test that script exits with error for non-existent font"""
@@ -64,11 +76,12 @@ def test_missing_font():
     result = subprocess.run(
         [python_exec, str(script_path), "NonExistentFont123"],
         capture_output=True,
-        text=True
+        text=True,
     )
 
     assert result.returncode == 1
     assert "FONT_NOT_FOUND" in result.stdout
+
 
 def test_script_no_args():
     """Test that script exits with error when no font name provided"""
@@ -76,9 +89,7 @@ def test_script_no_args():
     python_exec = get_python_executable()
 
     result = subprocess.run(
-        [python_exec, str(script_path)],
-        capture_output=True,
-        text=True
+        [python_exec, str(script_path)], capture_output=True, text=True
     )
 
     assert result.returncode == 1

--- a/test/unit/test_font_detection.py
+++ b/test/unit/test_font_detection.py
@@ -20,6 +20,17 @@ MACOS_FONTS = ["Helvetica"]
 # Get fonts for current platform
 COMMON_FONTS = CROSS_PLATFORM_FONTS + (MACOS_FONTS if platform.system() == "Darwin" else [])
 
+def get_python_executable():
+    """Detect the correct Python executable alias"""
+    for alias in ["python3", "python", "py"]:
+        try:
+            result = subprocess.run([alias, "--version"], capture_output=True, text=True)
+            if result.returncode == 0 and "Python 3" in result.stdout:
+                return alias
+        except FileNotFoundError:
+            continue
+    return sys.executable  # Fallback to current Python
+
 def get_font_script_path():
     """Get path to get_user_fonts.py script"""
     project_root = Path(__file__).parent.parent.parent
@@ -29,9 +40,10 @@ def get_font_script_path():
 def test_font_detection(postscript_name):
     """Test that get_user_fonts.py can find common fonts by PostScript name"""
     script_path = get_font_script_path()
+    python_exec = get_python_executable()
 
     result = subprocess.run(
-        ["/usr/bin/python3", str(script_path), postscript_name],
+        [python_exec, str(script_path), postscript_name],
         capture_output=True,
         text=True
     )
@@ -47,9 +59,10 @@ def test_font_detection(postscript_name):
 def test_missing_font():
     """Test that script exits with error for non-existent font"""
     script_path = get_font_script_path()
+    python_exec = get_python_executable()
 
     result = subprocess.run(
-        ["/usr/bin/python3", str(script_path), "NonExistentFont123"],
+        [python_exec, str(script_path), "NonExistentFont123"],
         capture_output=True,
         text=True
     )
@@ -60,9 +73,10 @@ def test_missing_font():
 def test_script_no_args():
     """Test that script exits with error when no font name provided"""
     script_path = get_font_script_path()
+    python_exec = get_python_executable()
 
     result = subprocess.run(
-        ["/usr/bin/python3", str(script_path)],
+        [python_exec, str(script_path)],
         capture_output=True,
         text=True
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There were a series of minor issues related to fonts:
- There was another location on macOS machines with font files in it that were not being searched in the `get_user_fonts.py` fallback search script, called `/System/Library/Fonts`
- If a customer was using a `.ttc` font in their composition and the fallback script was run, the fallback script wouldn't be able to identify the font file used in the composition and thus wouldn't be able to warn the artist about using an incompatible font.
- If a customer had `get_user_fonts.py` missing, they ran the risk of getting the popup that it was missing several times.
- We had no unit testing of our `get_user_fonts.py` fallback script.

### What was the solution? (How)
- Added the additional font folder location and improved fallback script to handle searching for .ttc files, and refactored asset file existence checks to happen on submit to allow the submitter to fail early.
- The diff is a bit larger because I ran `hatch run lint` to format all the Python files. 

### What is the impact of this change?
Better fallback mechanism.

### How was this change tested?
On macOS AE24.6 and AE 25.5, I attempted to submit a job on macOS and forced the fallback script to be run by doing a manual code change. I verified the script worked and was able to find the font Helvetica.ttc which it couldn't find before, and a warning correctly surfaced to me that Helvetica.ttc was not a supported file type. There's another font called TamilSangamMN that wasn't being identified before but now it's being identified properly.

Then I wrote unit tests which passed on macOS. However, I'm unable to run the unit tests on Windows at this time due to technical issues, still troubleshooting.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
No

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
