### PR TITLE
feat: support ttc font type in job submission and rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Additionally, to disable warnings every time you submit a job with the submitter
 ## Font attachment system:
 
 The submitter detects fonts used in the submitted composition and automatically adds them as job attachments on submission. These get installed on the worker before the render starts and get removed again when the job ends.
-Currently supported font types include: OpenType (`.otf`), TrueType (`.ttf`), and [Adobe Fonts](https://fonts.adobe.com/).
+Currently supported font types include: OpenType (`.otf`), TrueType (`.ttf`), TrueTypeCollection (`.ttc`), and [Adobe Fonts](https://fonts.adobe.com/).
 Windows bitmap fonts (`.fon`) are only supported on Windows machines.
 
 If fonts are missing at render time, first check that they're installed (on the system or your user), and then check they're being included in the job attachments tab in the submitter.

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1777,7 +1777,7 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     var fontName = "";
 
     var validExtension = true;
-    const fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf", ".ttc"];
 
     // Windows also supports .fon files
     const os = $.os.toLowerCase();
@@ -1818,7 +1818,7 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     const extensionRegex = /\.[a-zA-Z]+$/;
 
     var validExtension = true;
-    const fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf", ".ttc"];
 
     // Windows also supports .fon files
     const os = $.os.toLowerCase();

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/font_manager.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/font_manager.py
@@ -36,7 +36,7 @@ FONT_LOCATION_USER = os.path.join(os.environ.get("LocalAppData"), "Microsoft", "
 
 # Font extensions supported in gdi32.AddFontResourceW
 # OpenType fonts without an extension can also be installed (e.g. Adobe Fonts)
-FONT_EXTENSIONS = [".otf", ".ttf", ".fon", ""]
+FONT_EXTENSIONS = [".otf", ".ttf", ".ttc", ".fon", ""]
 
 logger = logging.getLogger(__name__)
 

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -343,7 +343,7 @@ function createFontFilename(fontLocation, fontPostScriptName) {
     var fontName = "";
 
     var validExtension = true;
-    const fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf", ".ttc"];
 
     // Windows also supports .fon files
     const os = $.os.toLowerCase();
@@ -384,7 +384,7 @@ function getFontFilenameAndSupportStatus(fontLocation, fontPostScriptName) {
     const extensionRegex = /\.[a-zA-Z]+$/;
 
     var validExtension = true;
-    const fontExtensions = [".otf", ".ttf"];
+    const fontExtensions = [".otf", ".ttf", ".ttc"];
 
     // Windows also supports .fon files
     const os = $.os.toLowerCase();


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Artists are unable to submit jobs with "SF Pro" font family to service-managed fleets because those fonts are in TTC font type which is blocked from submission. 

### What was the solution? (How)
Add TTC font type to the support font extensions list, so TTC font files can be uploaded as job attachments and installed on the rendering worker. Service-managed fleets only support windows machines at the moment, since not all TTC fonts can be installed on windows, jobs submitted with those fonts will fail rendering. The team is working on a solution to fix that. 

### What is the impact of this change?
- Artists will be able to submit jobs with TTC font types to service-managed fleets
- Artists using "SF Pro" family font will be unblocked for rendering

### How was this change tested?
Tested submitting a job on AE 24.6.8 and 25.5.0 with SF Pro Display and SF Hello HK ttc fonts. The render was successful and output video showed all fonts correctly.

<img width="650" height="367" alt="Screenshot 2025-11-21 at 11 08 41 AM" src="https://github.com/user-attachments/assets/f59ab375-0041-4542-a219-15009f1823c3" />


#### If you modified source files, did you run the Python script to update the files under the dist folder?
I directly modified font_manager.py, but used the script to update DeadlineCloudSubmitter.jsx.

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the 

No

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test 

No

### Was this change documented?

Updated README.md

### Is this a breaking change?

No



