### PR TITLE
chore: update codeql to include security event with write permission

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,3 +14,5 @@ jobs:
     uses: aws-deadline/.github/.github/workflows/reusable_codeql.yml@mainline
     with:
       languages: "javascript"
+    permissions:
+      security-events: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud-for-after-effects/pull/283 CodeQL approval rule failed to execute with the error
```
The workflow is not valid. .github/workflows/codeql.yaml (Line: 12, Col: 3): Error calling workflow 'aws-deadline/.github/.github/workflows/reusable_codeql.yml@mainline'. The nested job 'analyze' is requesting 'security-events: write', but is only allowed 'security-events: none'.
```
### What was the solution? (How)
Add the permission to Github workflow
### What is the impact of this change?
Fix the failed workflow
### How was this change tested?
N/A
#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A
#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A

### Was this change documented?

N/A

### Is this a breaking change?
No
---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
