### PR TITLE
fix: fix fallback script regex to only strip leading and trailing whitespace instead of all whitespace

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1749,8 +1749,9 @@ function getLocationForFont(fontPostScriptName) {
         }
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
-        // Clean the output by removing all whitespace characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        // Clean the output by removing all leading and trailing whitespace and newline characters
+        var cleanOutput = outputRaw ? outputRaw.replace(/^\s+|\s+$/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1751,7 +1751,7 @@ function getLocationForFont(fontPostScriptName) {
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
 
         // Clean the output by removing all leading and trailing whitespace and newline characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/^\s+|\s+$/g, '') : null;
+        var cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1751,7 +1751,7 @@ function getLocationForFont(fontPostScriptName) {
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
 
         // Clean the output by removing all leading and trailing whitespace and newline characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
+        const cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -315,8 +315,9 @@ function getLocationForFont(fontPostScriptName) {
         }
         const scriptPath = scriptFolder + "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/get_user_fonts.py";
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
-        // Clean the output by removing all whitespace characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/\s+/g, '') : null;
+
+        // Clean the output by removing all leading and trailing whitespace and newline characters
+        var cleanOutput = outputRaw ? outputRaw.replace(/^\s+|\s+$/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -317,7 +317,7 @@ function getLocationForFont(fontPostScriptName) {
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
 
         // Clean the output by removing all leading and trailing whitespace and newline characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
+        const cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -317,7 +317,7 @@ function getLocationForFont(fontPostScriptName) {
         const outputRaw = system.callSystem(pythonExecutable + " \"" + scriptPath + "\" \"" + fontPostScriptName + "\"");
 
         // Clean the output by removing all leading and trailing whitespace and newline characters
-        var cleanOutput = outputRaw ? outputRaw.replace(/^\s+|\s+$/g, '') : null;
+        var cleanOutput = outputRaw ? outputRaw.replace(/(^\s+)|(\s+$)/g, '') : null;
 
         if (cleanOutput === "FONT_NOT_FOUND" || cleanOutput === "FONT_ERROR") {
             logger.error("Error when finding font, received code: " + cleanOutput + "\n", jobTemplateHelperFile);


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Fonts with whitespace in their filename were not being added as job attachments. This was because the regex for stripping whitespace was stripping ALL whitespace instead of only leading and trailing whitespace.

### What was the solution? (How)
Fixed the regex to only strip leading and trailing whitespace and newline characters.

### What is the impact of this change?
Fixes regression with the fallback font search script.

### How was this change tested?
Forced the fallback script to run by deleting the `font.location` approach from being used and verified the fallback script approach worked.

<img width="643" height="225" alt="Screenshot 2025-10-17 at 6 18 54 PM" src="https://github.com/user-attachments/assets/2feba1e9-8e6e-4f74-b7f8-d1c6bb914a53" />

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A

### Was this change documented?
No

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
