### PR TITLE
docs: update README about ttc font support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Additionally, to disable warnings every time you submit a job with the submitter
 ## Font attachment system:
 
 The submitter detects fonts used in the submitted composition and automatically adds them as job attachments on submission. These get installed on the worker before the render starts and get removed again when the job ends.
-Currently supported font types include: OpenType (`.otf`), TrueType (`.ttf`), TrueTypeCollection (`.ttc`), and [Adobe Fonts](https://fonts.adobe.com/).
+Currently supported font types include: OpenType (`.otf`), TrueType (`.ttf`), [Adobe Fonts](https://fonts.adobe.com/) and a majority of TrueTypeCollection (`.ttc`).
 Windows bitmap fonts (`.fon`) are only supported on Windows machines.
 
 If fonts are missing at render time, first check that they're installed (on the system or your user), and then check they're being included in the job attachments tab in the submitter.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Not all ttc fonts will work on Windows SMF, e.g. Helvetica font. It's hard to list out the full list of supported ttc fonts, but at least we can make it more clear in README.

### What was the solution? (How)
Update README to be more accurate about ttc font support.

### What is the impact of this change?
More accurate README.

### How was this change tested?
N/A

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

### Is this a breaking change?
No
