### PR TITLE
docs: add user guide doc

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -1,0 +1,17 @@
+# AWS Deadline Cloud for After Effects User Guide
+
+This guide provides step-by-step instructions for using AWS Deadline Cloud with After Effects to render your projects faster by distributing rendering tasks across multiple machines.
+
+## What's Inside
+
+This user guide covers:
+
+- [Installation](installation.md) - How to install the After Effects submitter
+- [Using the Submitter](using-submitter.md) - How to prepare and submit rendering jobs
+
+## Support
+
+Need help or have feedback? Here's how to get support:
+
+1. **[Report a bug or issue](https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues)** - Report a bug or issue with the After Effects submitter
+2. **[Discussion forum](https://github.com/aws-deadline/deadline-cloud-for-after-effects/discussions)** - Add any feature requests, questions and the team can help support you!

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -1,0 +1,87 @@
+# Installation
+
+To install AWS Deadline Cloud submitter for After Effects, please prepare the following environment:
+
+- Windows or macOS workstation
+- Adobe After Effects 24 or 25 installation
+- Python 3.9 or higher
+- Access to an AWS Deadline Cloud farm with either
+    - a service-managed fleet with After Effects available (via custom Conda package)
+    - a customer-managed fleet with After Effects and licensing set up
+
+## Prerequisites
+
+Before installing the submitter, you need to:
+
+1. Install the Deadline CLI and Deadline Cloud Monitor by running the Deadline Submitter and Deadline Monitor installers from the downloads section of the Deadline Cloud service in your AWS Console.
+
+2. Enable script permissions in After Effects. This submitter requires the ability to write files and send communication over the network in order to function properly. By default, After Effects scripts are not allowed to perform these actions. [Reference link](https://helpx.adobe.com/after-effects/using/scripts.html).
+
+   To allow scripts to write files or send communication over a network:
+   
+   - **Windows**: Select `Edit > Preferences > Scripting & Expressions > select Allow Scripts To Write Files And Access Network`
+   - **macOS**: Select `After Effects > Settings > Scripting & Expressions > select Allow Scripts To Write Files And Access Network`
+
+## Installing the submitter
+
+The After Effects submitter extension allows you to submit jobs to Deadline Cloud directly from within After Effects.
+
+**Note: During the installer process, you will choose between User Install or System Install. macOS users will default to User Install, since automatic System Install is currently not supported on macOS (manual System Install is still possible for admin users). Read only the section below that matches your selection:**
+
+### User Install
+
+1. Download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
+2. Run the installer (no admin required).
+3. Follow the prompts and select the After Effects submitter and choose the major version (e.g., 24 or 25).
+4. The submitter will be installed based on your operating system:
+   - **macOS**: The installer automatically places `DeadlineCloudSubmitter(User).jsx` and `DeadlineCloudSubmitter_Assets` into your After Effects user preferences directory for all minor versions of the selected major version:
+     ```
+     /Users/<user>/Library/Preferences/Adobe/After Effects/<version>/Scripts/ScriptUI Panels
+     ```
+     The submitter will appear in the **Window** menu in After Effects.
+   - **Windows**: The submitter is installed to a standalone location by default:
+     ```
+     C:\Users\<user>\DeadlineCloudSubmitter\Submitters\AfterEffects\AE<version>
+     ```
+     You will need to run the script manually via **File > Scripts > Run Script File**.
+
+### System Install
+
+**Note: Automatic macOS system install is not yet supported by the submitter installer. macOS admin users can perform a manual system install by copying files to the application directory (see [Manual Installation](#manual-installation-alternative)).**
+
+1. Download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
+2. **Windows only**: Right-click the installer and choose `Run as Admin`.
+3. Follow the prompts and select the After Effects submitter. It will be installed to:
+   - **Windows**: `C:\Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
+   - **macOS** (manual): `/Applications/Adobe After Effects <version>/Scripts/ScriptUI Panels`
+
+### Final Setup Steps
+
+1. After installing via submitter installer, ensure you log into your Deadline user profile by running `deadline auth login` in the Terminal/Powershell or logging in via the Deadline Cloud Monitor.
+2. Next, to install the necessary dependencies used by the AE submitter, run the following in your local Terminal or Command Prompt:
+   ```
+   pip install fonttools
+   ```
+3. Finally, restart After Effects if it was open.
+
+## Manual Installation (Alternative)
+
+If you prefer to install manually, you can copy the submitter files directly:
+
+1. Locate the `DeadlineCloudSubmitter.jsx` file and the `DeadlineCloudSubmitter_Assets` folder in the `dist` folder of this repository.
+2. Copy both to the **ScriptUI Panels** folder within your After Effects installation:
+   - **Windows**: `Program Files\Adobe\Adobe After Effects <version>\Support Files\Scripts\Script UI Panels`
+   - **macOS**: `Applications/Adobe After Effects <version>/Scripts/Script UI Panels`
+3. Restart After Effects if it was open.
+
+## Setting up After Effects with your Deadline Cloud Farm
+
+After Effects conda packages are available in AWS Deadline Cloud Service Managed Fleet. For the list of supported versions, see the [Deadline Cloud User Guide](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html). If you would like to build a conda channel that contains a different After Effects conda package, please follow [these instructions](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html).
+
+You can also use the After Effects conda recipe in [deadline-cloud-samples package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-25.0) as a reference when building the package.
+
+Jobs created by this submitter require the `aerender` executable to be available on the PATH of the user that will be running your jobs. Alternatively, you can set the `AERENDER_EXECUTABLE` environment variable to point to the aerender executable.
+
+## Updating the submitter
+
+To update the submitter to the latest version, download and run the latest submitter installer.

--- a/docs/user_guide/using-submitter.md
+++ b/docs/user_guide/using-submitter.md
@@ -1,0 +1,178 @@
+# Using the After Effects Submitter
+
+To use the Deadline Cloud submitter for After Effects, please ensure your Farm is configured with an After Effects capable fleet (see [Setting up After Effects with your Deadline Cloud Farm](installation.md#setting-up-after-effects-with-your-deadline-cloud-farm)), and have the submitter installed. Also, please log into the Deadline Cloud Monitor or provide AWS credentials via a configuration profile for Deadline Cloud access.
+
+Refer to the [installation.md](installation.md) to configure the fleet and After Effects application.
+
+## Submit a job
+
+**Note: Follow the instructions below that match the install type you selected during installation.**
+
+### User Install - macOS
+
+1. Launch Adobe After Effects.
+2. Open the submitter by clicking **Window > DeadlineCloudSubmitter(User).jsx**.
+3. Follow the steps in [Submitting Your Job](#submitting-your-job) below.
+
+### User Install - Windows
+
+1. Launch Adobe After Effects.
+2. Open the submitter by clicking **File > Scripts > Run Script File** and navigate to where the `DeadlineCloudSubmitter.jsx` file is located and select it to run the submitter. If you recently closed the submitter, you can reopen it by clicking **File > Scripts > Recent Script Files** and pick the `DeadlineCloudSubmitter.jsx` file that was previously run.
+3. Follow the steps in [Submitting Your Job](#submitting-your-job) below.
+
+### System Install
+
+1. Launch After Effects as Admin (Windows) or with appropriate permissions (macOS).
+2. Open the submitter by clicking **Window > DeadlineCloudSubmitter.jsx**.
+3. Follow the steps in [Submitting Your Job](#submitting-your-job) below.
+
+### Submitting Your Job
+
+1. Click "Open Render Queue" on the submitter. Add any composition to your render queue and set up your render settings, output module, and output path.
+2. Click **Refresh** on the submitter to see your composition in the composition list.
+3. Select your composition you want to render and click **Submit** to submit a render job. For details on available settings, see [After Effects Specific Settings](#after-effects-specific-settings) below.
+4. If you see a warning popup window with "You are about to run the script contained in file", you can suppress the warning by following the instruction in the popup or the instructions in [installation.md](installation.md) to disable warnings when submitting jobs.
+5. Install any python libraries if prompted and press the **Login** button in the bottom left if you are not logged in.
+6. Set the farm and queue you are submitting to with the **Settings** button, and click **Submit**.
+
+**Note**: The After Effects submitter calls the Deadline GUI Submitter to complete job submission. If you hit any issues on the GUI submitter, please refer to [deadline-cloud](https://github.com/aws-deadline/deadline-cloud) library for help.
+
+### Shared Job Settings
+
+Settings that apply to the entire job:
+
+- **Farm Selection** - Choose which farm your job will render on
+- **Queue Selection** - Select the specific queue within your chosen farm
+- **Job Name** - Give your render job a descriptive name
+- **Job Description** - Add optional details about your render job
+- **Priority** - Set job priority for queue management
+- **Initial State** - Control whether the job starts immediately or remains paused
+- **Max Failed Tasks Count** - Maximum number of tasks that can fail before the job is marked as failed
+- **Max Retries Per Task** - Number of times a failed task will be retried
+- **Max Worker Count** - Maximum number of workers that can work on this job simultaneously
+
+### After Effects Specific Settings
+
+Settings specific to After Effects rendering:
+
+- **Composition Selection** - Select which composition from your render queue to submit
+- **Frames Per Task** - (For image sequences) Specify how many frames each task should render. By default, Deadline Cloud creates one task for every frame. Increasing this value can speed up rendering in jobs where each frame renders quickly.
+- **Multi-Frame Rendering** - Enable After Effects multi-frame rendering. You can also specify the max percentage of CPU usage to allocate towards rendering. For more information, visit [Adobe's multi-frame rendering documentation](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
+- **Timeout** - (Optional) Configure timeout settings (days, hours, and minutes) to handle unexpected cases where a task may become unresponsive. The default timeout is 2 days.
+- **Output Type** - Automatically detected based on your render queue settings (image sequence or video)
+- **Output Path** - Directory where rendered files will be saved (from your render queue settings)
+
+For information about the other submitter tabs, see the [AWS Deadline Cloud guide for using a submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/jobs-using-submitter.html).
+
+### Font Attachment System
+
+Fonts used in the submitted composition are detected by the submitter and are automatically added as job attachments on submission. These get installed on the worker before the render starts and get removed again when the job ends.
+
+**Supported font types:**
+- OpenType (`.otf`)
+- TrueType (`.ttf`)
+- TrueTypeCollection (`.ttc`) - majority supported
+- [Adobe Fonts](https://fonts.adobe.com/)
+- Windows bitmap fonts (`.fon`) - only supported on Windows machines
+
+**Troubleshooting fonts:**
+If fonts are missing at render time:
+
+1. Check that fonts are installed on your system:
+   - **Windows**: Open Settings > Personalization > Fonts to view installed fonts
+   - **macOS**: Open Font Book application to view installed fonts
+2. Verify fonts are included in job attachments: After clicking **Submit** in the submitter, check the **Job Attachments** tab in the submission dialog to confirm your fonts are listed.
+
+**Adobe Creative Cloud Fonts:**
+In order for Deadline Cloud to use fonts distributed through Adobe Creative Cloud, they must be made available for all non-Adobe apps on your workstation.
+
+To install fonts for non-Adobe apps in Creative Cloud:
+1. Open Adobe Creative Cloud Desktop.
+2. Click "Adobe Fonts" on the account sidebar under "Your plan" to show the Adobe Fonts panel.
+3. Click "Added fonts" on the "Adobe Fonts" sidebar to show your added fonts.
+4. Click "Install family" next to the fonts you would like to make available for non-Adobe apps.
+
+## Viewing the Job Bundle
+
+To submit a job, the submitter first generates a [Job Bundle](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/build-job-bundle.html), and then uses functionality from the Deadline package to submit the Job Bundle to your render farm to run.
+
+If you would like to see the job that will be submitted to your farm:
+
+1. Use the **Export Bundle** button in the submitter to export the Job Bundle in the job history directory (default: `~/.deadline/job_history`).
+2. If you want to submit the job from the export, rather than through the submitter, you can use the Deadline Cloud application to submit that bundle to your farm.
+
+## Monitoring your jobs
+
+You can monitor job progress using the Deadline Cloud monitor. For more information, see the [AWS Deadline Cloud guide for using the monitor](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/working-with-deadline-monitor.html).
+
+## Getting help
+
+- Contact AWS Support
+- For bugs, please log an [issue to our GitHub](https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues) (Requires a GitHub account)
+- For feature requests or improvement ideas, visit our [discussion forum](https://github.com/aws-deadline/deadline-cloud-for-after-effects/discussions)
+
+## Troubleshooting
+
+### Error: Couldn't find Python 3 or higher on your PATH
+
+**For macOS:**
+1. Open your Terminal and run the following scripts in your command line: `where python` and `where python3`. If you're not getting any results, this means you need to install Python for your workstation.
+2. If you do not have `python3` CLI installed but you have `python`, run `python --version` to check if you have Python 3.9 or higher. If not, please install Python 3.9 or higher first and add it to your path.
+3. Once you are getting results from the version check and where check, then check which python executable is actively being used. Run `which python`, `which python3`. If you're not getting any results, you'll need to add your python CLI to your zsh $PATH.
+4. We must also ensure you're adding the Python that was used to install Deadline CLI. Run `python -m pip list` and/or `python3 -m pip list` to verify this and add to $PATH whichever python applies.
+5. Finally, add the `bin` folder containing Python CLI to your path by editing `~/.zshrc` (and `~/.bashrc` if applicable) and updating the $PATH. For example, if your Python and Deadline CLI are under `/Library/Frameworks/Python.framework/Versions/3.13/bin`, add the following code to your `~/.zshrc` file at the end of the file so it gets final priority when the $PATH is evaluated:
+   ```
+   export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.13/bin
+   ```
+6. Save and exit, then run `source ~/.zshrc`
+
+In the end, your output should follow a pattern similar to the following example:
+```
+user@7cf34df03377 ~ % which python3
+/Library/Frameworks/Python.framework/Versions/3.13/bin/python3
+user@7cf34df03377 ~ % where deadline
+/Library/Frameworks/Python.framework/Versions/3.13/bin/deadline
+```
+7. Now if you run `python --version` and `deadline --version`, you should have access to both of the executables and After Effects should too. Retry job submission.
+
+**For Windows:**
+1. Open Command Prompt (or PowerShell).
+2. Run `where python`, `where python3`, `where py`, and `where deadline` to locate the executables. Note: In PowerShell, use `Get-Command python` instead of `where python`.
+3. Press Windows + S and search for "Edit the system environment variables". Note this will require admin access. Click "Environment Variables...".
+4. Depending on whether Deadline CLI was a user installation or system installation, select the "Path" variable under either "User variables" or "System variables", then click **Edit**.
+5. In the Edit window, click **New** and paste the path to the folder containing your Python and Deadline executables.
+6. Ensure that the binary folders containing deadline and your python CLI have been added. Deadline will either be located in the DeadlineCloudSubmitter folder when installed from the submitter installer or under a python folder if managed by pip. If you're managing Deadline CLI with pip, run `python -m pip list` and/or `python3 -m pip list` to ensure you add the Python containing Deadline CLI to your path.
+
+### Error: Deadline Not Found
+
+1. First, open your Terminal or Command Prompt and run `deadline --version` to verify installation.
+2. Then follow the troubleshooting steps above for Python for your respective OS and verify that deadline is on your $PATH.
+3. If you have multiple Python installations and manage Deadline via Pip, verify that the Python on your $PATH is the Python that managed your Deadline installation. This can be done by running `python -m pip list` and `python3 -m pip list` to verify this.
+
+### Error: Missing job template at /Applications/Adobe After Effects 2025/Scripts/ScriptUI Panels/DeadlineCloudSubmitter_Assets/JobTemplate
+
+This error occurs when the `DeadlineCloudSubmitter_Assets` folder is missing or not located next to the `DeadlineCloudSubmitter.jsx` script file.
+
+1. Locate where your `DeadlineCloudSubmitter.jsx` script is installed or moved to.
+2. Ensure the `DeadlineCloudSubmitter_Assets` folder is in the same directory as the script.
+3. If the assets folder is missing, copy it from your original installation source to the same location as the JSX script.
+4. Restart After Effects and try running the submitter again.
+
+### Warning: Unsupported After Effects Version Detected
+
+This means you are using an After Effects version that is not available in the deadline-cloud Conda channel. For example, if you're using After Effects 24.3, but the channel only supports 24.6.
+
+If you continue, the default major version in use locally will be filled in the CondaPackages field, but your job submission may fail unless you have created a custom Conda channel with your specific After Effects version and included this channel in the CondaChannels parameter.
+
+To resolve this, you can either:
+1. Switch to a supported After Effects version,
+2. Acknowledge the warning and proceed (at your own risk), or
+3. Create a custom Conda channel with your desired After Effects version
+
+### After submission on Windows, a command prompt screen flashes open and close and submitter GUI doesn't pop open
+
+Go to the Windows Start menu and search for "Manage app execution aliases". Then disable the `python3.exe` and `python.exe` aliases manually and retry submission.
+
+### Font with an unsupported extension was found
+
+See the **Font Attachment System** section above for supported font types.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,36 @@
+site_name: AWS Deadline Cloud for After Effects User Guide
+site_url: https://aws-deadline.github.io/deadline-cloud-for-after-effects/
+repo_url: https://github.com/aws-deadline/deadline-cloud-for-after-effects
+repo_name: aws-deadline/deadline-cloud-for-after-effects
+edit_uri: edit/mainline/docs/user_guide/
+
+theme:
+  name: material
+  palette:
+    primary: custom
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.expand
+    - content.code.copy
+
+extra:
+  generator: false # Hide mkdocs-material call out
+
+copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+markdown_extensions:
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Using the Submitter: using-submitter.md
+  - Telemetry: ../telemetry.md
+
+plugins:
+  - search
+
+docs_dir: docs/user_guide
+site_dir: site


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
AE doesn't have a user guide yet
### What was the solution? (How)
Created one by README.md content
### What is the impact of this change?
Customer will be able to use user guide (the central page) to understand how to setup AE submitter
### How was this change tested?
follow https://github.com/aws-deadline/aws-deadline.github.io to deploy it in local server <img width="1184" height="437" alt="Screenshot 2026-01-28 at 11 39 34 AM" src="https://github.com/user-attachments/assets/1f750a45-84d2-412a-b19a-dfc95032d33f" /> unfortunately it cannot be shared.
#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below
N/A
#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below
N/A
### Was this change documented?
Y

### Is this a breaking change?

N/A
---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
