### PR TITLE
chore: process improvements

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,6 +21,7 @@ jobs:
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     secrets: inherit

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -70,7 +70,7 @@ jobs:
       project_name: ${{ github.event.repository.name }}
           
   Release:
-    needs: [TagRelease, ManualTestGate]
+    needs: [TagRelease, ReleaseInstaller]
     runs-on: ubuntu-latest
     name: Release
     permissions:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -44,14 +44,21 @@ jobs:
   IsCondaReady:
     needs: BuildInstaller
     runs-on: ubuntu-latest
-    environment: release
+    environment: release-gate
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
     steps:
       - run: |
          :
 
+  ManualTestGate:
+    needs: [TagRelease, BuildInstaller]
+    runs-on: ubuntu-latest
+    environment: release-gate
+    steps:
+      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
+
   ReleaseInstaller:
-    needs: [TagRelease, IsCondaReady]
+    needs: [TagRelease, IsCondaReady, ManualTestGate]
     uses: aws-deadline/.github/.github/workflows/reusable_release_installers.yml@mainline
     secrets: inherit
     permissions:
@@ -63,7 +70,7 @@ jobs:
       project_name: ${{ github.event.repository.name }}
           
   Release:
-    needs: [TagRelease, ReleaseInstaller]
+    needs: [TagRelease, ManualTestGate]
     runs-on: ubuntu-latest
     name: Release
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release process is a bit tedious.

### What was the solution? (How)
- Improve pip and hatch caching with CI actions. (Caching was added in shared workflows already.)
- Add permissions to release note process so they can be LLM generated
- Add a single manual approval step instead of requiring manual approvals on every release step. Before merging, will require a new ManualReleaseGate environment and removing approvals for the release environment

### What is the impact of this change?
Faster releases

### How was this change tested?
Works in deadline-cloud repo

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
