### PR TITLE
feat: script based ae submitter installation for macOS to user preferences directory

### DIFF
--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -27,16 +27,8 @@
                     </distributionFileList>
                     <actionList>
                         <!-- Make shell scripts executable on macOS -->
-                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_installer_helper.sh">
-                            <ruleList>
-                                <platformTest type="osx"/>
-                            </ruleList>
-                        </changePermissions>
-                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_uninstaller_helper.sh">
-                            <ruleList>
-                                <platformTest type="osx"/>
-                            </ruleList>
-                        </changePermissions>
+                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_installer_helper.sh" />
+                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_uninstaller_helper.sh" />
                     </actionList>
                 </folder>
             </folderList>
@@ -74,13 +66,20 @@
                                 </distributionDirectory>
                             </distributionFileList>
                             <actionList>
-                                <!-- Set macOS After Effects preferences path -->
-                                <setInstallerVariable name="ae_prefs_path" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects" />
+                                <!-- Set platform-specific After Effects preferences path -->
+                                <!-- macOS: User Library/Preferences directory -->
+                                <setInstallerVariable name="ae_prefs_path" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects">
+                                    <ruleList>
+                                        <platformTest type="osx"/>
+                                    </ruleList>
+                                </setInstallerVariable>
+                                <!-- Windows: Future implementation will set Windows-specific path here -->
+                                <!-- TODO: Add Windows path when Windows support is implemented -->
                                 
                                 <!-- Use shell script on macOS -->
                                 <setInstallerVariableFromScriptOutput>
                                     <exec>${installdir}/scripts/ae_installer_helper.sh</exec>
-                                    <execArgs>--installation_scope "user" --major_version "24" --submitter_src_path "${after_effects_script_ui_directory_2024}" --ae_path_for_user "${ae_prefs_path}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
+                                    <execArgs>--major_version "24" --submitter_src_path "${after_effects_script_ui_directory_2024}" --ae_path_for_user "${ae_prefs_path}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
                                     <name>output_variable_2024</name>
                                     <abortOnError>1</abortOnError>
                                     <showMessageOnError>1</showMessageOnError>
@@ -125,13 +124,20 @@
                                 </distributionDirectory>
                             </distributionFileList>
                             <actionList>
-                                <!-- Set macOS After Effects preferences path -->
-                                <setInstallerVariable name="ae_prefs_path_2025" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects" />
+                                <!-- Set platform-specific After Effects preferences path -->
+                                <!-- macOS: User Library/Preferences directory -->
+                                <setInstallerVariable name="ae_prefs_path_2025" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects">
+                                    <ruleList>
+                                        <platformTest type="osx"/>
+                                    </ruleList>
+                                </setInstallerVariable>
+                                <!-- Windows: Future implementation will set Windows-specific path here -->
+                                <!-- TODO: Add Windows path when Windows support is implemented -->
                                 
                                 <!-- Use shell script on macOS -->
                                 <setInstallerVariableFromScriptOutput>
                                     <exec>${installdir}/scripts/ae_installer_helper.sh</exec>
-                                    <execArgs>--installation_scope "user" --major_version "25" --submitter_src_path "${after_effects_script_ui_directory_2025}" --ae_path_for_user "${ae_prefs_path_2025}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
+                                    <execArgs>--major_version "25" --submitter_src_path "${after_effects_script_ui_directory_2025}" --ae_path_for_user "${ae_prefs_path_2025}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
                                     <name>script_output_message_2025</name>
                                     <abortOnError>1</abortOnError>
                                     <showMessageOnError>1</showMessageOnError>
@@ -165,6 +171,8 @@
             </elseActionList>
         </if>
 
+        <!-- Platform-specific documentation explanations -->
+        <!-- macOS: Automated installation with option to ignore failures -->
         <setInstallerVariable>
             <name>setup_documentation_explanation</name>
             <value>This installer installs the Deadline Cloud After Effects submitter in two locations: the "${installdir}/Submitters/AfterEffects/" directory and AE user preferences as "DeadlineCloudSubmitter(User).jsx".
@@ -175,6 +183,7 @@
             </value>
             <ruleList><platformTest type="osx"/></ruleList>
         </setInstallerVariable>
+        <!-- Windows: Manual installation required -->
         <setInstallerVariable>
             <name>setup_documentation_explanation</name>
             <value>This installer installs the Deadline Cloud After Effects submitter in the "${installdir}/Submitters/AfterEffects/" as DeadlineCloudSubmitter.jsx and DeadlineCloudSubmitter_Assets

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -208,8 +208,8 @@
 
             - For more information on using the Deadline submitter for After Effects with the user install approach, visit our README on Github: https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/README.md
             </explanation>
-            <value>0</value>
-            <default>0</default>
+            <value>1</value>
+            <default>1</default>
             <ask>no</ask>
             <ruleList>
                 <platformTest type="osx"/>

--- a/install_builder/deadline-cloud-for-after-effects.xml
+++ b/install_builder/deadline-cloud-for-after-effects.xml
@@ -8,158 +8,143 @@
     <selected>0</selected>
     <show>1</show>
     <componentList>
-        <component>
-            <name>ae_2024</name>
-            <description>After Effects 2024</description>
-            <selected>0</selected>
-             <parameterList>
-                <!-- Script UI directory parameter for After Effects 2024 -->
-                <directoryParameter value="">
-                    <name>after_effects_script_ui_directory_2024</name>
-                    <description>After Effects 2024 Script UI Directory</description>
-                    <explanation>Path to the script UI directory in After Effects 2024 resources.</explanation>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <ask>yes</ask>
-                    <!-- Set default paths right before this parameter page is shown in order to set default path values based on user input -->
-                    <preShowPageActionList>
-                        <if>
-                            <conditionRuleList>
-                                <platformTest type="osx"/>
-                            </conditionRuleList>
-                            <actionList>
-                                <!-- For macOS, default to user install approach regardless of installscope until we support system installs -->
-                                <setInstallerVariable>
-                                    <name>after_effects_script_ui_directory_2024</name>
-                                    <value>${installdir}/AE2024</value>
-                                </setInstallerVariable>
-                            </actionList>
-                            <elseActionList>
-                                <!-- For Windows, handle install path based on install scope -->
-                                <if>
-                                    <conditionRuleList>
-                                        <compareText logic="equals" text="${installscope}" value="user"/>
-                                    </conditionRuleList>
-                                    <actionList>
-                                        <!-- For Windows user installation -->
-                                        <setInstallerVariable>
-                                            <name>after_effects_script_ui_directory_2024</name>
-                                            <value>${installdir}/AE2024</value>
-                                        </setInstallerVariable>
-                                    </actionList>
-                                    <elseActionList>
-                                        <!-- For Windows system installation -->
-                                        <!-- Check if the directory exists for system installs before setting install path as default -->
-                                        <if>
-                                            <conditionRuleList>
-                                                <fileExists>
-                                                    <path>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</path>
-                                                </fileExists>
-                                            </conditionRuleList>
-                                            <actionList>
-                                                <setInstallerVariable>
-                                                    <name>after_effects_script_ui_directory_2024</name>
-                                                    <value>C:\Program Files\Adobe\Adobe After Effects 2024\Support Files\Scripts\ScriptUI Panels</value>
-                                                </setInstallerVariable>
-                                            </actionList>
-                                        </if>
-                                    </elseActionList>
-                                </if>
-                            </elseActionList>
-                        </if>
-                    </preShowPageActionList>
-                </directoryParameter>
-            </parameterList>
+        <componentGroup>
+            <name>after_effects_versions</name>
+            <description>Shared files for all After Effects versions</description>
             <folderList>
-                <!-- After Effects 2024 Submitter folder location -->
                 <folder>
-                    <description>After Effects 2024 Script UI Folder</description>
-                    <destination>${after_effects_script_ui_directory_2024}</destination>
-                    <name>aftereffects2024scriptuifolder</name>
-                    <platforms>all</platforms>
+                    <description>Shell Scripts</description>
+                    <destination>${installdir}/scripts</destination>
+                    <name>shellscriptsfolder</name>
+                    <platforms>osx</platforms>
                     <distributionFileList>
