### PR TITLE
docs: Update supported AE versions to include 25.6 and 26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AWS Deadline Cloud for After Effects is a package that supports creating and run
 
 ## Compatibility
 
-1. After Effects 2024 - 2025,
+1. After Effects 2024 - 2026,
 1. Python 3.9 or higher; and
 1. Windows or macOS operating system.
 
@@ -151,7 +151,7 @@ To install fonts for non-Adobe apps in Creative Cloud:
 
 ## Setting up After Effects with your Deadline Cloud Farm
 
-After Effects 24.6, 25.1, and 25.2 conda packages are available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
+After Effects 24.6, 25.1, 25.2, 25.6, and 26.0 conda packages are available in AWS Deadline Cloud Service Managed Fleet (See this [link](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html) for more information). If you would like to build a conda channel that contains different After Effects conda package, please follow
 [these instructions](https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/configure-jobs-s3-channel.html).
 You can also use After Effects conda recipe in
 [deadline-cloud-sample package](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/conda_recipes/aftereffects-25.1)

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -3,7 +3,7 @@
 To install AWS Deadline Cloud submitter for After Effects, please prepare the following environment:
 
 - Windows or macOS workstation
-- Adobe After Effects 24 or 25 installation
+- Adobe After Effects 24, 25, or 26 installation
 - Python 3.9 or higher
 - Access to an AWS Deadline Cloud farm with either
     - a service-managed fleet with After Effects available (via custom Conda package)
@@ -32,7 +32,7 @@ The After Effects submitter extension allows you to submit jobs to Deadline Clou
 
 1. Download the Deadline Cloud Submitter installer by following [Step 1: Install the Deadline Cloud Submitter](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/submitter.html#submitter-installation).
 2. Run the installer (no admin required).
-3. Follow the prompts and select the After Effects submitter and choose the major version (e.g., 24 or 25).
+3. Follow the prompts and select the After Effects submitter and choose the major version (e.g., 24, 25, or 26).
 4. The submitter will be installed based on your operating system:
    - **macOS**: The installer automatically places `DeadlineCloudSubmitter(User).jsx` and `DeadlineCloudSubmitter_Assets` into your After Effects user preferences directory for all minor versions of the selected major version:
      ```


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The README and user guide documentation still listed After Effects 2024-2025 as the supported versions, and only listed conda packages 24.6, 25.1, and 25.2. The submitter and installer already added AE 2026 support in v0.4.5 (#291), but the documentation was not updated to reflect this.

### What was the solution? (How)

Updated version references across documentation:
- **README.md**: Updated compatibility range from "2024 - 2025" to "2024 - 2026", and added 25.6 and 26.0 to the list of available conda packages for Service Managed Fleets.
- **docs/user_guide/installation.md**: Updated prerequisites from "After Effects 24 or 25" to "24, 25, or 26", and updated the installer version selection example accordingly.

### What is the impact of this change?

Customers will see accurate version support information in the README and user guide, matching the actual capabilities added in v0.4.5.

### How was this change tested?

Documentation-only change. Verified all version references are consistent across files.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
No — docs-only change, no source files modified.

### Was this change documented?

This PR *is* the documentation update.

### Is this a breaking change?

No.