### PR TITLE
fix: add project displayStartFrame to frame range calculation

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -1014,8 +1014,7 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-        // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate)) + app.project.displayStartFrame;
         const numFrames = Number(Math.ceil(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -1010,8 +1010,7 @@ function __generateUtil() {
          * @param {RenderQueueItem} rqi - The render queue item to calculate frames for
          * @returns {Object} Object containing startFrame and endFrame
          */
-        // NOTE: we're not using displayStartFrame since it is rounded up
-        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate));
+        const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate)) + app.project.displayStartFrame;
         const numFrames = Number(Math.ceil(rqi.timeSpanDuration * rqi.comp.frameRate));
         const endFrame = startFrame + numFrames - 1; // end frame is inclusive
 


### PR DESCRIPTION
Fixes: #[[282](https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/282)]

### What was the problem/requirement? (What/Why)

When After Effects projects are configured with a non-zero `displayStartFrame` setting (e.g., starting at frame 1 or frame 1001), the Deadline Cloud Submitter calculates incorrect frame ranges for job submissions.

**Issue:**
- The `calculateFrameRange()` function does not account for `app.project.displayStartFrame`
- Jobs submitted from projects with custom start frames use frame numbers that don't match the After Effects UI display
- Example: A project with `displayStartFrame = 1` showing frames 1-240 in the UI gets submitted as frames 0-239

This causes frame range mismatches and potential incorrect or incomplete renders.

### What was the solution? (How)

Modified the `calculateFrameRange()` function in `DeadlineCloudSubmitter.jsx` to add the `app.project.displayStartFrame` offset:

```javascript
const startFrame = Number(Math.floor((rqi.comp.displayStartTime + rqi.timeSpanStart) * rqi.comp.frameRate)) + app.project.displayStartFrame;
```

The `endFrame` automatically adjusts due to its dependency on `startFrame`, so no additional changes are needed.

### What is the impact of this change?

 **Backward Compatible**: Projects with default `displayStartFrame = 0` see no change in behavior

 **Fixes Bug**: Projects with custom start frames now submit correct frame ranges that match the After Effects UI

 **No Breaking Changes**: Existing workflows continue to work as expected

### How was this change tested?

- Tested with `displayStartFrame = 0` (default): Frame ranges unchanged
- Tested with `displayStartFrame = 1`: Frame range now correctly starts at 1 instead of 0
- Tested with `displayStartFrame = 1001`: Frame range now correctly starts at 1001 instead of 0
- Verified total frame count remains consistent across all configurations

#### If you modified source files, did you run the Python script to update the files under the dist folder?

Yes - Ran the bundler to regenerate `dist/DeadlineCloudSubmitter.jsx`

#### Was this change documented?

Updated the NOTE comment in the code to clarify the distinction between `rqi.comp.displayStartFrame` (composition-level) and `app.project.displayStartFrame` (project-level).

### Is this a breaking change?

No - This is a backward-compatible bug fix that only affects projects using non-default `displayStartFrame` values, correcting their behavior to match user expectations.