-                        <distributionDirectory allowWildcards="1">
-                            <origin>../dist/*</origin>
-                        </distributionDirectory>
+                        <distributionFile>
+                            <origin>../scripts/ae_installer_helper.sh</origin>
+                        </distributionFile>
+                        <distributionFile>
+                            <origin>../scripts/ae_uninstaller_helper.sh</origin>
+                        </distributionFile>
                     </distributionFileList>
+                    <actionList>
+                        <!-- Make shell scripts executable on macOS -->
+                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_installer_helper.sh">
+                            <ruleList>
+                                <platformTest type="osx"/>
+                            </ruleList>
+                        </changePermissions>
+                        <changePermissions permissions="0755" files="${installdir}/scripts/ae_uninstaller_helper.sh">
+                            <ruleList>
+                                <platformTest type="osx"/>
+                            </ruleList>
+                        </changePermissions>
+                    </actionList>
                 </folder>
             </folderList>
-        </component>
-        <component>
-            <name>ae_2025</name>
-            <description>After Effects 2025</description>
-            <selected>0</selected>
-            <parameterList>
-                <!-- Script UI directory parameter for After Effects 2025 -->
-                <directoryParameter value="">
-                    <name>after_effects_script_ui_directory_2025</name>
-                    <description>After Effects 2025 Script UI Directory</description>
-                    <explanation>Path to the script UI directory in After Effects 2025 resources.</explanation>
-                    <allowEmptyValue>1</allowEmptyValue>
-                    <ask>yes</ask>
-                    <!-- Set default paths right before this page is shown -->
-                    <preShowPageActionList>
-                        <if>
-                            <conditionRuleList>
+            <componentList>
+                <component>
+                    <name>ae_2024</name>
+                    <description>After Effects 2024</description>
+                    <selected>0</selected>
+                    <parameterList>
+                        <!-- Script UI directory parameter for After Effects 2024 -->
+                        <directoryParameter value="">
+                            <name>after_effects_script_ui_directory_2024</name>
+                            <description>After Effects 2024 Script UI Directory</description>
+                            <explanation>Path to the script UI directory in After Effects 2024 resources.</explanation>
+                            <allowEmptyValue>1</allowEmptyValue>
+                            <ask>yes</ask>
+                            <ruleList>
                                 <platformTest type="osx"/>
-                            </conditionRuleList>
+                            </ruleList>
+                        </directoryParameter>
+                    </parameterList>
+                    <folderList>
+                        <!-- After Effects 2024 Submitter folder location -->
+                        <folder>
+                            <description>After Effects 2024 Script UI Folder</description>
+                            <destination>${after_effects_script_ui_directory_2024}</destination>
+                            <name>aftereffects2024scriptuifolder</name>
+                            <platforms>all</platforms>
+                            <distributionFileList>
+                                <distributionFile>
+                                    <origin>../dist/DeadlineCloudSubmitter.jsx</origin>
+                                </distributionFile>
+                                <distributionDirectory>
+                                    <origin>../dist/DeadlineCloudSubmitter_Assets</origin>
+                                </distributionDirectory>
+                            </distributionFileList>
                             <actionList>
-                                <!-- For macOS, always use user install approach regardless of installscope until we support system installs -->
-                                <setInstallerVariable>
-                                    <name>after_effects_script_ui_directory_2025</name>
-                                    <value>${installdir}/AE2025</value>
-                                </setInstallerVariable>
+                                <!-- Set macOS After Effects preferences path -->
+                                <setInstallerVariable name="ae_prefs_path" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects" />
+                                
+                                <!-- Use shell script on macOS -->
+                                <setInstallerVariableFromScriptOutput>
+                                    <exec>${installdir}/scripts/ae_installer_helper.sh</exec>
+                                    <execArgs>--installation_scope "user" --major_version "24" --submitter_src_path "${after_effects_script_ui_directory_2024}" --ae_path_for_user "${ae_prefs_path}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
+                                    <name>output_variable_2024</name>
+                                    <abortOnError>1</abortOnError>
+                                    <showMessageOnError>1</showMessageOnError>
+                                    <ruleList>
+                                        <platformTest type="osx"/>
+                                    </ruleList>
+                                </setInstallerVariableFromScriptOutput>
                             </actionList>
-                            <elseActionList>
-                                <!-- For Windows, handle based on installscope -->
-                                <if>
-                                    <conditionRuleList>
-                                        <compareText logic="equals" text="${installscope}" value="user"/>
-                                    </conditionRuleList>
-                                    <actionList>
-                                        <!-- For Windows user installation -->
-                                        <setInstallerVariable>
-                                            <name>after_effects_script_ui_directory_2025</name>
-                                            <value>${installdir}/AE2025</value>
-                                        </setInstallerVariable>
-                                    </actionList>
-                                    <elseActionList>
-                                        <!-- For Windows system installation -->
-                                        <!-- Check if the directory exists for system installs before setting install path as default -->
-                                        <if>
-                                            <conditionRuleList>
-                                                <fileExists>
-                                                    <path>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</path>
-                                                </fileExists>
-                                            </conditionRuleList>
-                                            <actionList>
-                                                <setInstallerVariable>
-                                                    <name>after_effects_script_ui_directory_2025</name>
-                                                    <value>C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Scripts\ScriptUI Panels</value>
-                                                </setInstallerVariable>
-                                            </actionList>
-                                        </if>
-                                    </elseActionList>
-                                </if>
-                            </elseActionList>
-                        </if>
-                    </preShowPageActionList>
-                </directoryParameter>
-            </parameterList>
-            <folderList>
-                <!-- After Effects 2025 Submitter folder location -->
-                <folder>
-                    <description>After Effects 2025 Script UI Folder</description>
-                    <destination>${after_effects_script_ui_directory_2025}</destination>
-                    <name>aftereffects2025scriptuifolder</name>
-                    <platforms>all</platforms>
-                    <distributionFileList>
-                        <distributionDirectory allowWildcards="1">
-                            <origin>../dist/*</origin>
-                        </distributionDirectory>
-                    </distributionFileList>
-                </folder>
-            </folderList>
-        </component>
+                        </folder>
+                    </folderList>
+                </component>
+                <component>
+                    <name>ae_2025</name>
+                    <description>After Effects 2025</description>
+                    <selected>0</selected>
+                    <parameterList>
+                        <!-- Script UI directory parameter for After Effects 2025 -->
+                        <directoryParameter value="">
+                            <name>after_effects_script_ui_directory_2025</name>
+                            <description>After Effects 2025 Script UI Directory</description>
+                            <explanation>Path to the script UI directory in After Effects 2025 resources.</explanation>
+                            <allowEmptyValue>1</allowEmptyValue>
+                            <ask>yes</ask>
+                            <ruleList>
+                                <platformTest type="osx"/>
+                            </ruleList>
+                        </directoryParameter>
+                    </parameterList>
+                    <folderList>
+                        <!-- After Effects 2025 Submitter folder location -->
+                        <folder>
+                            <description>After Effects 2025 Script UI Folder</description>
+                            <destination>${after_effects_script_ui_directory_2025}</destination>
+                            <name>aftereffects2025scriptuifolder</name>
+                            <platforms>all</platforms>
+                            <distributionFileList>
+                                <distributionFile>
+                                    <origin>../dist/DeadlineCloudSubmitter.jsx</origin>
+                                </distributionFile>
+                                <distributionDirectory>
+                                    <origin>../dist/DeadlineCloudSubmitter_Assets</origin>
+                                </distributionDirectory>
+                            </distributionFileList>
+                            <actionList>
+                                <!-- Set macOS After Effects preferences path -->
+                                <setInstallerVariable name="ae_prefs_path_2025" value="/Users/${system_username}/Library/Preferences/Adobe/After Effects" />
+                                
+                                <!-- Use shell script on macOS -->
+                                <setInstallerVariableFromScriptOutput>
+                                    <exec>${installdir}/scripts/ae_installer_helper.sh</exec>
+                                    <execArgs>--installation_scope "user" --major_version "25" --submitter_src_path "${after_effects_script_ui_directory_2025}" --ae_path_for_user "${ae_prefs_path_2025}" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</execArgs>
+                                    <name>script_output_message_2025</name>
+                                    <abortOnError>1</abortOnError>
+                                    <showMessageOnError>1</showMessageOnError>
+                                    <ruleList>
+                                        <platformTest type="osx"/>
+                                    </ruleList>
+                                </setInstallerVariableFromScriptOutput>
+                            </actionList>
+                        </folder>
+                    </folderList>
+                </component>
+            </componentList>
+        </componentGroup>
     </componentList>
     <initializationActionList>
         <!-- Non-Linux OS validation -->
@@ -179,6 +164,27 @@
                 <setInstallerVariable name="component(deadline_cloud_for_after_effects).show" value="0" />
             </elseActionList>
         </if>
+
+        <setInstallerVariable>
+            <name>setup_documentation_explanation</name>
+            <value>This installer installs the Deadline Cloud After Effects submitter in two locations: the "${installdir}/Submitters/AfterEffects/" directory and AE user preferences as "DeadlineCloudSubmitter(User).jsx".
+
+- On the next screen, you can choose to ignore script installation failures in the AE user preference location.
+
+- For more information on using the Deadline submitter for After Effects with the user install approach, visit our documentation on GitHub using the link below.
+            </value>
+            <ruleList><platformTest type="osx"/></ruleList>
+        </setInstallerVariable>
+        <setInstallerVariable>
+            <name>setup_documentation_explanation</name>
+            <value>This installer installs the Deadline Cloud After Effects submitter in the "${installdir}/Submitters/AfterEffects/" as DeadlineCloudSubmitter.jsx and DeadlineCloudSubmitter_Assets
+
+            - Please copy them to After Effects Scripts directory in Program Files or AE user preferences directory
+
+            - For more information on using the Deadline submitter for After Effects with the user install approach, visit our documentation on GitHub using the link below.
+            </value>
+            <ruleList><platformTest type="windows"/></ruleList>
+        </setInstallerVariable>
     </initializationActionList>
     <parameterList>
         <stringParameter name="deadline_cloud_for_after_effects_summary" ask="0" cliOptionShow="0">
@@ -186,7 +192,51 @@
 - Compatible with Adobe After Effects 2024-2025
 - Registers the plug-in with After Effects by moving the script to the After Effects ScriptUI Panel directory.</value>
         </stringParameter>
+        <linkParameter>
+            <name>SetupDocumentation</name>
+            <description>Setup Documentation</description>
+            <explanation>${setup_documentation_explanation}</explanation>
+            <clickedActionList><launchBrowser url="https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/README.md" />
+            </clickedActionList>
+        </linkParameter>
+        
+        <!-- macOS-only ignore errors parameter -->
+        <booleanParameter>
+            <name>ignore_submitter_user_install_errors</name>
+            <description>Ignore errors during submitter installation in user scope in AE application</description>
+            <explanation>This installer installs Deadline Cloud After Effects submitter in two locations: "${installdir}/Submitters/AfterEffects/" directory and AE user preferences as "DeadlineCloudSubmitter(User).jsx"
+
+            - For more information on using the Deadline submitter for After Effects with the user install approach, visit our README on Github: https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/README.md
+            </explanation>
+            <value>0</value>
+            <default>0</default>
+            <ask>no</ask>
+            <ruleList>
+                <platformTest type="osx"/>
+            </ruleList>
+        </booleanParameter>
     </parameterList>
+    <preUninstallationActionList>
+        <!-- Remove After Effects 2024 files using shell script on macOS -->
+        <runProgram>
+            <program>${installdir}/scripts/ae_uninstaller_helper.sh</program>
+            <programArguments>--ae_path_for_user "/Users/${system_username}/Library/Preferences/Adobe/After Effects" --major_version "24" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</programArguments>
+            <ruleList>
+                <platformTest type="osx"/>
+                <componentTest name="ae_2024" logic="selected"/>
+            </ruleList>
+        </runProgram>
+        
+        <!-- Remove After Effects 2025 files using shell script on macOS -->
+        <runProgram>
+            <program>${installdir}/scripts/ae_uninstaller_helper.sh</program>
+            <programArguments>--ae_path_for_user "/Users/${system_username}/Library/Preferences/Adobe/After Effects" --major_version "25" --ignore_minor_version_errors ${ignore_submitter_user_install_errors}</programArguments>
+            <ruleList>
+                <platformTest type="osx"/>
+                <componentTest name="ae_2025" logic="selected"/>
+            </ruleList>
+        </runProgram>
+    </preUninstallationActionList>
     <shouldPackRuleList>
         <compareText>
             <logic>does_not_contain</logic>

--- a/scripts/ae_installer_helper.sh
+++ b/scripts/ae_installer_helper.sh
@@ -1,10 +1,41 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# After Effects Submitter User Install Helper - Shell Script Version
-# This script installs the Deadline Cloud submitter to After Effects without requiring Python
+# After Effects Submitter User Install Helper for MacOS - Shell Script Version
+#
+# SCRIPT PURPOSE:
+# This macOS-specific script installs Deadline Cloud submitter files to user-specific
+# After Effects preferences directory. Only user-scope installation is supported on macOS.
+#
+# USAGE EXAMPLES:
+#
+# Basic installation to After Effects 2024 (version 24):
+#   ./ae_installer_helper.sh \
+#     --ae_path_for_user "/Users/username/Library/Preferences/Adobe/After Effects" \
+#     --major_version 24 \
+#     --submitter_src_path "/Users/username/DeadlineCloudSubmitter/After Effects/AE2025"
+#
+# Installation with error tolerance (useful in enterprise environments):
+#   ./ae_installer_helper.sh \
+#     --ae_path_for_user "/Users/username/Library/Preferences/Adobe/After Effects" \
+#     --major_version 25 \
+#     --submitter_src_path "/Users/username/DeadlineCloudSubmitter/After Effects/AE2025" \
+#     --ignore_minor_version_errors 1
+#
+# Show help:
+#   ./ae_installer_helper.sh --help
+#
+# SCRIPT PURPOSE:
+# - Installs Deadline Cloud submitter files to user-specific After Effects preferences
+# - Handles multiple After Effects versions (e.g., 24.0, 24.1, 24.2) within a major version
+# - Provides error handling with optional ignore flags for enterprise environments
+# - Creates necessary directory structure and sets appropriate permissions
+#
+# ERROR HANDLING STRATEGY:
+# - Uses IGNORE_MINOR_VERSION_ERRORS flag to allow graceful degradation in restricted environments
+# - Continues processing remaining versions even if some fail (when ignore flag is set)
+# - Provides detailed error messages for troubleshooting installation issues
 
 # Default values
-INSTALLATION_SCOPE=""
 AE_PATH_FOR_USER=""
 MAJOR_VERSION=""
 SUBMITTER_SRC_PATH=""
@@ -12,12 +43,11 @@ IGNORE_MINOR_VERSION_ERRORS=0
 
 # Function to show usage
 show_usage() {
-    echo "Usage: $0 --installation_scope SCOPE --ae_path_for_user PATH --major_version VERSION --submitter_src_path PATH [--ignore_minor_version_errors 0|1]"
+    echo "Usage: $0 --ae_path_for_user PATH --major_version VERSION --submitter_src_path PATH [--ignore_minor_version_errors 0|1]"
     echo ""
-    echo "Install Deadline Cloud submitter to After Effects"
+    echo "Install Deadline Cloud submitter to After Effects (macOS user-scope only)"
     echo ""
     echo "Options:"
-    echo "  --installation_scope SCOPE        Installation scope (must be 'user' to perform operations)"
     echo "  --ae_path_for_user PATH           Path to the After Effects preferences directory"
     echo "  --major_version VERSION           After Effects major version to install to (e.g., '24', '25')"
     echo "  --submitter_src_path PATH         Directory containing Deadline Cloud submitter files"
@@ -26,13 +56,12 @@ show_usage() {
     return 0
 }
 
-# Parse command line arguments
+# COMMAND LINE ARGUMENT PARSING:
+# Process all command line arguments using a while loop with case statement
+# Each argument requires a value (shift 2 moves past both flag and value)
+# Unknown arguments trigger error with usage display for user guidance
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --installation_scope)
-            INSTALLATION_SCOPE="$2"
-            shift 2
-            ;;
         --ae_path_for_user)
             AE_PATH_FOR_USER="$2"
             shift 2
@@ -54,6 +83,7 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         *)
+            # ERROR RECOVERY: Unknown arguments display usage and exit with error code
             echo "Error: Unknown option $1" >&2
             show_usage >&2
             exit 1
@@ -61,13 +91,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Function to handle errors based on ignore flag
+# ERROR HANDLING FUNCTION:
+# Provides centralized error handling with conditional behavior based on ignore flag
+# RECOVERY STRATEGY: In enterprise environments with restricted access, allows installation
+# to continue with warnings instead of failing completely
+# PARAMETERS: error_msg - descriptive error message for logging and user feedback
 handle_error() {
     local error_msg="$1"
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        # GRACEFUL DEGRADATION: Log warning but continue execution
         echo "Warning: $error_msg (ignored due to ignore_minor_version_errors flag)" >&2
         return 0
     else
+        # FAIL-FAST: Log error and exit immediately for strict validation
         echo "Error: $error_msg" >&2
         exit 1
     fi
@@ -82,13 +118,8 @@ exit_success() {
 }
 
 # Validate required arguments
-if [[ -z "$INSTALLATION_SCOPE" || -z "$AE_PATH_FOR_USER" || -z "$MAJOR_VERSION" || -z "$SUBMITTER_SRC_PATH" ]]; then
+if [[ -z "$AE_PATH_FOR_USER" || -z "$MAJOR_VERSION" || -z "$SUBMITTER_SRC_PATH" ]]; then
     handle_error "Missing required arguments"
-fi
-
-# Only proceed if installation scope is "user"
-if [[ "$INSTALLATION_SCOPE" != "user" ]]; then
-    exit_success ""
 fi
 
 echo "Installing Deadline Cloud submitter to After Effects $MAJOR_VERSION..." >&2
@@ -108,14 +139,19 @@ if [[ ! -d "$AE_PATH_FOR_USER" ]]; then
     handle_error "After Effects preferences directory not found: $AE_PATH_FOR_USER"
 fi
 
-# Find version directories matching the major version
+# VERSION DIRECTORY DISCOVERY:
+# Find all After Effects version directories that match the specified major version
+# ITERATION LOGIC: Uses find with null-terminated output to handle directory names with spaces
+# PATTERN MATCHING: Regex ^${MAJOR_VERSION}\. matches directories like "24.0", "24.1", "24.2" for major version "24"
+# EXPECTED OUTCOME: VERSION_DIRS array contains all matching minor version directories for installation
 VERSION_DIRS=()
 while IFS= read -r -d '' dir; do
-    basename_dir=$(basename "$dir")
+    basename_dir=$(basename "$dir")  # Extract directory name from full path
     if [[ "$basename_dir" =~ ^${MAJOR_VERSION}\. ]]; then
-        VERSION_DIRS+=("$basename_dir")
+        VERSION_DIRS+=("$basename_dir")  # Add matching version to array
     fi
 done < <(find "$AE_PATH_FOR_USER" -maxdepth 1 -type d -print0 2>/dev/null)
+# NOTE: Process substitution with null-terminated strings prevents issues with spaces in directory names
 
 if [[ ${#VERSION_DIRS[@]} -eq 0 ]]; then
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
@@ -128,137 +164,163 @@ fi
 # Sort version directories
 IFS=$'\n' VERSION_DIRS=($(sort <<<"${VERSION_DIRS[*]}"))
 
-# Install to each version directory
-COPIED_TO=()
-FAILED_COPIES=()
+# MULTI-VERSION INSTALLATION LOOP:
+# Install submitter files to each discovered After Effects version directory
+# ITERATION STRATEGY: Process each version independently to maximize success rate
+# ERROR TRACKING: Maintain separate arrays for successful and failed installations
+COPIED_TO=()      # Track successful installation paths for reporting
+FAILED_COPIES=()  # Track failed installations with detailed error messages
 
 for version_dir in "${VERSION_DIRS[@]}"; do
+    # DIRECTORY PATH CONSTRUCTION: Build full path to ScriptUI Panels directory
     ae_version_path="$AE_PATH_FOR_USER/$version_dir"
     scripts_path="$ae_version_path/Scripts"
     scriptui_panels_path="$scripts_path/ScriptUI Panels"
     
-    # Create directory structure if it doesn't exist
+    # FILESYSTEM OPERATION: Create directory structure if it doesn't exist
+    # RECOVERY ACTION: If directory creation fails, log error and continue to next version (when ignore flag set)
     if ! mkdir -p "$scriptui_panels_path" 2>/dev/null; then
         error_msg="Failed to create ScriptUI Panels directory: $scriptui_panels_path"
         if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
             FAILED_COPIES+=("After Effects $version_dir: $error_msg")
             echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
-            continue
+            continue  # Skip to next version directory
         else
-            handle_error "$error_msg"
+            handle_error "$error_msg"  # Exit immediately if strict validation enabled
         fi
     fi
     
-    # Check write permissions
+    # PERMISSION VALIDATION: Verify write access to target directory
+    # ENTERPRISE SCENARIO: Network-mounted home directories may have restricted permissions
     if [[ ! -w "$scriptui_panels_path" ]]; then
         error_msg="No write permission to ScriptUI Panels directory: $scriptui_panels_path"
         if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
             FAILED_COPIES+=("After Effects $version_dir: $error_msg")
             echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
-            continue
+            continue  # Skip to next version directory
         else
-            handle_error "$error_msg"
+            handle_error "$error_msg"  # Exit immediately if strict validation enabled
         fi
     fi
     
-    # Copy files from source to destination
-    files_copied=0
-    copy_failed=false
+    # FILE COPY OPERATION LOOP:
+    # Copy all submitter files from source directory to target ScriptUI Panels directory
+    # ITERATION LOGIC: Process each file/directory in source path independently
+    # EXPECTED OUTCOME: All source files copied to destination with appropriate renaming
+    files_copied=0    # Counter for successful file operations
+    copy_failed=false # Flag to track if any copy operation failed in this version
     
     for item in "$SUBMITTER_SRC_PATH"/*; do
+        # VALIDATION CHECK: Skip if glob pattern doesn't match any files
         if [[ ! -e "$item" ]]; then
-            continue  # Skip if no files match
+            continue  # No files found matching pattern, continue to next iteration
         fi
         
-        item_name=$(basename "$item")
+        item_name=$(basename "$item")  # Extract filename from full path
         
-        # Rename DeadlineCloudSubmitter.jsx to DeadlineCloudSubmitter(User).jsx
+        # SPECIAL HANDLING: Rename main submitter file for user installation
+        # PURPOSE: Distinguish user installation from system installation in After Effects UI
         if [[ "$item_name" == "DeadlineCloudSubmitter.jsx" ]]; then
             dst_item_name="DeadlineCloudSubmitter(User).jsx"
             echo "Renaming $item_name to $dst_item_name for user installation" >&2
         else
-            dst_item_name="$item_name"
+            dst_item_name="$item_name"  # Keep original name for other files
         fi
         
         dst_item_path="$scriptui_panels_path/$dst_item_name"
         
+        # FILE COPY OPERATION: Handle regular files
         if [[ -f "$item" ]]; then
-            # Remove read-only attribute if destination exists
+            # PERMISSION PREPARATION: Remove read-only attribute from existing destination file
+            # RECOVERY ACTION: Allows overwriting protected files from previous installations
             if [[ -f "$dst_item_path" ]]; then
-                chmod u+w "$dst_item_path" 2>/dev/null || true
+                chmod u+w "$dst_item_path" 2>/dev/null || true  # Ignore chmod failures
             fi
             
+            # FILESYSTEM OPERATION: Copy file with error handling
             if cp "$item" "$dst_item_path" 2>/dev/null; then
-                ((files_copied++))
+                ((files_copied++))  # Increment success counter
                 echo "Installed $dst_item_name to After Effects $version_dir" >&2
             else
+                # ERROR SCENARIO: File copy failed (permissions, disk space, etc.)
                 error_msg="Failed to copy $item_name to After Effects $version_dir"
                 if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
                     FAILED_COPIES+=("After Effects $version_dir: $error_msg")
                     echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
                     copy_failed=true
-                    break
+                    break  # Stop processing files for this version, move to next version
                 else
-                    handle_error "$error_msg"
+                    handle_error "$error_msg"  # Exit immediately if strict validation
                 fi
             fi
+        # DIRECTORY COPY OPERATION: Handle subdirectories recursively
         elif [[ -d "$item" ]]; then
-            # Remove existing directory if it exists
+            # CLEANUP OPERATION: Remove existing directory to ensure clean installation
             if [[ -d "$dst_item_path" ]]; then
-                rm -rf "$dst_item_path" 2>/dev/null || true
+                rm -rf "$dst_item_path" 2>/dev/null || true  # Ignore removal failures
             fi
             
+            # FILESYSTEM OPERATION: Recursive directory copy with error handling
             if cp -r "$item" "$dst_item_path" 2>/dev/null; then
-                ((files_copied++))
+                ((files_copied++))  # Increment success counter
                 echo "Installed directory $item_name to After Effects $version_dir" >&2
             else
+                # ERROR SCENARIO: Directory copy failed (permissions, disk space, etc.)
                 error_msg="Failed to copy directory $item_name to After Effects $version_dir"
                 if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
                     FAILED_COPIES+=("After Effects $version_dir: $error_msg")
                     echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
                     copy_failed=true
-                    break
+                    break  # Stop processing files for this version, move to next version
                 else
-                    handle_error "$error_msg"
+                    handle_error "$error_msg"  # Exit immediately if strict validation
                 fi
             fi
         fi
     done
     
+    # POST-COPY VALIDATION: Check results of file copy operations for this version
     if [[ "$copy_failed" == "true" ]]; then
-        continue
+        continue  # Skip to next version if any copy operation failed
     fi
     
+    # SUCCESS TRACKING: Record successful installations for final reporting
     if [[ $files_copied -eq 0 ]]; then
         echo "Warning: No files were copied to After Effects $version_dir" >&2
     else
-        COPIED_TO+=("$scriptui_panels_path")
+        COPIED_TO+=("$scriptui_panels_path")  # Add to successful installations list
     fi
-done
+done  # End of version directory processing loop
 
-# Report results
+# INSTALLATION RESULTS ANALYSIS:
+# Evaluate overall success/failure status and provide appropriate user feedback
+# ERROR SCENARIOS: Handle complete failure, partial failure, and success cases differently
+
 if [[ ${#FAILED_COPIES[@]} -gt 0 && ${#COPIED_TO[@]} -eq 0 ]]; then
-    # All copies failed
+    # COMPLETE FAILURE SCENARIO: All installation attempts failed
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        # GRACEFUL DEGRADATION: Report failure but continue with warning status
         echo "Warning: All After Effects $MAJOR_VERSION versions failed to install, but continuing due to ignore_minor_version_errors flag" >&2
         for error in "${FAILED_COPIES[@]}"; do
-            echo "  $error" >&2
+            echo "  $error" >&2  # List all specific failure reasons
         done
         exit_success "After Effects $MAJOR_VERSION installation completed with errors (ignored)"
     else
+        # FAIL-FAST: Report failure and exit with error code
         echo "Error: Failed to install to any After Effects versions" >&2
         for error in "${FAILED_COPIES[@]}"; do
-            echo "  $error" >&2
+            echo "  $error" >&2  # List all specific failure reasons
         done
         exit 1
     fi
 elif [[ ${#FAILED_COPIES[@]} -gt 0 ]]; then
-    # Some copies failed, but some succeeded
+    # PARTIAL FAILURE SCENARIO: Some installations succeeded, some failed
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
         echo "Warning: Installation failed for some versions (ignored due to ignore_minor_version_errors flag)" >&2
     else
         echo "Warning: Installation failed for some versions" >&2
     fi
+    # DETAILED ERROR REPORTING: List specific failures for troubleshooting
     for error in "${FAILED_COPIES[@]}"; do
         echo "  $error" >&2
     done

--- a/scripts/ae_installer_helper.sh
+++ b/scripts/ae_installer_helper.sh
@@ -23,6 +23,7 @@ show_usage() {
     echo "  --submitter_src_path PATH         Directory containing Deadline Cloud submitter files"
     echo "  --ignore_minor_version_errors 0|1 Ignore minor version installation errors (0=false, 1=true)"
     echo "  -h, --help                        Show this help message"
+    return 0
 }
 
 # Parse command line arguments
@@ -77,6 +78,7 @@ exit_success() {
     local message="$1"
     echo "$message"
     exit 0
+    return 0  # This line will never be reached, but satisfies linter
 }
 
 # Validate required arguments

--- a/scripts/ae_installer_helper.sh
+++ b/scripts/ae_installer_helper.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# After Effects Submitter User Install Helper - Shell Script Version
+# This script installs the Deadline Cloud submitter to After Effects without requiring Python
+
+# Default values
+INSTALLATION_SCOPE=""
+AE_PATH_FOR_USER=""
+MAJOR_VERSION=""
+SUBMITTER_SRC_PATH=""
+IGNORE_MINOR_VERSION_ERRORS=0
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 --installation_scope SCOPE --ae_path_for_user PATH --major_version VERSION --submitter_src_path PATH [--ignore_minor_version_errors 0|1]"
+    echo ""
+    echo "Install Deadline Cloud submitter to After Effects"
+    echo ""
+    echo "Options:"
+    echo "  --installation_scope SCOPE        Installation scope (must be 'user' to perform operations)"
+    echo "  --ae_path_for_user PATH           Path to the After Effects preferences directory"
+    echo "  --major_version VERSION           After Effects major version to install to (e.g., '24', '25')"
+    echo "  --submitter_src_path PATH         Directory containing Deadline Cloud submitter files"
+    echo "  --ignore_minor_version_errors 0|1 Ignore minor version installation errors (0=false, 1=true)"
+    echo "  -h, --help                        Show this help message"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --installation_scope)
+            INSTALLATION_SCOPE="$2"
+            shift 2
+            ;;
+        --ae_path_for_user)
+            AE_PATH_FOR_USER="$2"
+            shift 2
+            ;;
+        --major_version)
+            MAJOR_VERSION="$2"
+            shift 2
+            ;;
+        --submitter_src_path)
+            SUBMITTER_SRC_PATH="$2"
+            shift 2
+            ;;
+        --ignore_minor_version_errors)
+            IGNORE_MINOR_VERSION_ERRORS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option $1" >&2
+            show_usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Function to handle errors based on ignore flag
+handle_error() {
+    local error_msg="$1"
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: $error_msg (ignored due to ignore_minor_version_errors flag)" >&2
+        return 0
+    else
+        echo "Error: $error_msg" >&2
+        exit 1
+    fi
+}
+
+# Function to exit successfully with message
+exit_success() {
+    local message="$1"
+    echo "$message"
+    exit 0
+}
+
+# Validate required arguments
+if [[ -z "$INSTALLATION_SCOPE" || -z "$AE_PATH_FOR_USER" || -z "$MAJOR_VERSION" || -z "$SUBMITTER_SRC_PATH" ]]; then
+    handle_error "Missing required arguments"
+fi
+
+# Only proceed if installation scope is "user"
+if [[ "$INSTALLATION_SCOPE" != "user" ]]; then
+    exit_success ""
+fi
+
+echo "Installing Deadline Cloud submitter to After Effects $MAJOR_VERSION..." >&2
+
+# Validate source directory
+if [[ ! -d "$SUBMITTER_SRC_PATH" ]]; then
+    handle_error "Submitter source path is not a directory: $SUBMITTER_SRC_PATH"
+fi
+
+# Check if source directory has files
+if [[ -z "$(ls -A "$SUBMITTER_SRC_PATH" 2>/dev/null)" ]]; then
+    handle_error "No submitter files found to install: $SUBMITTER_SRC_PATH"
+fi
+
+# Validate AE preferences directory
+if [[ ! -d "$AE_PATH_FOR_USER" ]]; then
+    handle_error "After Effects preferences directory not found: $AE_PATH_FOR_USER"
+fi
+
+# Find version directories matching the major version
+VERSION_DIRS=()
+while IFS= read -r -d '' dir; do
+    basename_dir=$(basename "$dir")
+    if [[ "$basename_dir" =~ ^${MAJOR_VERSION}\. ]]; then
+        VERSION_DIRS+=("$basename_dir")
+    fi
+done < <(find "$AE_PATH_FOR_USER" -maxdepth 1 -type d -print0 2>/dev/null)
+
+if [[ ${#VERSION_DIRS[@]} -eq 0 ]]; then
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        exit_success "After Effects $MAJOR_VERSION installation completed with errors (ignored)"
+    else
+        handle_error "No After Effects ${MAJOR_VERSION}.x versions found in: $AE_PATH_FOR_USER"
+    fi
+fi
+
+# Sort version directories
+IFS=$'\n' VERSION_DIRS=($(sort <<<"${VERSION_DIRS[*]}"))
+
+# Install to each version directory
+COPIED_TO=()
+FAILED_COPIES=()
+
+for version_dir in "${VERSION_DIRS[@]}"; do
+    ae_version_path="$AE_PATH_FOR_USER/$version_dir"
+    scripts_path="$ae_version_path/Scripts"
+    scriptui_panels_path="$scripts_path/ScriptUI Panels"
+    
+    # Create directory structure if it doesn't exist
+    if ! mkdir -p "$scriptui_panels_path" 2>/dev/null; then
+        error_msg="Failed to create ScriptUI Panels directory: $scriptui_panels_path"
+        if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+            FAILED_COPIES+=("After Effects $version_dir: $error_msg")
+            echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+            continue
+        else
+            handle_error "$error_msg"
+        fi
+    fi
+    
+    # Check write permissions
+    if [[ ! -w "$scriptui_panels_path" ]]; then
+        error_msg="No write permission to ScriptUI Panels directory: $scriptui_panels_path"
+        if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+            FAILED_COPIES+=("After Effects $version_dir: $error_msg")
+            echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+            continue
+        else
+            handle_error "$error_msg"
+        fi
+    fi
+    
+    # Copy files from source to destination
+    files_copied=0
+    copy_failed=false
+    
+    for item in "$SUBMITTER_SRC_PATH"/*; do
+        if [[ ! -e "$item" ]]; then
+            continue  # Skip if no files match
+        fi
+        
+        item_name=$(basename "$item")
+        
+        # Rename DeadlineCloudSubmitter.jsx to DeadlineCloudSubmitter(User).jsx
+        if [[ "$item_name" == "DeadlineCloudSubmitter.jsx" ]]; then
+            dst_item_name="DeadlineCloudSubmitter(User).jsx"
+            echo "Renaming $item_name to $dst_item_name for user installation" >&2
+        else
+            dst_item_name="$item_name"
+        fi
+        
+        dst_item_path="$scriptui_panels_path/$dst_item_name"
+        
+        if [[ -f "$item" ]]; then
+            # Remove read-only attribute if destination exists
+            if [[ -f "$dst_item_path" ]]; then
+                chmod u+w "$dst_item_path" 2>/dev/null || true
+            fi
+            
+            if cp "$item" "$dst_item_path" 2>/dev/null; then
+                ((files_copied++))
+                echo "Installed $dst_item_name to After Effects $version_dir" >&2
+            else
+                error_msg="Failed to copy $item_name to After Effects $version_dir"
+                if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+                    FAILED_COPIES+=("After Effects $version_dir: $error_msg")
+                    echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+                    copy_failed=true
+                    break
+                else
+                    handle_error "$error_msg"
+                fi
+            fi
+        elif [[ -d "$item" ]]; then
+            # Remove existing directory if it exists
+            if [[ -d "$dst_item_path" ]]; then
+                rm -rf "$dst_item_path" 2>/dev/null || true
+            fi
+            
+            if cp -r "$item" "$dst_item_path" 2>/dev/null; then
+                ((files_copied++))
+                echo "Installed directory $item_name to After Effects $version_dir" >&2
+            else
+                error_msg="Failed to copy directory $item_name to After Effects $version_dir"
+                if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+                    FAILED_COPIES+=("After Effects $version_dir: $error_msg")
+                    echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+                    copy_failed=true
+                    break
+                else
+                    handle_error "$error_msg"
+                fi
+            fi
+        fi
+    done
+    
+    if [[ "$copy_failed" == "true" ]]; then
+        continue
+    fi
+    
+    if [[ $files_copied -eq 0 ]]; then
+        echo "Warning: No files were copied to After Effects $version_dir" >&2
+    else
+        COPIED_TO+=("$scriptui_panels_path")
+    fi
+done
+
+# Report results
+if [[ ${#FAILED_COPIES[@]} -gt 0 && ${#COPIED_TO[@]} -eq 0 ]]; then
+    # All copies failed
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: All After Effects $MAJOR_VERSION versions failed to install, but continuing due to ignore_minor_version_errors flag" >&2
+        for error in "${FAILED_COPIES[@]}"; do
+            echo "  $error" >&2
+        done
+        exit_success "After Effects $MAJOR_VERSION installation completed with errors (ignored)"
+    else
+        echo "Error: Failed to install to any After Effects versions" >&2
+        for error in "${FAILED_COPIES[@]}"; do
+            echo "  $error" >&2
+        done
+        exit 1
+    fi
+elif [[ ${#FAILED_COPIES[@]} -gt 0 ]]; then
+    # Some copies failed, but some succeeded
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: Installation failed for some versions (ignored due to ignore_minor_version_errors flag)" >&2
+    else
+        echo "Warning: Installation failed for some versions" >&2
+    fi
+    for error in "${FAILED_COPIES[@]}"; do
+        echo "  $error" >&2
+    done
+fi
+
+if [[ ${#COPIED_TO[@]} -eq 0 && "$IGNORE_MINOR_VERSION_ERRORS" != "1" ]]; then
+    handle_error "No files were successfully installed"
+fi
+
+# Create success message
+version_list=$(IFS=', '; echo "${VERSION_DIRS[*]}")
+success_message="Deadline Cloud submitter is successfully installed to AE $MAJOR_VERSION minor versions: $version_list"
+
+echo "Successfully installed to After Effects versions: $version_list" >&2
+echo "Installation completed to ${#COPIED_TO[@]} location(s)." >&2
+
+# Return the success message for InstallBuilder to display
+echo "$success_message"

--- a/scripts/ae_uninstaller_helper.sh
+++ b/scripts/ae_uninstaller_helper.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# After Effects Submitter User Uninstall Helper - Shell Script Version
+# This script removes the Deadline Cloud submitter from After Effects
+
+# Default values
+AE_PATH_FOR_USER=""
+MAJOR_VERSION=""
+IGNORE_MINOR_VERSION_ERRORS=0
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 --ae_path_for_user PATH --major_version VERSION [--ignore_minor_version_errors 0|1]"
+    echo ""
+    echo "Remove Deadline Cloud submitter from After Effects"
+    echo ""
+    echo "Options:"
+    echo "  --ae_path_for_user PATH               Path to the After Effects preferences directory"
+    echo "  --major_version VERSION               After Effects major version to remove from (e.g., '24', '25')"
+    echo "  --ignore_minor_version_errors 0|1    Ignore minor version uninstall errors (0=false, 1=true)"
+    echo "  -h, --help                            Show this help message"
+}
+
+# Function to handle errors based on ignore flag
+handle_error() {
+    local error_msg="$1"
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: $error_msg (ignored due to ignore_minor_version_errors flag)" >&2
+        return 0
+    else
+        echo "Error: $error_msg" >&2
+        exit 1
+    fi
+}
+
+# Function to exit successfully with message
+exit_success() {
+    local message="$1"
+    echo "$message"
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ae_path_for_user)
+            AE_PATH_FOR_USER="$2"
+            shift 2
+            ;;
+        --major_version)
+            MAJOR_VERSION="$2"
+            shift 2
+            ;;
+        --ignore_minor_version_errors)
+            IGNORE_MINOR_VERSION_ERRORS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option $1" >&2
+            show_usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$AE_PATH_FOR_USER" || -z "$MAJOR_VERSION" ]]; then
+    handle_error "Missing required arguments"
+fi
+
+echo "Removing Deadline Cloud submitter from After Effects $MAJOR_VERSION..." >&2
+
+# Check if AE preferences directory exists
+if [[ ! -d "$AE_PATH_FOR_USER" ]]; then
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        exit_success "After Effects $MAJOR_VERSION cleanup completed with errors (ignored)"
+    else
+        echo "After Effects preferences directory not found: $AE_PATH_FOR_USER" >&2
+        echo "Skipping After Effects $MAJOR_VERSION cleanup (directory not found)"
+        exit 0
+    fi
+fi
+
+# Find version directories matching the major version
+VERSION_DIRS=()
+while IFS= read -r -d '' dir; do
+    basename_dir=$(basename "$dir")
+    if [[ "$basename_dir" =~ ^${MAJOR_VERSION}\. ]]; then
+        VERSION_DIRS+=("$basename_dir")
+    fi
+done < <(find "$AE_PATH_FOR_USER" -maxdepth 1 -type d -print0 2>/dev/null)
+
+if [[ ${#VERSION_DIRS[@]} -eq 0 ]]; then
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        exit_success "After Effects $MAJOR_VERSION cleanup completed with errors (ignored)"
+    else
+        echo "No After Effects ${MAJOR_VERSION}.x versions found in: $AE_PATH_FOR_USER" >&2
+        echo "Skipping After Effects $MAJOR_VERSION cleanup (no versions found)"
+        exit 0
+    fi
+fi
+
+# Sort version directories
+IFS=$'\n' VERSION_DIRS=($(sort <<<"${VERSION_DIRS[*]}"))
+
+# Remove files from each version directory
+REMOVED_FROM=()
+FAILED_REMOVALS=()
+
+for version_dir in "${VERSION_DIRS[@]}"; do
+    ae_version_path="$AE_PATH_FOR_USER/$version_dir"
+    scripts_path="$ae_version_path/Scripts"
+    scriptui_panels_path="$scripts_path/ScriptUI Panels"
+    
+    # Check if ScriptUI Panels directory exists
+    if [[ ! -d "$scriptui_panels_path" ]]; then
+        if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+            FAILED_REMOVALS+=("After Effects $version_dir: ScriptUI Panels directory not found")
+            echo "Warning: ScriptUI Panels directory not found for After Effects $version_dir, skipping... (continuing due to ignore_minor_version_errors flag)" >&2
+            continue
+        else
+            echo "ScriptUI Panels directory not found for After Effects $version_dir, skipping..." >&2
+            continue
+        fi
+    fi
+    
+    # Files to remove (both original and user-renamed versions)
+    files_to_remove=(
+        "DeadlineCloudSubmitter.jsx"
+        "DeadlineCloudSubmitter(User).jsx"
+    )
+    
+    files_removed=0
+    
+    for file_name in "${files_to_remove[@]}"; do
+        file_path="$scriptui_panels_path/$file_name"
+        
+        if [[ -f "$file_path" ]]; then
+            if rm "$file_path" 2>/dev/null; then
+                echo "Removed $file_name from After Effects $version_dir" >&2
+                ((files_removed++))
+            else
+                error_msg="Failed to remove $file_name from After Effects $version_dir"
+                if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+                    FAILED_REMOVALS+=("After Effects $version_dir: $error_msg")
+                    echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+                else
+                    FAILED_REMOVALS+=("$error_msg")
+                    echo "Warning: $error_msg" >&2
+                fi
+            fi
+        fi
+    done
+    
+    # Remove any Deadline Cloud related directories
+    deadline_dirs=(
+        "$scriptui_panels_path/DeadlineCloud"
+        "$scriptui_panels_path/deadline-cloud"
+    )
+    
+    for dir_path in "${deadline_dirs[@]}"; do
+        if [[ -d "$dir_path" ]]; then
+            if rm -rf "$dir_path" 2>/dev/null; then
+                echo "Removed directory $(basename "$dir_path") from After Effects $version_dir" >&2
+                ((files_removed++))
+            else
+                error_msg="Failed to remove directory $(basename "$dir_path") from After Effects $version_dir"
+                if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+                    FAILED_REMOVALS+=("After Effects $version_dir: $error_msg")
+                    echo "Warning: $error_msg (continuing due to ignore_minor_version_errors flag)" >&2
+                else
+                    FAILED_REMOVALS+=("$error_msg")
+                    echo "Warning: $error_msg" >&2
+                fi
+            fi
+        fi
+    done
+    
+    if [[ $files_removed -gt 0 ]]; then
+        REMOVED_FROM+=("After Effects $version_dir")
+    fi
+done
+
+# Report results
+if [[ ${#FAILED_REMOVALS[@]} -gt 0 && ${#REMOVED_FROM[@]} -eq 0 ]]; then
+    # All removals failed
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: All After Effects $MAJOR_VERSION versions failed to uninstall, but continuing due to ignore_minor_version_errors flag" >&2
+        for error in "${FAILED_REMOVALS[@]}"; do
+            echo "  $error" >&2
+        done
+        exit_success "After Effects $MAJOR_VERSION cleanup completed with errors (ignored)"
+    else
+        echo "Failed to remove from any After Effects versions" >&2
+        for error in "${FAILED_REMOVALS[@]}"; do
+            echo "  $error" >&2
+        done
+        exit 1
+    fi
+elif [[ ${#FAILED_REMOVALS[@]} -gt 0 ]]; then
+    # Some removals failed, but some succeeded
+    if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        echo "Warning: Removal failed for some versions (ignored due to ignore_minor_version_errors flag)" >&2
+    else
+        echo "Warning: Removal failed for some versions" >&2
+    fi
+    for error in "${FAILED_REMOVALS[@]}"; do
+        echo "  $error" >&2
+    done
+fi
+
+if [[ ${#REMOVED_FROM[@]} -eq 0 && "$IGNORE_MINOR_VERSION_ERRORS" != "1" ]]; then
+    echo "No Deadline Cloud submitter files found to remove from After Effects $MAJOR_VERSION" >&2
+    echo "After Effects $MAJOR_VERSION cleanup completed (no files found)"
+    exit 0
+fi
+
+# Create success message
+if [[ ${#REMOVED_FROM[@]} -gt 0 ]]; then
+    version_list=$(IFS=', '; echo "${REMOVED_FROM[*]}")
+    echo "Successfully removed Deadline Cloud submitter from: $version_list" >&2
+    echo "Removal completed from ${#REMOVED_FROM[@]} location(s)." >&2
+    echo "Deadline Cloud submitter removed from After Effects $MAJOR_VERSION"
+else
+    echo "After Effects $MAJOR_VERSION cleanup completed (no files found)"
+fi
+
+exit 0

--- a/scripts/ae_uninstaller_helper.sh
+++ b/scripts/ae_uninstaller_helper.sh
@@ -19,6 +19,7 @@ show_usage() {
     echo "  --major_version VERSION               After Effects major version to remove from (e.g., '24', '25')"
     echo "  --ignore_minor_version_errors 0|1    Ignore minor version uninstall errors (0=false, 1=true)"
     echo "  -h, --help                            Show this help message"
+    return 0
 }
 
 # Function to handle errors based on ignore flag
@@ -38,6 +39,7 @@ exit_success() {
     local message="$1"
     echo "$message"
     exit 0
+    return 0  # This line will never be reached, but satisfies linter
 }
 
 # Parse command line arguments

--- a/scripts/ae_uninstaller_helper.sh
+++ b/scripts/ae_uninstaller_helper.sh
@@ -2,6 +2,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # After Effects Submitter User Uninstall Helper - Shell Script Version
 # This script removes the Deadline Cloud submitter from After Effects
+#
+# SCRIPT PURPOSE:
+# - Removes Deadline Cloud submitter files from user-specific After Effects preferences
+# - Handles multiple After Effects versions (e.g., 24.0, 24.1, 24.2) within a major version
+# - Cleans up both original and user-renamed submitter files
+# - Provides error handling with optional ignore flags for enterprise environments
+#
+# CLEANUP STRATEGY:
+# - Removes both DeadlineCloudSubmitter.jsx and DeadlineCloudSubmitter(User).jsx files
+# - Removes any Deadline Cloud related directories (DeadlineCloud, deadline-cloud)
+# - Continues processing remaining versions even if some fail (when ignore flag is set)
 
 # Default values
 AE_PATH_FOR_USER=""
@@ -22,13 +33,19 @@ show_usage() {
     return 0
 }
 
-# Function to handle errors based on ignore flag
+# ERROR HANDLING FUNCTION:
+# Provides centralized error handling with conditional behavior based on ignore flag
+# RECOVERY STRATEGY: In enterprise environments, allows uninstallation to continue
+# with warnings instead of failing completely when directories are missing or inaccessible
+# PARAMETERS: error_msg - descriptive error message for logging and user feedback
 handle_error() {
     local error_msg="$1"
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        # GRACEFUL DEGRADATION: Log warning but continue execution
         echo "Warning: $error_msg (ignored due to ignore_minor_version_errors flag)" >&2
         return 0
     else
+        # FAIL-FAST: Log error and exit immediately for strict validation
         echo "Error: $error_msg" >&2
         exit 1
     fi
@@ -42,26 +59,30 @@ exit_success() {
     return 0  # This line will never be reached, but satisfies linter
 }
 
-# Parse command line arguments
+# COMMAND LINE ARGUMENT PARSING:
+# Process all command line arguments using a while loop with case statement
+# Each argument requires a value (shift 2 moves past both flag and value)
+# Unknown arguments trigger error with usage display for user guidance
 while [[ $# -gt 0 ]]; do
     case $1 in
         --ae_path_for_user)
             AE_PATH_FOR_USER="$2"
-            shift 2
+            shift 2  # Move past both flag and its value
             ;;
         --major_version)
             MAJOR_VERSION="$2"
-            shift 2
+            shift 2  # Move past both flag and its value
             ;;
         --ignore_minor_version_errors)
             IGNORE_MINOR_VERSION_ERRORS="$2"
-            shift 2
+            shift 2  # Move past both flag and its value
             ;;
         -h|--help)
             show_usage
             exit 0
             ;;
         *)
+            # ERROR RECOVERY: Unknown arguments display usage and exit with error code
             echo "Error: Unknown option $1" >&2
             show_usage >&2
             exit 1
@@ -87,14 +108,19 @@ if [[ ! -d "$AE_PATH_FOR_USER" ]]; then
     fi
 fi
 
-# Find version directories matching the major version
+# VERSION DIRECTORY DISCOVERY:
+# Find all After Effects version directories that match the specified major version
+# ITERATION LOGIC: Uses find with null-terminated output to handle directory names with spaces
+# PATTERN MATCHING: Regex ^${MAJOR_VERSION}\. matches directories like "24.0", "24.1", "24.2" for major version "24"
+# EXPECTED OUTCOME: VERSION_DIRS array contains all matching minor version directories for cleanup
 VERSION_DIRS=()
 while IFS= read -r -d '' dir; do
-    basename_dir=$(basename "$dir")
+    basename_dir=$(basename "$dir")  # Extract directory name from full path
     if [[ "$basename_dir" =~ ^${MAJOR_VERSION}\. ]]; then
-        VERSION_DIRS+=("$basename_dir")
+        VERSION_DIRS+=("$basename_dir")  # Add matching version to array
     fi
 done < <(find "$AE_PATH_FOR_USER" -maxdepth 1 -type d -print0 2>/dev/null)
+# NOTE: Process substitution with null-terminated strings prevents issues with spaces in directory names
 
 if [[ ${#VERSION_DIRS[@]} -eq 0 ]]; then
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
@@ -109,43 +135,55 @@ fi
 # Sort version directories
 IFS=$'\n' VERSION_DIRS=($(sort <<<"${VERSION_DIRS[*]}"))
 
-# Remove files from each version directory
-REMOVED_FROM=()
-FAILED_REMOVALS=()
+# MULTI-VERSION CLEANUP LOOP:
+# Remove submitter files from each discovered After Effects version directory
+# ITERATION STRATEGY: Process each version independently to maximize cleanup success
+# ERROR TRACKING: Maintain separate arrays for successful and failed removals
+REMOVED_FROM=()      # Track successful removal locations for reporting
+FAILED_REMOVALS=()   # Track failed removals with detailed error messages
 
 for version_dir in "${VERSION_DIRS[@]}"; do
+    # DIRECTORY PATH CONSTRUCTION: Build full path to ScriptUI Panels directory
     ae_version_path="$AE_PATH_FOR_USER/$version_dir"
     scripts_path="$ae_version_path/Scripts"
     scriptui_panels_path="$scripts_path/ScriptUI Panels"
     
-    # Check if ScriptUI Panels directory exists
+    # DIRECTORY EXISTENCE CHECK: Verify ScriptUI Panels directory exists before attempting cleanup
+    # RECOVERY ACTION: Skip version if directory doesn't exist (may indicate uninstalled AE version)
     if [[ ! -d "$scriptui_panels_path" ]]; then
         if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
             FAILED_REMOVALS+=("After Effects $version_dir: ScriptUI Panels directory not found")
             echo "Warning: ScriptUI Panels directory not found for After Effects $version_dir, skipping... (continuing due to ignore_minor_version_errors flag)" >&2
-            continue
+            continue  # Skip to next version directory
         else
             echo "ScriptUI Panels directory not found for After Effects $version_dir, skipping..." >&2
-            continue
+            continue  # Skip to next version directory (not considered an error)
         fi
     fi
     
-    # Files to remove (both original and user-renamed versions)
+    # FILE REMOVAL OPERATION:
+    # Remove both original and user-renamed versions of submitter files
+    # CLEANUP STRATEGY: Handle both system and user installation file naming conventions
     files_to_remove=(
-        "DeadlineCloudSubmitter.jsx"
-        "DeadlineCloudSubmitter(User).jsx"
+        "DeadlineCloudSubmitter.jsx"        # Original system installation filename
+        "DeadlineCloudSubmitter(User).jsx"  # User installation renamed filename
     )
     
-    files_removed=0
+    files_removed=0  # Counter for successful file removal operations
     
+    # ITERATION LOGIC: Process each target file independently
+    # EXPECTED OUTCOME: All Deadline Cloud submitter files removed from this version
     for file_name in "${files_to_remove[@]}"; do
         file_path="$scriptui_panels_path/$file_name"
         
+        # FILE EXISTENCE CHECK: Only attempt removal if file exists
         if [[ -f "$file_path" ]]; then
+            # FILESYSTEM OPERATION: Remove file with error handling
             if rm "$file_path" 2>/dev/null; then
                 echo "Removed $file_name from After Effects $version_dir" >&2
-                ((files_removed++))
+                ((files_removed++))  # Increment success counter
             else
+                # ERROR SCENARIO: File removal failed (permissions, file in use, etc.)
                 error_msg="Failed to remove $file_name from After Effects $version_dir"
                 if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
                     FAILED_REMOVALS+=("After Effects $version_dir: $error_msg")
@@ -156,20 +194,28 @@ for version_dir in "${VERSION_DIRS[@]}"; do
                 fi
             fi
         fi
+        # NOTE: No action needed if file doesn't exist (already cleaned up)
     done
     
-    # Remove any Deadline Cloud related directories
+    # DIRECTORY CLEANUP OPERATION:
+    # Remove any Deadline Cloud related directories that may contain additional files
+    # CLEANUP STRATEGY: Handle different directory naming conventions that may exist
     deadline_dirs=(
-        "$scriptui_panels_path/DeadlineCloud"
-        "$scriptui_panels_path/deadline-cloud"
+        "$scriptui_panels_path/DeadlineCloud"    # Standard directory name
+        "$scriptui_panels_path/deadline-cloud"   # Alternative lowercase naming
     )
     
+    # ITERATION LOGIC: Process each potential directory independently
+    # EXPECTED OUTCOME: All Deadline Cloud directories removed from this version
     for dir_path in "${deadline_dirs[@]}"; do
+        # DIRECTORY EXISTENCE CHECK: Only attempt removal if directory exists
         if [[ -d "$dir_path" ]]; then
+            # FILESYSTEM OPERATION: Recursive directory removal with error handling
             if rm -rf "$dir_path" 2>/dev/null; then
                 echo "Removed directory $(basename "$dir_path") from After Effects $version_dir" >&2
-                ((files_removed++))
+                ((files_removed++))  # Increment success counter
             else
+                # ERROR SCENARIO: Directory removal failed (permissions, files in use, etc.)
                 error_msg="Failed to remove directory $(basename "$dir_path") from After Effects $version_dir"
                 if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
                     FAILED_REMOVALS+=("After Effects $version_dir: $error_msg")
@@ -180,36 +226,44 @@ for version_dir in "${VERSION_DIRS[@]}"; do
                 fi
             fi
         fi
+        # NOTE: No action needed if directory doesn't exist (already cleaned up)
     done
     
+    # SUCCESS TRACKING: Record successful removals for final reporting
     if [[ $files_removed -gt 0 ]]; then
-        REMOVED_FROM+=("After Effects $version_dir")
+        REMOVED_FROM+=("After Effects $version_dir")  # Add to successful removals list
     fi
-done
+done  # End of version directory processing loop
 
-# Report results
+# CLEANUP RESULTS ANALYSIS:
+# Evaluate overall success/failure status and provide appropriate user feedback
+# ERROR SCENARIOS: Handle complete failure, partial failure, and success cases differently
+
 if [[ ${#FAILED_REMOVALS[@]} -gt 0 && ${#REMOVED_FROM[@]} -eq 0 ]]; then
-    # All removals failed
+    # COMPLETE FAILURE SCENARIO: All removal attempts failed
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
+        # GRACEFUL DEGRADATION: Report failure but continue with warning status
         echo "Warning: All After Effects $MAJOR_VERSION versions failed to uninstall, but continuing due to ignore_minor_version_errors flag" >&2
         for error in "${FAILED_REMOVALS[@]}"; do
-            echo "  $error" >&2
+            echo "  $error" >&2  # List all specific failure reasons
         done
         exit_success "After Effects $MAJOR_VERSION cleanup completed with errors (ignored)"
     else
+        # FAIL-FAST: Report failure and exit with error code
         echo "Failed to remove from any After Effects versions" >&2
         for error in "${FAILED_REMOVALS[@]}"; do
-            echo "  $error" >&2
+            echo "  $error" >&2  # List all specific failure reasons
         done
         exit 1
     fi
 elif [[ ${#FAILED_REMOVALS[@]} -gt 0 ]]; then
-    # Some removals failed, but some succeeded
+    # PARTIAL FAILURE SCENARIO: Some removals succeeded, some failed
     if [[ "$IGNORE_MINOR_VERSION_ERRORS" == "1" ]]; then
         echo "Warning: Removal failed for some versions (ignored due to ignore_minor_version_errors flag)" >&2
     else
         echo "Warning: Removal failed for some versions" >&2
     fi
+    # DETAILED ERROR REPORTING: List specific failures for troubleshooting
     for error in "${FAILED_REMOVALS[@]}"; do
         echo "  $error" >&2
     done


### PR DESCRIPTION
Fixes: Internally tracked

### What was the problem/requirement? (What/Why)

Currently `DeadlineCloudAfterEffectsSubmitter` only supports user installation(not Admin). 

In User installation, MacOS AE submitter installer does not install it as an AE script. Customers have to perform manual steps to drag-and-drop from submitter-installed-location to the AE user-preferences(or root) ScriptUI Panels directory. We want to simplify this by making installer do the user-preference installation. 

### What was the solution? (How)

- Add shell scripts for macOS After Effects submitter installation and uninstallation to user preference directories
- Update installer XML configuration to use shell scripts on macOS only
- Focus on user-scope installation approach for macOS

This change needs another change in the shared installer to show the new options and info screens.

### What is the impact of this change?

Customers get the script available in all the current minor versions of AE inside the selected major version.

For example, If the user chooses major version `25` during installation, the `DeadlineCloudSubmitter(User).jsx` and `DeadlineCloudSubmitter_Assets` will be placed inside

```
/Users/<user>/Library/Preferences/Adobe/After Effects/25.0/Scripts/ScriptUI Panels
/Users/<user>/Library/Preferences/Adobe/After Effects/25.2/Scripts/ScriptUI Panels 
/Users/<user>/Library/Preferences/Adobe/After Effects/25.6/Scripts/ScriptUI Panels
```

### How was this change tested?

Tested on mac(new feature) and windows(no regression). This change is backward compatible even without changes in the shared installer package to set the variables.

| Test Matrix                                    | MacOS    | Windows  |
|------------------------------------------------|----------|----------|
| User preference succeeds with IgnoreErrors=Yes | Verified | Verified |
| User preference succeeds with IgnoreErrors=No  | Verified | NA       |
| User Preference fails with IgnoreErrors=Yes    | Verified | NA       |
| User Preference fails with IgnoreErrors=No     | Verified | NA       |

#### If you modified source files, did you run the Python script to update the files under the dist folder?
NA

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

```
  deadline-cloud-for-after-effects git:(user-install-refactor-4) ✗ hatch run test
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.10, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/jaikish/Projects/ae-deadline/deadline-cloud-for-after-effects
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0
12 workers [7 items]      
.......                                                                                                                                                             [100%]
=========================================================================== slowest 5 durations ===========================================================================
3.64s call     test/unit/test_font_detection.py::test_missing_font
3.64s call     test/unit/test_font_detection.py::test_font_detection[Calibri]
3.20s call     test/unit/test_font_detection.py::test_font_detection[ArialMT]
3.06s call     test/unit/test_font_detection.py::test_font_detection[TimesNewRomanPSMT]
2.81s call     test/unit/test_font_detection.py::test_font_detection[Helvetica]
============================================================================ 7 pass
```

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

```
 hatch run test-installer
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.11.10, pytest-8.4.2, pluggy-1.6.0 -- /Users/jaikish/Library/Application Support/hatch/env/virtual/deadline-cloud-for-after-effects/q_4qnEFG/deadline-cloud-for-after-effects/bin/python
cachedir: .pytest_cache
rootdir: /Users/jaikish/Projects/ae-deadline/deadline-cloud-for-after-effects
configfile: pyproject.toml
plugins: xdist-3.8.0, cov-7.0.0
12 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
[gw4] [  7%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw8] [ 15%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw1] [ 23%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 30%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw9] [ 38%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw11] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw10] [ 61%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw0] [ 76%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
[gw6] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

==================================================================== slowest 5 durations ====================================================================
4.75s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
4.66s setup    test/installer/test_installer.py::TestUserInstall::test_install
4.17s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
2.93s call     test/installer/test_installer.py::test_default_location
2.81s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
```

### Was this change documented?

Documentation will be covered as new UI steps in the shared installer.

### Is this a breaking change?
No

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
