### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ We ask that you use these commit types in your commit titles:
 - `refactor` - When the pull request is implementing only a refactor of existing code;
 - `ci` - When the pull request is implementing a change to the CI infrastructure of the package;
 - `chore` - When the pull request is a generic maintenance task.
+- `perf` - When the pull request is a performance improvement.
 
 We also require that the type in your conventional commit title end in an exclamation point (e.g. `feat!` or `fix!`)
 if the pull request should be considered to be a breaking change in some way. Please also include a "BREAKING CHANGE" footer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no development/release workflow for communicating performance improvements.

### What was the solution? (How)

[Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standardizes the `perf: ...` commit type for this purpose.

This followed a previous work in aws-deadline/deadline-cloud#870:

1.  adds a section to the changelog template for performance improvements
2. adds `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release
3. adds developer-facing documentation for using the `perf:` commit type for performance improvements

### What is the impact of this change?

Developers can use `perf: ...` [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to communicate performance improvements when changelogs are automatically generated as part of the release

### How was this change tested?

1.  Set my local `mainline` branch to this commit
2. Added example commits using the `perf: ...` commit summary message
3. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
4.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly

>   ## 0.4.3 (2025-10-20)
>   
>   
>   ### Features
>   * Ignore Missing Dependencies (#212) ([`844fd24`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/844fd248a4f4c2a548bcd7cb55f1da6d378a1cd4))
>   
>   ### Bug Fixes
>   * fix fallback script regex to only strip leading and trailing whitespace instead of all whitespace (#261) ([`bc8787b`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/bc8787b0704b49d9dd20b38be820b15407fcbca2))
>   * fix fallback script regex to only strip leading and trailing whitespace instead of all whitespace ([`bc8787b`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/bc8787b0704b49d9dd20b38be820b15407fcbca2))
>   * improve get_user_fonts.py script and refactored file existence validation to minimize popups (#260) ([`01c66a9`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/01c66a99025b870bf94b1f844ab5a1cb59dc119e))
>   * bug fix for valid fonts not being collected (#259) ([`3623190`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/36231906a3b457a31ba42f7157b70ab8c990fe4e))
>   * aggregate font errors into single popup for submission (#257) ([`3f91674`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/3f91674345626a4385606c2273ea27f40cc804fe))
>   * sanitize parameter names to comply with open-jd specification (#254) ([`cfb6a4a`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/cfb6a4a62b01c674692a18953a1e6ab2a635035d))
>   * sanitize parameter names to comply with open-jd specification ([`cfb6a4a`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/cfb6a4a62b01c674692a18953a1e6ab2a635035d))
>   * update generatePrettyName as well to be consistent to replace special characters ([`cfb6a4a`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/cfb6a4a62b01c674692a18953a1e6ab2a635035d))
>   * moved font search logic to get_user_fonts.py to permanently prevent JSON size overflow issues that crashes After Effects (#252) ([`a259316`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/a25931609b8630fdcc355a2c531f36f95cb149d6))
>   * Only the first frame from an image sequence gets included in Job Attachments (#214) ([`646e1e5`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/646e1e55c72f38c076f5f7ba63ee4ba9932cb4c4))
>   
>   ### Performance Improvements
>   * test commit message ([`a874daa`](https://github.com/aws-deadline/deadline-cloud-for-after-effects/commit/a874daaf00144b34abd46f5cfa97179f3eb77b3f))

#### If you modified source files, did you run the Python script to update the files under the dist folder?

N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the 

N/A

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

N/A

### Was this change documented?

Yes. I added documentation for the `perf:` commit type to `CONTRIBUTING.md`.

### Is this a breaking change?

No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
