### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -81,7 +81,7 @@ jobs:
       TAG: ${{ needs.TagRelease.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{env.TAG}}
           fetch-depth: 0

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read


### PR DESCRIPTION
## What

Adds a thin `.github/workflows/security_scan.yml` stub that calls the central reusable Security Scan workflow (`aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline`), which runs zizmor against this repo's workflows using the org-central config. New checks added centrally apply here automatically. The gate fails PRs on **high**-severity findings.

## Fixes made first (so CI is green)

Fixed all pre-existing high-severity zizmor findings:
- **unpinned-uses (2)**: pinned `dependabot/fetch-metadata` (auto_approve.yml) and `actions/checkout` (release_publish.yml) to full commit SHAs with `# vX.Y.Z` comments.
- **dangerous-triggers (2, suppressed)**: intentional `workflow_run` triggers in `claude_pr_review.yml` and `on_opened_pr.yml` — both run from the default branch with this repo's context; fork PRs cannot alter behavior or secrets.
- **bot-conditions (1, suppressed)**: canonical dependabot auto-approve actor check in `auto_approve.yml` — job only has `pull-requests: write` and runs Dependabot's own metadata action.

Replicates aws-deadline/deadline-cloud PR #1256. Commits are signed off (DCO).