### PR TITLE
feat!: Make render options job-wide and raise comps per job to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ Additionally, to disable warnings every time you submit a job with the submitter
 1. Launch Adobe After Effects.
 2. Open submitter by clicking **File > Scripts > Run Script File** and navigate to where the `DeadlineCloudSubmitter.jsx` file is located and select it to run the submitter. If the submitter is closed, reopen it easily by clicking **File > Scripts > Recent Script Files** and pick the `DeadlineCloudSubmitter.jsx` file that was previously run.
 3. Click "Open Render Queue" on the submitter. Add any composition to your render queue and set up your render settings, output module, and output path.
-4. Then click **Refresh** on the submitter to see your composition in the composition list.
-5. Select your composition you want to render click `Submit` to submit a render job. Here are some settings you can set:
-   1. (Optional) For image sequences output types you can specify the number of frames per task so that the job created by the After Effects submitter will create the tasks based on the chunk size of the frames and then Deadline Cloud will assign the tasks to available workers to delegate the load.
-   2. You can also specify multi-frame rendering with your job submission. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
+4. Then click **Refresh** on the submitter to see your compositions in the composition list.
+5. Select the compositions you want to render and click `Submit` to submit a render job. Shift+Click, Command+Click (macOS), or Ctrl+Click (Windows) selects several render queue items to group them into a single job, up to a maximum of 15. The settings below apply to the whole job rather than to individual compositions:
+   1. (Optional) For image sequence output types you can specify the number of frames per task, so that the job created by the After Effects submitter creates the tasks based on the chunk size of the frames and then Deadline Cloud assigns the tasks to available workers to delegate the load. This applies to every image sequence in the submission. Video outputs are always rendered as a single task, so this setting has no effect on them.
+   2. You can also specify multi-frame rendering for the job. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
    3. You need to set up timeout days, hours and minutes to avoid the task gets stuck forever. The default timeout is 2 days.
 6. If you see a warning popup window with "You are about to run the script contained in file", you can suppress the warning by following the instruction in the popup or the instructions above to disable warnings when submitting jobs.
 7. Install any python libraries if prompted and press the Login button in the bottom left if you are not logged in.
@@ -121,10 +121,10 @@ Additionally, to disable warnings every time you submit a job with the submitter
 1. Launch After Effects as Admin.
 2. Open submitter by clicking **Window > DeadlineCloudSubmitter.jsx**.
 3. Click "Open Render Queue" on the submitter. Add any composition to your render queue and set up your render settings, output module, and output path.
-4. Then click **Refresh** on the submitter to see your composition in the composition list.
-5. Select your composition you want to render click `Submit` to submit a render job. Here are some settings you can set:
-   1. (Optional) For image sequences output types you can specify the number of frames per task so that the job created by the After Effects submitter will create the tasks based on the chunk size of the frames and then Deadline Cloud will assign the tasks to available workers to delegate the load.
-   2. You can also specify multi-frame rendering with your job submission. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
+4. Then click **Refresh** on the submitter to see your compositions in the composition list.
+5. Select the compositions you want to render and click `Submit` to submit a render job. Shift+Click, Command+Click (macOS), or Ctrl+Click (Windows) selects several render queue items to group them into a single job, up to a maximum of 15. The settings below apply to the whole job rather than to individual compositions:
+   1. (Optional) For image sequence output types you can specify the number of frames per task, so that the job created by the After Effects submitter creates the tasks based on the chunk size of the frames and then Deadline Cloud assigns the tasks to available workers to delegate the load. This applies to every image sequence in the submission. Video outputs are always rendered as a single task, so this setting has no effect on them.
+   2. You can also specify multi-frame rendering for the job. If you do, you can also specify the max percentage of CPU usage you wish to allocate towards rendering in case you would like to limit it to allow other background applications or processes to run smoothly. For more information about multi-frame rendering, visit Adobe's website [here](https://helpx.adobe.com/after-effects/using/multi-frame-rendering.html).
    3. You need to set up timeout days, hours and minutes to avoid the task gets stuck forever. The default timeout is 2 days.
 6. If you see a warning popup window with "You are about to run the script contained in file", you can suppress the warning by following the instruction in the popup or the instructions above to disable warnings when submitting jobs.
 7. Install any python libraries if prompted and press the Login button in the bottom left if you are not logged in.
@@ -213,6 +213,22 @@ This error occurs when the `DeadlineCloudSubmitter_Assets` folder is missing or 
 2. Ensure the `DeadlineCloudSubmitter_Assets` folder is in the same directory as the script.
 3. If the assets folder is missing, copy it from your original installation source to the same location as the JSX script.
 4. Restart After Effects and try running the submitter again.
+
+### Error: \<number\> render queue items are selected, but a single job supports at most 15
+
+Every render queue item in a submission adds parameters to the job template that the submitter generates, and the Open Job Description specification allows a job template to declare at most 50 parameters. That budget works out to 15 render queue items per job.
+
+This is a limit on the job template, not on After Effects or on your farm. To render more compositions than that, select up to 15 render queue items and submit them, then select the next group and submit it as a separate job. Jobs submitted this way are independent and can render at the same time on your farm.
+
+### Error: Could not merge parameters from environment template ... parameterDefinitions must have at most 50 elements
+
+The 50 parameter budget described above is shared between the job template and the queue environments of the queue you submit to. The submitter reserves room for a queue environment when it decides how many render queue items fit into one job, but a queue whose environments declare an unusually large number of parameters can still exceed the limit.
+
+To resolve this, either submit fewer render queue items per job, or remove parameters that your queue environments do not need. To see what your queue's environments declare, run:
+
+```
+deadline queue paramdefs
+```
 
 ### Warning: Unsupported After Effects Version Detected
 

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2070,16 +2070,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
     }
 
     stepTemplateObject.steps[0].name = generateParameterName(renderQueueItemIndex, compName, "");
+    const renderQueueIndexToken = "{{Param." + generateParameterName(renderQueueItemIndex, compName, "RenderQueueIndex") + "}}";
+    const outputFileNameToken = "{{Param." + generateParameterName(renderQueueItemIndex, compName, "OutputFileName") + "}}";
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
-        // Substitute the inlined values first so that the parameter renaming below does not see them
-        var scriptArg = scriptArgs[i]
-            .replace("{{Param.RenderQueueIndex}}", renderQueueItemIndex.toString())
-            .replace("{{Param.OutputFileName}}", outputFileName);
+        // Rename first, so the regex never sees the output file name, which may contain "Param."
         // JobParams
-        replacedArgs.push(scriptArg.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
+        var scriptArg = scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_");
+        // split/join keeps a $ in the output file name literal
+        scriptArg = scriptArg.split(renderQueueIndexToken).join(renderQueueItemIndex.toString());
+        replacedArgs.push(scriptArg.split(outputFileNameToken).join(outputFileName));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
@@ -2462,12 +2464,12 @@ function SubmitSelection(selection, selectionSettings) {
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
         // The file name is written into the step's command rather than passed as a parameter, so it
-        // ends up inside an Open Job Description format string. "{{" there would be read as the start
-        // of a parameter reference instead of as part of the file name.
-        if (sanitizedOutputFileName.indexOf("{{") !== -1) {
+        // ends up inside an Open Job Description format string. "{{" or "}}" there would be read as
+        // parameter reference delimiters instead of as part of the file name.
+        if (sanitizedOutputFileName.indexOf("{{") !== -1 || sanitizedOutputFileName.indexOf("}}") !== -1) {
             adcAlert(
-                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\", which is not " +
-                "supported.\n\nPlease rename the output file in the render queue and try again.", true
+                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\" or \"}}\", which " +
+                "is not supported.\n\nPlease rename the output file in the render queue and try again.", true
             );
             return;
         }

--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -24,9 +24,6 @@ if (typeof SUPPORTED_VERSIONS === "undefined") {
 if (typeof DEADLINECLOUD_SETTINGS_ROOT === "undefined") {
     const DEADLINECLOUD_SETTINGS_ROOT = "xmp:DeadlineCloudSubmitter";
 }
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
 if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
     const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
 }
@@ -74,6 +71,28 @@ if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
 }
 if (typeof DEFAULT_IGNORE_MISSING_DEPENDENCIES === "undefined") {
     const DEFAULT_IGNORE_MISSING_DEPENDENCIES = false;
+}
+// The most parameter definitions the Open Job Description specification allows a job template to
+// declare. The service checks this against the job template's parameters merged with those of the
+// queue's environments, so the two share this budget.
+if (typeof MAX_JOB_PARAMETERS === "undefined") {
+    const MAX_JOB_PARAMETERS = 50;
+}
+// The most render queue items this submitter puts into a single job, calculated from
+// MAX_JOB_PARAMETERS because the template grows by a fixed number of parameters per item:
+//   7 per job: the JobParams names in SubmitBundle.jsx. ChunkSize is only declared when the
+//     submission contains an image sequence; counting it always keeps this one number valid for any
+//     mix of output types, at the cost of one item for video only submissions.
+//   2 per item: OutputDir and Frames. The render queue index and output file name are written into
+//     the step's command instead, see generateStepTemplateFragment.
+// The remaining budget belongs to the queue's environments, and the submitter cannot know which
+// queue the artist will pick. 15 items leaves 50 - 7 - (2 * 15) = 13 parameters for them, where the
+// Conda queue environments the Deadline Cloud console creates need 1 to 2. Submitting to a queue
+// whose environments declare more than that reserve fails in CreateJob rather than here.
+// Recalculate if either count changes. README.md and docs/user_guide/using-submitter.md also state
+// this limit.
+if (typeof MAX_RENDER_QUEUE_ITEMS_PER_JOB === "undefined") {
+    const MAX_RENDER_QUEUE_ITEMS_PER_JOB = 15;
 }
 
 var FootageTypes = {
@@ -609,8 +628,8 @@ function __generateUtil() {
 
     /**
      * Extracts frame number, prefix, and suffix for single frame in image sequence.
-     * @param {string} fileName 
-     * @returns Object containing prefix, name, and suffix 
+     * @param {string} fileName
+     * @returns Object containing prefix, name, and suffix
      */
     function getImageSequenceInformation(fileName) {
         var regex = /^(.*?)(\d*)(\D*)$/;
@@ -1042,52 +1061,21 @@ function __generateUtil() {
         return true;
     }
 
-    function getSelection(list) {
-        if (list.selection.length >= 1) {
-            return list.selection[0];
+    /**
+     * Reports whether the given render queue item renders to an image sequence.
+     * Items with no output module, or more than one, are not treated as image sequences.
+     * @param {Object} renderQueueItem
+     * @returns {boolean}
+     */
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem == null || renderQueueItem.numOutputModules !== 1) {
+            return false;
         }
-    }
-
-    function getRenderQueueItemID(renderQueueIndex) {
-        /** Calculates an ID for the Render Queue Item with the given index in the render queue
-         * Not guaranteed to be unique if render queue items are reordered
-         */
-        return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
-    }
-
-    function getXMPPathLeaf(path) {
-        // The backslash is needed for this regex, so we need to skip SonarQube scan
-        const regex = /xmp:([^\/]+)$/;
-        return regex.exec(path)[1];
-    }
-
-    function deleteUnusedMetadata(renderMetadataRoot) {
-        var metadata = new XMPMeta(app.project.xmpPacket);
-        var paths = []
-        var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
-        var property;
-        while (property = iterator.next()) {
-            paths.push(property.path);
+        const outputModule = renderQueueItem.outputModule(1).file;
+        if (outputModule == null) {
+            return false;
         }
-        var ids = []
-        for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            ids.push(getRenderQueueItemID(i));
-        }
-        for (var i = 0; i < paths.length; i++) {
-            var presentInArray = false;
-            var currentPath = paths[i];
-            for (var j = 0; j < ids.length; j++) {
-                var renderQueueID = ids[j];
-                if (getXMPPathLeaf(currentPath) === renderQueueID) {
-                    presentInArray = true;
-                    break;
-                }
-            }
-            if (!presentInArray) {
-                metadata.deleteProperty(XMPConst.NS_XMP, currentPath);
-            }
-        }
-        app.project.xmpPacket = metadata.serialize();
+        return isImage(getFileExtension(getFileNameNoRegex(outputModule.name)));
     }
 
     return {
@@ -1132,13 +1120,11 @@ function __generateUtil() {
         "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
-        "getSelection": getSelection,
-        "getRenderQueueItemID": getRenderQueueItemID,
+        "isRenderQueueItemImageOutput": isRenderQueueItemImageOutput,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists,
-        "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
         "getFilePathsFromFootageItem": getFilePathsFromFootageItem,
         "isVideo": isVideo,
@@ -1335,14 +1321,12 @@ var logger = Logger(logFileName, logNormDirectoryPath);
 
 function UiSettingsState() {
     /**
-     * Container that stores all of the configurable properties in the submitter UI
+     * Container that stores all of the configurable properties in the submitter UI.
+     * Every setting here applies to the job as a whole rather than to an individual
+     * render queue item.
      */
 
-    // Contains UiSettingsStore objects that store comp-specific settings
-    this.settings = {}
-
     this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
-    this.rqiXmpPath = dcUtil.composeXMPPath(this.xmpPath, "rqiSpecificSettings");
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
@@ -1377,117 +1361,65 @@ function UiSettingsState() {
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
-}
-
-function UiSettingsStore(xmpPathPrefix, name) {
-    /**
-     * Stores comp-specific settings for the comp with given name.
-     */
-    this.name = name;
-    this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
-
     this.framesPerTask = function () {
-        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function (value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        logger.warning("Setting framesPerTask to " + value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function () {
-        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function (value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        logger.warning("Setting multiFrameRendering to " + value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function () {
-        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
-
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
     }
     this.setMaxCpuUsagePercentage = function (value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        logger.warning("Setting maxCpuUsagePercentage to " + value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 
     this.ignoreMissingDependencies = function () {
-        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
     }
     this.setIgnoreMissingDependencies = function (value) {
-        logger.warning("(" + this.name + ") Setting ignoreMissingDependencies to " + value)
-        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
+        logger.warning("Setting ignoreMissingDependencies to " + value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
     }
 }
 
-UiSettingsState.prototype.get = function (RQIID) {
-    /**
-     * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
-     */
-    if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(this.rqiXmpPath, RQIID);
-    }
-    return this.settings[RQIID]
-}
 
 
 var jobTemplateHelperFile = "JobTemplateHelper.json";
 /**
- * Generates the basic parameterValue file for the job template
+ * Generates the per-render-queue-item parameterValue entries for the job template.
+ * Settings that apply to the whole job, such as multi-frame rendering and frames per task, are
+ * added once by SubmitSelection rather than repeated for every render queue item. The render queue
+ * index and output file name are written straight into the step's command by
+ * generateStepTemplateFragment instead of being parameters, since neither is worth an artist's time
+ * to change in the Deadline submitter and every parameter counts against the job template's limit.
  **/
 function generateParameterValues(
-    renderQueueIndex,
-    projectFile,
     outputDir,
-    outputFileName,
-    isImageSeq,
     startFrame,
     endFrame,
-    chunkSize,
-    multiFrameRendering,
-    maxCpuUsagePercentage,
-    ignoreMissingDependencies,
     prefix
 ) {
     const parameterValuesList = [{
-        name: prefix + "_RenderQueueIndex",
-        value: renderQueueIndex,
-    },
-    {
         name: prefix + "_OutputDir",
         value: outputDir,
-    },
-    {
-        name: prefix + "_OutputFileName",
-        value: outputFileName,
     },
     {
         name: prefix + "_Frames",
         value: startFrame.toString() + "-" + endFrame.toString(),
     },
-    {
-        name: prefix + "_MultiFrameRendering",
-        value: multiFrameRendering === true ? "ON" : "OFF",
-    },
     ];
-    if (maxCpuUsagePercentage) {
-        parameterValuesList.push({
-            name: prefix + "_MaxCpuUsagePercentage",
-            value: maxCpuUsagePercentage,
-        });
-    }
-    if (isImageSeq) {
-        parameterValuesList.push({
-            name: prefix + "_ChunkSize",
-            value: chunkSize,
-        });
-    }
-    if (ignoreMissingDependencies) {
-        parameterValuesList.push({
-            name: prefix + "_IgnoreMissingDependencies",
-            value: ignoreMissingDependencies === true ? "ON" : "OFF",
-        })
-    }
     return {
         parameterValues: parameterValuesList
     };
@@ -1956,10 +1888,18 @@ function generateFontReferences(fontPaths) {
 }
 
 
+// Parameters that are declared once for the whole job instead of once per render queue item.
+// Listing a name here has two effects: generateStepParameterFragment skips emitting a per-item
+// definition for it, and generateStepTemplateFragment leaves "{{Param.<name>}}" references in the
+// step fragments unprefixed so that every step resolves them to the single job-level parameter.
 var JobParams = [
     "JobScriptDir",
     "CondaPackages",
-    "ProjectFile"
+    "ProjectFile",
+    "ChunkSize",
+    "MultiFrameRendering",
+    "MaxCpuUsagePercentage",
+    "IgnoreMissingDependencies"
 ]
 
 var paramPattern = "Param\\.";
@@ -2112,7 +2052,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex,
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parameters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds, outputFileName) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -2134,8 +2074,12 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
+        // Substitute the inlined values first so that the parameter renaming below does not see them
+        var scriptArg = scriptArgs[i]
+            .replace("{{Param.RenderQueueIndex}}", renderQueueItemIndex.toString())
+            .replace("{{Param.OutputFileName}}", outputFileName);
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
+        replacedArgs.push(scriptArg.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
@@ -2166,6 +2110,13 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
  * Submit the selected render queue item
  **/
 function SubmitSelection(selection, selectionSettings) {
+    // The Submit button stays enabled at all times, so this is the only thing standing between an
+    // empty selection and a job template with no steps in it.
+    if (selection === null || selection.length === 0) {
+        adcAlert("Error: Select at least one render queue item to submit.", true);
+        return;
+    }
+
     // Calculate task run timeout in seconds
     var taskTimeoutSeconds = (selectionSettings.taskRunDays() * 24 * 60 * 60) + (selectionSettings.taskRunHours() * 60 * 60) + (selectionSettings.taskRunMinutes() * 60);
     // Validate timeout values during job submission
@@ -2206,6 +2157,21 @@ function SubmitSelection(selection, selectionSettings) {
     
     if (missingFiles.length > 0) {
         adcAlert("Error: Missing required files:\n" + missingFiles.join("\n"), true);
+        return;
+    }
+
+    // Checked before the project is saved and before any dependency scanning, so an oversized
+    // selection is refused immediately rather than after a wait.
+    if (selection.length > MAX_RENDER_QUEUE_ITEMS_PER_JOB) {
+        adcAlert(
+            "Error: " + selection.length + " render queue items are selected, but a single job supports at most " +
+            MAX_RENDER_QUEUE_ITEMS_PER_JOB + ".\n\n" +
+            "Each render queue item adds parameters to the job template that this submitter generates, and the " +
+            "Open Job Description specification allows a job template at most " + MAX_JOB_PARAMETERS + " parameters, " +
+            "shared with the parameters declared by the queue's environments.\n\n" +
+            "Please select " + MAX_RENDER_QUEUE_ITEMS_PER_JOB +
+            " or fewer render queue items and submit the rest as a separate job.", true
+        );
         return;
     }
 
@@ -2334,9 +2300,83 @@ function SubmitSelection(selection, selectionSettings) {
             },
             "default": "aftereffects=" + aftereffectsCondaVersion,
             "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        },
+        {
+            "name": "MultiFrameRendering",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": [
+                "ON",
+                "OFF"
+            ],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Enable or disable multi-frame rendering",
+                "groupLabel": "Multi-Frame Rendering"
+            },
+            "description": "Multi frame rendering settings"
+        },
+        {
+            "name": "MaxCpuUsagePercentage",
+            "type": "INT",
+            "userInterface": {
+                "control": "SPIN_BOX",
+                "label": "Max CPU Usage Percentage",
+                "groupLabel": "Multi-Frame Rendering"
+            },
+            "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
+            "minValue": 1,
+            "maxValue": 100,
+            "default": 90
+        },
+        {
+            "name": "IgnoreMissingDependencies",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": [
+                "ON",
+                "OFF"
+            ],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Ignore Missing Dependencies",
+                "groupLabel": "Ignore Missing Dependencies"
+            },
+            "description": "Allows render to continue without failing if referenced files are missing."
         }
         ]
     }
+
+    // ChunkSize only drives the image step's task parameter space, so it is left out entirely when
+    // nothing in the selection renders an image sequence.
+    var selectionHasImageSequence = false;
+    for (var i = 0; i < renderQueueItems.length; i++) {
+        if (dcUtil.isRenderQueueItemImageOutput(renderQueueItems[i][0])) {
+            selectionHasImageSequence = true;
+            break;
+        }
+    }
+    if (selectionHasImageSequence) {
+        jobParameterDefinitions.parameterDefinitions.push({
+            "name": "ChunkSize",
+            "type": "INT",
+            "userInterface": {
+                "control": "SPIN_BOX",
+                "label": "Frames Per Task",
+                "groupLabel": "Frame Range"
+            },
+            "description": "The chunk size of frames per task to render",
+            "minValue": 1,
+            "default": DEFAULT_FRAMESPERTASK
+        });
+    }
+    // These four settings apply to the whole job, so they are read once here rather than per
+    // render queue item, and contribute one parameter value each instead of one per step.
+    const jobFramesPerTask = selectionSettings.framesPerTask();
+    const jobMaxCpuUsagePercentage = selectionSettings.maxCpuUsagePercentage();
+    const jobMultiFrameRendering = selectionSettings.multiFrameRendering();
+    const jobIgnoreMissingDependencies = selectionSettings.ignoreMissingDependencies();
+
     const jobParameterValues = {
         parameterValues: [{
             name: "deadline:targetTaskRunStatus",
@@ -2358,7 +2398,25 @@ function SubmitSelection(selection, selectionSettings) {
             name: "ProjectFile",
             value: app.project.file.fsName,
         },
+        {
+            name: "MultiFrameRendering",
+            value: jobMultiFrameRendering === true ? "ON" : "OFF",
+        },
+        {
+            name: "MaxCpuUsagePercentage",
+            value: jobMaxCpuUsagePercentage,
+        },
+        {
+            name: "IgnoreMissingDependencies",
+            value: jobIgnoreMissingDependencies === true ? "ON" : "OFF",
+        },
         ]
+    }
+    if (selectionHasImageSequence) {
+        jobParameterValues.parameterValues.push({
+            name: "ChunkSize",
+            value: jobFramesPerTask,
+        });
     }
 
     const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
@@ -2375,11 +2433,6 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
-        var stepIgnoreMissingDependencies = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).ignoreMissingDependencies();
-
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
         var outputFile = outputModule.name;
@@ -2394,17 +2447,30 @@ function SubmitSelection(selection, selectionSettings) {
         var startFrame = frameRange.startFrame;
         var endFrame = frameRange.endFrame;
 
-        var dependencies = findJobAttachments(renderQueueItem.comp, stepIgnoreMissingDependencies); // list of filenames
+        var dependencies = findJobAttachments(renderQueueItem.comp, jobIgnoreMissingDependencies); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
         var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        var isImageSeq = dcUtil.isImage(extension);
+        // Uses the same check as selectionHasImageSequence above. The two must agree: that flag
+        // decides whether ChunkSize is declared, and this decides whether a step references it.
+        var isImageSeq = dcUtil.isRenderQueueItemImageOutput(renderQueueItem);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
+
+        // The file name is written into the step's command rather than passed as a parameter, so it
+        // ends up inside an Open Job Description format string. "{{" there would be read as the start
+        // of a parameter reference instead of as part of the file name.
+        if (sanitizedOutputFileName.indexOf("{{") !== -1) {
+            adcAlert(
+                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\", which is not " +
+                "supported.\n\nPlease rename the output file in the render queue and try again.", true
+            );
+            return;
+        }
 
         // Push step asset references
         for (var d = 0; d < dependencies.length; d++) {
@@ -2413,17 +2479,9 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValues(
-            renderQueueIndex,
-            app.project.file.fsName,
             sanitizedOutputFolder,
-            sanitizedOutputFileName,
-            isImageSeq,
             startFrame,
             endFrame,
-            stepFramesPerTask,
-            stepMultiFrameRendering,
-            stepMaxCpuUsagePercentage,
-            stepIgnoreMissingDependencies,
             generateParameterName(renderQueueIndex, compName, "")
         );
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
@@ -2435,7 +2493,7 @@ function SubmitSelection(selection, selectionSettings) {
         stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
         // Generates template and parameters for the current render queue item, then pushes them to the main template
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds, sanitizedOutputFileName);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
@@ -2454,6 +2512,24 @@ function SubmitSelection(selection, selectionSettings) {
                 template.parameterDefinitions.push(stepParameters.parameterDefinitions[p]);
             }
         }
+    }
+
+    // Backstop for MAX_RENDER_QUEUE_ITEMS_PER_JOB, which is calculated by hand. Firing means that
+    // number is now too high, and that the artist waited through dependency scanning for nothing.
+    if (template.parameterDefinitions.length > MAX_JOB_PARAMETERS) {
+        adcAlert(
+            "Error: The generated job template declares " + template.parameterDefinitions.length +
+            " parameters, more than the " + MAX_JOB_PARAMETERS + " an Open Job Description job template allows.\n\n" +
+            "Please select fewer render queue items and submit the rest as a separate job.", true
+        );
+        logger.error(
+            "Job template declared " + template.parameterDefinitions.length + " parameterDefinitions for " +
+            renderQueueItems.length + " render queue items, which exceeds the Open Job Description limit of " +
+            MAX_JOB_PARAMETERS + ". The selection was within MAX_RENDER_QUEUE_ITEMS_PER_JOB (" +
+            MAX_RENDER_QUEUE_ITEMS_PER_JOB + "), so that value is too high for the parameters this template " +
+            "now declares and needs recalculating.", submitBundleFile
+        );
+        return;
     }
 
     // Writes out final bundle files
@@ -3146,54 +3222,62 @@ function buildUI(thisObj) {
     const controlsPanel = controlsGroup.add("panel", undefined, "");
     controlsPanel.alignment = ['fill', 'top'];
 
-    // Container with settings to modify comp-specific settings
-    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Render Queue Item Settings");
-    perCompSettingsGroup.orientation = "column";
-    perCompSettingsGroup.alignment = ['fill', 'top'];
-    perCompSettingsGroup.alignChildren = ['left', 'top'];
+    // These settings apply to the whole submission, not to individual render queue items. Not named
+    // "Render Settings" because After Effects already uses that for a per-item concept.
+    const jobRenderOptionsPanel = controlsPanel.add("panel", undefined, "Job Render Options");
+    jobRenderOptionsPanel.orientation = "column";
+    jobRenderOptionsPanel.alignment = ['fill', 'top'];
+    jobRenderOptionsPanel.alignChildren = ['left', 'top'];
 
     // Setting up frame per task GUI
-    const framesPerTaskGroup = perCompSettingsGroup.add("group", undefined, "");
+    const framesPerTaskGroup = jobRenderOptionsPanel.add("group", undefined, "");
     framesPerTaskGroup.orientation = "row";
     framesPerTaskGroup.alignment = ['fill', 'top'];
     framesPerTaskGroup.alignChildren = ['left', 'center'];
 
-    const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task");
+    // Always enabled, because this is a project level setting rather than a per composition one.
+    // The label says which outputs it affects so video-only artists do not expect an effect.
+    const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task (img seq only)");
     framesPerTaskLabel.alignment = ['left', 'center'];
-    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output.";
+    framesPerTaskLabel.helpTip = "The number of frames per task, applied to every image sequence in the submission. Has no effect on video output.";
 
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
+    framesPerTaskTextBox.text = uiSettingsState.framesPerTask();
 
     function onFramesPerTaskChanged() {
-        if (list.selection == null) {
-            return;
+        // Frames per task is submitted as the ChunkSize job parameter, which the job template
+        // declares with a minimum of 1, and is used as the stride of the step's frame range.
+        // Strip non-digits so a stray minus sign or trailing text can't reach the template, then
+        // floor the result so an explicit "0" can't produce an invalid range such as "1-100:0".
+        const minFramesPerTask = 1;
+        const maxFramesPerTask = 9999;
+        framesPerTaskTextBox.text = framesPerTaskTextBox.text.replace(/[^0-9]/g, "");
+        var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
+        if (isNaN(newFramesPerTaskValue)) {
+            newFramesPerTaskValue = uiSettingsState.framesPerTask();
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
-            if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).framesPerTask();
-            }
-            if (newFramesPerTaskValue > 9999) {
-                newFramesPerTaskValue = 9999;
-            }
-            framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
+        if (newFramesPerTaskValue < minFramesPerTask) {
+            newFramesPerTaskValue = minFramesPerTask;
         }
+        if (newFramesPerTaskValue > maxFramesPerTask) {
+            newFramesPerTaskValue = maxFramesPerTask;
+        }
+        framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
+        uiSettingsState.setFramesPerTask(newFramesPerTaskValue);
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
-    const mfrGroup = perCompSettingsGroup.add("group", undefined, "");
+    const mfrGroup = jobRenderOptionsPanel.add("group", undefined, "");
     mfrGroup.orientation = "column";
     mfrGroup.alignment = ['fill', 'top'];
     mfrGroup.alignChildren = ['left', 'center'];
     mfrGroup.margins = 5;
 
     const mfrCheckBox = mfrGroup.add("checkbox", undefined, "Enable Multi-Frame Rendering");
-    mfrCheckBox.value = DEFAULT_MULTI_FRAME_RENDERING;
+    mfrCheckBox.value = uiSettingsState.multiFrameRendering();
 
     const maxCpuUsagePercentageGroup = mfrGroup.add("group", undefined, "");
     maxCpuUsagePercentageGroup.orientation = "row";
@@ -3207,82 +3291,68 @@ function buildUI(thisObj) {
     const maxCpuUsagePercentageTextBox = maxCpuUsagePercentageGroup.add("edittext", undefined, "N/A");
     maxCpuUsagePercentageTextBox.alignment = ['fill', 'top'];
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
-    maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? DEFAULT_MAX_CPU_USAGE_PERCENTAGE : "N/A";
+
+    // Max CPU usage is only meaningful while MFR is on, so the control follows the checkbox. This
+    // only reads the stored percentage, so toggling MFR off and back on does not disturb it.
+    function refreshMaxCpuUsagePercentageControl() {
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
+        maxCpuUsagePercentageTextBox.text = mfrCheckBox.value ?
+            uiSettingsState.maxCpuUsagePercentage().toString() :
+            "N/A";
+    }
+    refreshMaxCpuUsagePercentageControl();
 
     function onMaxCpuUsagePercentageChanged() {
+        // The job template declares MaxCpuUsagePercentage with a minimum of 1, so reject 0 along
+        // with non-numeric and out-of-range input rather than persisting a value the template rejects.
+        const minMaxCpuUsagePercentage = 1;
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
-        if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
+        if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue < minMaxCpuUsagePercentage || maxCpuUsagePercentageValue > 100) {
             maxCpuUsagePercentageTextBox.text = DEFAULT_MAX_CPU_USAGE_PERCENTAGE;
         } else {
             // Need to reassign in case input string is a number followed my random characters
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
-        }
+        uiSettingsState.setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
-        const isMfrChecked = mfrCheckBox.value;
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            var RQIID = dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex);
-            if (!isMfrChecked) {
-                maxCpuUsagePercentageTextBox.text = "N/A";
-                uiSettingsState.get(RQIID).setMultiFrameRendering(false);
-            } else {
-                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(RQIID).maxCpuUsagePercentage();
-                uiSettingsState.get(RQIID).setMultiFrameRendering(true);
-            }
-        }
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+        uiSettingsState.setMultiFrameRendering(mfrCheckBox.value);
+        refreshMaxCpuUsagePercentageControl();
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
     // Ignore Missing Dependencies GUI
-    const ignoreMissingDepsGroup = perCompSettingsGroup.add("group", undefined, "");
+    const ignoreMissingDepsGroup = jobRenderOptionsPanel.add("group", undefined, "");
     ignoreMissingDepsGroup.orientation = "column";
     ignoreMissingDepsGroup.alignment = ['fill', 'top'];
     ignoreMissingDepsGroup.alignChildren = ['left', 'center'];
 
     const ignoreMissingDepsCheckBox = ignoreMissingDepsGroup.add("checkbox", undefined, "Ignore Missing Dependencies");
     ignoreMissingDepsGroup.orientation = "column";
+    ignoreMissingDepsCheckBox.value = uiSettingsState.ignoreMissingDependencies();
 
     // Ignore Missing Dependencies Checkbox
     function onIgnoreMissingDepsCheckBoxClicked() {
-        if (list.selection == null) {
-            return;
-        }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
-        }
+        uiSettingsState.setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
     }
     ignoreMissingDepsCheckBox.onClick = onIgnoreMissingDepsCheckBoxClicked;
 
-    function isRenderQueueItemImageOutput(renderQueueItem) {
-        if (renderQueueItem.numOutputModules === 1) {
-            const outputModule = renderQueueItem.outputModule(1).file;
-            if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
-                return dcUtil.isImage(extension);
-            }
-        }
-        return false;
+    // Re-reads the render options from the project, which is needed because they go stale when a
+    // different project is opened. Reading a setting the project never stored seeds it with its
+    // default, which marks the project dirty.
+    function refreshRenderSettingControls() {
+        framesPerTaskTextBox.text = uiSettingsState.framesPerTask();
+        mfrCheckBox.value = uiSettingsState.multiFrameRendering();
+        ignoreMissingDepsCheckBox.value = uiSettingsState.ignoreMissingDependencies();
+        refreshMaxCpuUsagePercentageControl();
     }
 
-    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings");
-    globalSettingsGroup.orientation = "column";
-    globalSettingsGroup.alignment = ['fill', 'top'];
-    globalSettingsGroup.alignChildren = ['left', 'top'];
     // Add Timeouts settings group
-    const timeoutsPanel = globalSettingsGroup.add("panel", undefined, "Timeouts");
+    const timeoutsPanel = controlsPanel.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
     timeoutsPanel.alignment = ['fill', 'top'];
     timeoutsPanel.alignChildren = ['left', 'center'];
@@ -3379,15 +3449,13 @@ function buildUI(thisObj) {
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function () {
         if (getPythonExecutable()) {
-            if (list.selection === null) {
-                return;
-            }
+            // The button is deliberately always enabled; SubmitSelection reports what is wrong, so
+            // an unexpected UI state cannot leave the artist with a button that does nothing.
             SubmitSelection(list.selection, uiSettingsState);
             list.selection = null;
         }
     }
     submitButton.alignment = 'right';
-    submitButton.enabled = false;
 
     function updateList() {
         const bounds = list == null ? undefined : list.bounds;
@@ -3401,10 +3469,11 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 200;
         newList.preferredSize.width = 500;
 
-        // Disable all controls if the render queue is empty
-        // This forces the user to click "refresh" when a new project is opened and populate the list
-        controlsGroup.enabled = app.project.renderQueue.numItems > 0;
-        // Also populate timeout settings because the values could be stale if a new project has been opened since the last refresh
+        // The settings apply to the job rather than to individual render queue items, and they
+        // persist across submissions, so they stay editable even while the render queue is empty.
+        // Repopulate them here because they are stored in the project and a different project may
+        // have been opened since the last refresh.
+        refreshRenderSettingControls();
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
@@ -3420,8 +3489,6 @@ function buildUI(thisObj) {
             var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
-            // Create a default entry for each comp as needed.
-            uiSettingsState.get(i);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -3440,68 +3507,16 @@ function buildUI(thisObj) {
             }
         }
 
-        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
-
         if (list != null) {
             listGroup.remove(list);
         }
         list = newList;
 
-        function onSelectionChange() {
-            const selection = list.selection;
-            perCompSettingsGroup.enabled = false;
-
-            framesPerTaskTextBox.text = "";
-            mfrCheckBox.value = false;
-            maxCpuUsagePercentageTextBox.text = "";
-            ignoreMissingDepsCheckBox.value = false;
-
-            if (selection === null) {
-                submitButton.enabled = false;
-            } else {
-                submitButton.enabled = true;
-            }
-
-            if (selection === null || selection.length !== 1) {
-                return;
-            }
-            const selectionItem = selection[0];
-            perCompSettingsGroup.enabled = true;
-            logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-
-            const settings = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex));
-            if (settings === undefined) {
-                logger.warning("Could not find settings for : " + selectionItem.compId);
-                return;
-            }
-
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-            if (imageOutput) {
-                framesPerTaskTextBox.text = settings.framesPerTask();
-                framesPerTaskTextBox.enabled = true;
-                framesPerTaskTextBox.onChange();
-            } else {
-                framesPerTaskTextBox.text = "Selection is not image sequence";
-                framesPerTaskTextBox.enabled = false;
-            }
-            maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
-            maxCpuUsagePercentageTextBox.onChange();
-            mfrCheckBox.value = settings.multiFrameRendering();
-            mfrCheckBox.onClick();
-            ignoreMissingDepsCheckBox.value = settings.ignoreMissingDependencies();
-            ignoreMissingDepsCheckBox.onClick();
-        }
-        list.onChange = onSelectionChange;
+        // No onChange handler needed: nothing in the panel depends on which items are selected.
         list.selection = null;
-        onSelectionChange();
     }
 
     updateList();
-    if (list.selection != null && list.selection.length === 1) {
-        const selectionItem = list.selection[0];
-        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
-        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
-    }
     refreshButton.onClick = function () {
         updateList();
     }

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/image_template.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/image_template.json
@@ -83,7 +83,8 @@
                 "groupLabel": "Frame Range"
             },
             "description": "The chunk size of frames per task to render",
-            "minValue": 1
+            "minValue": 1,
+            "default": 10
         },
         {
             "name": "MultiFrameRendering",
@@ -109,6 +110,18 @@
             "minValue": 1,
             "maxValue": 100,
             "default": 90
+        },
+        {
+            "name": "IgnoreMissingDependencies",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": ["ON", "OFF"],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Ignore Missing Dependencies",
+                "groupLabel": "Ignore Missing Dependencies"
+            },
+            "description": "Allows render to continue without failing if referenced files are missing."
         },
         {
             "name": "JobScriptDir",
@@ -212,7 +225,9 @@
                             "--multi-frame-rendering",
                             "{{Param.MultiFrameRendering}}",
                             "--max-cpu-usage-percentage",
-                            "{{Param.MaxCpuUsagePercentage}}"
+                            "{{Param.MaxCpuUsagePercentage}}",
+                            "--ignore-missing-dependencies",
+                            "{{Param.IgnoreMissingDependencies}}"
                         ]
                     }
                 }

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_image_fragment.json
@@ -28,17 +28,6 @@
       "description": "The After Effects project file to render."
     },
     {
-      "name": "RenderQueueIndex",
-      "type": "INT",
-      "userInterface": {
-        "control": "SPIN_BOX",
-        "label": "Render Queue Index",
-        "groupLabel": "Source"
-      },
-      "description": "The index of the item in the render queue to render.",
-      "default": 1
-    },
-    {
       "name": "OutputDir",
       "type": "PATH",
       "objectType": "DIRECTORY",
@@ -52,17 +41,6 @@
       "description": "Choose the render output directory."
     },
     {
-      "name": "OutputFileName",
-      "type": "STRING",
-      "userInterface": {
-        "control": "HIDDEN",
-        "label": "Output File Pattern",
-        "groupLabel": "Render Parameters"
-      },
-      "default": "output_####.png",
-      "description": "The file name used for aerender cmd. Not a changeable parameter."
-    },
-    {
       "name": "Frames",
       "type": "STRING",
       "userInterface": {
@@ -70,60 +48,6 @@
         "label": "Start Frame - End Frame",
         "groupLabel": "Frame Range"
       }
-    },
-    {
-      "name": "ChunkSize",
-      "type": "INT",
-      "userInterface": {
-        "control": "SPIN_BOX",
-        "label": "Frames Per Task",
-        "groupLabel": "Frame Range"
-      },
-      "description": "The chunk size of frames per task to render",
-      "minValue": 1
-    },
-    {
-      "name": "MultiFrameRendering",
-      "type": "STRING",
-      "default": "OFF",
-      "allowedValues": [
-        "ON",
-        "OFF"
-      ],
-      "userInterface": {
-        "control": "DROPDOWN_LIST",
-        "label": "Enable or disable multi-frame rendering",
-        "groupLabel": "Multi-Frame Rendering"
-      },
-      "description": "Multi frame rendering settings"
-    },
-    {
-      "name": "MaxCpuUsagePercentage",
-      "type": "INT",
-      "userInterface": {
-        "control": "SPIN_BOX",
-        "label": "Max CPU Usage Percentage",
-        "groupLabel": "Multi-Frame Rendering"
-      },
-      "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
-      "minValue": 1,
-      "maxValue": 100,
-      "default": 90
-    },
-    {
-      "name": "IgnoreMissingDependencies",
-      "type": "STRING",
-      "default": "OFF",
-      "allowedValues": [
-        "ON",
-        "OFF"
-      ],
-      "userInterface": {
-        "control": "DROPDOWN_LIST",
-        "label": "Ignore Missing Dependencies",
-        "groupLabel": "Ignore Missing Dependencies"
-      },
-      "description": "Allows render to continue without failing if referenced files are missing."
     },
     {
       "name": "JobScriptDir",

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/parameter_definitions_video_fragment.json
@@ -28,17 +28,6 @@
       "description": "The After Effects project file to render."
     },
     {
-      "name": "RenderQueueIndex",
-      "type": "INT",
-      "userInterface": {
-        "control": "SPIN_BOX",
-        "label": "Render Queue Index",
-        "groupLabel": "Source"
-      },
-      "description": "The index of the item in the render queue to render.",
-      "default": 1
-    },
-    {
       "name": "OutputDir",
       "type": "PATH",
       "objectType": "DIRECTORY",
@@ -52,17 +41,6 @@
       "description": "Choose the render output directory."
     },
     {
-      "name": "OutputFileName",
-      "type": "STRING",
-      "userInterface": {
-        "control": "HIDDEN",
-        "label": "Output File Pattern",
-        "groupLabel": "Render Parameters"
-      },
-      "default": "output.mp4",
-      "description": "The file name used for aerender cmd. Not a changeable parameter."
-    },
-    {
       "name": "Frames",
       "type": "STRING",
       "userInterface": {
@@ -71,49 +49,6 @@
         "groupLabel": "Frame Range"
       },
       "default": "1-10"
-    },
-    {
-      "name": "MultiFrameRendering",
-      "type": "STRING",
-      "default": "OFF",
-      "allowedValues": [
-        "ON",
-        "OFF"
-      ],
-      "userInterface": {
-        "control": "DROPDOWN_LIST",
-        "label": "Enable or disable multi-frame rendering",
-        "groupLabel": "Multi-Frame Rendering"
-      },
-      "description": "Multi frame rendering settings"
-    },
-    {
-      "name": "MaxCpuUsagePercentage",
-      "type": "INT",
-      "userInterface": {
-        "control": "SPIN_BOX",
-        "label": "Max CPU Usage Percentage",
-        "groupLabel": "Multi-Frame Rendering"
-      },
-      "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
-      "minValue": 1,
-      "maxValue": 100,
-      "default": 90
-    },
-    {
-      "name": "IgnoreMissingDependencies",
-      "type": "STRING",
-      "default": "OFF",
-      "allowedValues": [
-        "ON",
-        "OFF"
-      ],
-      "userInterface": {
-        "control": "DROPDOWN_LIST",
-        "label": "Ignore Missing Dependencies",
-        "groupLabel": "Ignore Missing Dependencies"
-      },
-      "description": "Allows render to continue without failing if referenced files are missing."
     },
     {
       "name": "JobScriptDir",

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/video_template.json
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/video_template.json
@@ -101,6 +101,18 @@
             "default": 90
         },
         {
+            "name": "IgnoreMissingDependencies",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": ["ON", "OFF"],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Ignore Missing Dependencies",
+                "groupLabel": "Ignore Missing Dependencies"
+            },
+            "description": "Allows render to continue without failing if referenced files are missing."
+        },
+        {
             "name": "JobScriptDir",
             "description": "Directory containing embedded scripts.",
             "userInterface": {
@@ -189,7 +201,9 @@
                             "--multi-frame-rendering",
                             "{{Param.MultiFrameRendering}}",
                             "--max-cpu-usage-percentage",
-                            "{{Param.MaxCpuUsagePercentage}}"
+                            "{{Param.MaxCpuUsagePercentage}}",
+                            "--ignore-missing-dependencies",
+                            "{{Param.IgnoreMissingDependencies}}"
                         ]
                     }
                 }

--- a/src/submission/JobTemplateHelper.jsx
+++ b/src/submission/JobTemplateHelper.jsx
@@ -1,60 +1,27 @@
 var jobTemplateHelperFile = "JobTemplateHelper.json";
 /**
- * Generates the basic parameterValue file for the job template
+ * Generates the per-render-queue-item parameterValue entries for the job template.
+ * Settings that apply to the whole job, such as multi-frame rendering and frames per task, are
+ * added once by SubmitSelection rather than repeated for every render queue item. The render queue
+ * index and output file name are written straight into the step's command by
+ * generateStepTemplateFragment instead of being parameters, since neither is worth an artist's time
+ * to change in the Deadline submitter and every parameter counts against the job template's limit.
  **/
 function generateParameterValues(
-    renderQueueIndex,
-    projectFile,
     outputDir,
-    outputFileName,
-    isImageSeq,
     startFrame,
     endFrame,
-    chunkSize,
-    multiFrameRendering,
-    maxCpuUsagePercentage,
-    ignoreMissingDependencies,
     prefix
 ) {
     const parameterValuesList = [{
-        name: prefix + "_RenderQueueIndex",
-        value: renderQueueIndex,
-    },
-    {
         name: prefix + "_OutputDir",
         value: outputDir,
-    },
-    {
-        name: prefix + "_OutputFileName",
-        value: outputFileName,
     },
     {
         name: prefix + "_Frames",
         value: startFrame.toString() + "-" + endFrame.toString(),
     },
-    {
-        name: prefix + "_MultiFrameRendering",
-        value: multiFrameRendering === true ? "ON" : "OFF",
-    },
     ];
-    if (maxCpuUsagePercentage) {
-        parameterValuesList.push({
-            name: prefix + "_MaxCpuUsagePercentage",
-            value: maxCpuUsagePercentage,
-        });
-    }
-    if (isImageSeq) {
-        parameterValuesList.push({
-            name: prefix + "_ChunkSize",
-            value: chunkSize,
-        });
-    }
-    if (ignoreMissingDependencies) {
-        parameterValuesList.push({
-            name: prefix + "_IgnoreMissingDependencies",
-            value: ignoreMissingDependencies === true ? "ON" : "OFF",
-        })
-    }
     return {
         parameterValues: parameterValuesList
     };

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -1,7 +1,15 @@
+// Parameters that are declared once for the whole job instead of once per render queue item.
+// Listing a name here has two effects: generateStepParameterFragment skips emitting a per-item
+// definition for it, and generateStepTemplateFragment leaves "{{Param.<name>}}" references in the
+// step fragments unprefixed so that every step resolves them to the single job-level parameter.
 var JobParams = [
     "JobScriptDir",
     "CondaPackages",
-    "ProjectFile"
+    "ProjectFile",
+    "ChunkSize",
+    "MultiFrameRendering",
+    "MaxCpuUsagePercentage",
+    "IgnoreMissingDependencies"
 ]
 
 var paramPattern = "Param\\.";
@@ -154,7 +162,7 @@ function generateStepParameterFragment(bundlePath, isImageSeq, renderQueueIndex,
 
 // Generates the step chunk of the template for each step by loading the `step_<>_fragment.json`
 //      Replacing the parameters to be pointing to our per-renderQueueItem parameters and updating any parameters in the onRun
-function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds) {
+function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemIndex, compName, taskTimeoutSeconds, outputFileName) {
     var path = bundlePath + "/step_video_fragment.json";
     if (isImageSeq) {
         path = bundlePath + "/step_image_fragment.json";
@@ -176,8 +184,12 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
+        // Substitute the inlined values first so that the parameter renaming below does not see them
+        var scriptArg = scriptArgs[i]
+            .replace("{{Param.RenderQueueIndex}}", renderQueueItemIndex.toString())
+            .replace("{{Param.OutputFileName}}", outputFileName);
         // JobParams
-        replacedArgs.push(scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
+        replacedArgs.push(scriptArg.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
@@ -208,6 +220,13 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
  * Submit the selected render queue item
  **/
 function SubmitSelection(selection, selectionSettings) {
+    // The Submit button stays enabled at all times, so this is the only thing standing between an
+    // empty selection and a job template with no steps in it.
+    if (selection === null || selection.length === 0) {
+        adcAlert("Error: Select at least one render queue item to submit.", true);
+        return;
+    }
+
     // Calculate task run timeout in seconds
     var taskTimeoutSeconds = (selectionSettings.taskRunDays() * 24 * 60 * 60) + (selectionSettings.taskRunHours() * 60 * 60) + (selectionSettings.taskRunMinutes() * 60);
     // Validate timeout values during job submission
@@ -248,6 +267,21 @@ function SubmitSelection(selection, selectionSettings) {
     
     if (missingFiles.length > 0) {
         adcAlert("Error: Missing required files:\n" + missingFiles.join("\n"), true);
+        return;
+    }
+
+    // Checked before the project is saved and before any dependency scanning, so an oversized
+    // selection is refused immediately rather than after a wait.
+    if (selection.length > MAX_RENDER_QUEUE_ITEMS_PER_JOB) {
+        adcAlert(
+            "Error: " + selection.length + " render queue items are selected, but a single job supports at most " +
+            MAX_RENDER_QUEUE_ITEMS_PER_JOB + ".\n\n" +
+            "Each render queue item adds parameters to the job template that this submitter generates, and the " +
+            "Open Job Description specification allows a job template at most " + MAX_JOB_PARAMETERS + " parameters, " +
+            "shared with the parameters declared by the queue's environments.\n\n" +
+            "Please select " + MAX_RENDER_QUEUE_ITEMS_PER_JOB +
+            " or fewer render queue items and submit the rest as a separate job.", true
+        );
         return;
     }
 
@@ -376,9 +410,83 @@ function SubmitSelection(selection, selectionSettings) {
             },
             "default": "aftereffects=" + aftereffectsCondaVersion,
             "description": "If a queue accepts this parameter, it will create a conda virtual environment from it."
+        },
+        {
+            "name": "MultiFrameRendering",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": [
+                "ON",
+                "OFF"
+            ],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Enable or disable multi-frame rendering",
+                "groupLabel": "Multi-Frame Rendering"
+            },
+            "description": "Multi frame rendering settings"
+        },
+        {
+            "name": "MaxCpuUsagePercentage",
+            "type": "INT",
+            "userInterface": {
+                "control": "SPIN_BOX",
+                "label": "Max CPU Usage Percentage",
+                "groupLabel": "Multi-Frame Rendering"
+            },
+            "description": "Max Cpu Percentage to use with Multi-Frame Rendering, ignored if MFR is OFF",
+            "minValue": 1,
+            "maxValue": 100,
+            "default": 90
+        },
+        {
+            "name": "IgnoreMissingDependencies",
+            "type": "STRING",
+            "default": "OFF",
+            "allowedValues": [
+                "ON",
+                "OFF"
+            ],
+            "userInterface": {
+                "control": "DROPDOWN_LIST",
+                "label": "Ignore Missing Dependencies",
+                "groupLabel": "Ignore Missing Dependencies"
+            },
+            "description": "Allows render to continue without failing if referenced files are missing."
         }
         ]
     }
+
+    // ChunkSize only drives the image step's task parameter space, so it is left out entirely when
+    // nothing in the selection renders an image sequence.
+    var selectionHasImageSequence = false;
+    for (var i = 0; i < renderQueueItems.length; i++) {
+        if (dcUtil.isRenderQueueItemImageOutput(renderQueueItems[i][0])) {
+            selectionHasImageSequence = true;
+            break;
+        }
+    }
+    if (selectionHasImageSequence) {
+        jobParameterDefinitions.parameterDefinitions.push({
+            "name": "ChunkSize",
+            "type": "INT",
+            "userInterface": {
+                "control": "SPIN_BOX",
+                "label": "Frames Per Task",
+                "groupLabel": "Frame Range"
+            },
+            "description": "The chunk size of frames per task to render",
+            "minValue": 1,
+            "default": DEFAULT_FRAMESPERTASK
+        });
+    }
+    // These four settings apply to the whole job, so they are read once here rather than per
+    // render queue item, and contribute one parameter value each instead of one per step.
+    const jobFramesPerTask = selectionSettings.framesPerTask();
+    const jobMaxCpuUsagePercentage = selectionSettings.maxCpuUsagePercentage();
+    const jobMultiFrameRendering = selectionSettings.multiFrameRendering();
+    const jobIgnoreMissingDependencies = selectionSettings.ignoreMissingDependencies();
+
     const jobParameterValues = {
         parameterValues: [{
             name: "deadline:targetTaskRunStatus",
@@ -400,7 +508,25 @@ function SubmitSelection(selection, selectionSettings) {
             name: "ProjectFile",
             value: app.project.file.fsName,
         },
+        {
+            name: "MultiFrameRendering",
+            value: jobMultiFrameRendering === true ? "ON" : "OFF",
+        },
+        {
+            name: "MaxCpuUsagePercentage",
+            value: jobMaxCpuUsagePercentage,
+        },
+        {
+            name: "IgnoreMissingDependencies",
+            value: jobIgnoreMissingDependencies === true ? "ON" : "OFF",
+        },
         ]
+    }
+    if (selectionHasImageSequence) {
+        jobParameterValues.parameterValues.push({
+            name: "ChunkSize",
+            value: jobFramesPerTask,
+        });
     }
 
     const template = loadDefaultJobTemplate(bundle.fsName, submitBundleFile);
@@ -417,11 +543,6 @@ function SubmitSelection(selection, selectionSettings) {
             return;
         }
 
-        var stepFramesPerTask = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).framesPerTask();
-        var stepMaxCpuUsagePercentage = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).maxCpuUsagePercentage();
-        var stepMultiFrameRendering = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).multiFrameRendering();
-        var stepIgnoreMissingDependencies = selectionSettings.get(dcUtil.getRenderQueueItemID(renderQueueIndex)).ignoreMissingDependencies();
-
         var outputModule = renderQueueItem.outputModule(1).file;
         var outputPath = outputModule.fsName;
         var outputFile = outputModule.name;
@@ -436,17 +557,30 @@ function SubmitSelection(selection, selectionSettings) {
         var startFrame = frameRange.startFrame;
         var endFrame = frameRange.endFrame;
 
-        var dependencies = findJobAttachments(renderQueueItem.comp, stepIgnoreMissingDependencies); // list of filenames
+        var dependencies = findJobAttachments(renderQueueItem.comp, jobIgnoreMissingDependencies); // list of filenames
         var compName = dcUtil.removeIllegalCharacters(renderQueueItem.comp.name);
         var sanitizedOutputFolder = sanitizeFilePath(outputFolder);
 
         var outputFileNameNoRegex = getFileNameNoRegex(outputFile);
         var extension = getFileExtension(outputFileNameNoRegex);
         logger.debug("extension set to: " + extension, submitBundleFile);
-        var isImageSeq = dcUtil.isImage(extension);
+        // Uses the same check as selectionHasImageSequence above. The two must agree: that flag
+        // decides whether ChunkSize is declared, and this decides whether a step references it.
+        var isImageSeq = dcUtil.isRenderQueueItemImageOutput(renderQueueItem);
 
         var sanitizedOutputFileName = dcUtil.removePercentageFromFileName(outputFileNameNoRegex);
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
+
+        // The file name is written into the step's command rather than passed as a parameter, so it
+        // ends up inside an Open Job Description format string. "{{" there would be read as the start
+        // of a parameter reference instead of as part of the file name.
+        if (sanitizedOutputFileName.indexOf("{{") !== -1) {
+            adcAlert(
+                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\", which is not " +
+                "supported.\n\nPlease rename the output file in the render queue and try again.", true
+            );
+            return;
+        }
 
         // Push step asset references
         for (var d = 0; d < dependencies.length; d++) {
@@ -455,17 +589,9 @@ function SubmitSelection(selection, selectionSettings) {
         jobAssetReferences.assetReferences.outputs.directories.push(sanitizedOutputFolder);
 
         var parameterValues = generateParameterValues(
-            renderQueueIndex,
-            app.project.file.fsName,
             sanitizedOutputFolder,
-            sanitizedOutputFileName,
-            isImageSeq,
             startFrame,
             endFrame,
-            stepFramesPerTask,
-            stepMultiFrameRendering,
-            stepMaxCpuUsagePercentage,
-            stepIgnoreMissingDependencies,
             generateParameterName(renderQueueIndex, compName, "")
         );
         for (var p = 0; p < parameterValues.parameterValues.length; p++) {
@@ -477,7 +603,7 @@ function SubmitSelection(selection, selectionSettings) {
         stepOutputFolderParameters.push("{{Param." + generateParameterName(renderQueueIndex, compName, "OutputDir") + "}}");
 
         // Generates template and parameters for the current render queue item, then pushes them to the main template
-        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds);
+        var stepTemplate = generateStepTemplateFragment(bundle.fsName, isImageSeq, renderQueueIndex, compName, taskTimeoutSeconds, sanitizedOutputFileName);
         for (var s = 0; s < stepTemplate.steps.length; s++) {
             template.steps.push(stepTemplate.steps[s]);
         }
@@ -496,6 +622,24 @@ function SubmitSelection(selection, selectionSettings) {
                 template.parameterDefinitions.push(stepParameters.parameterDefinitions[p]);
             }
         }
+    }
+
+    // Backstop for MAX_RENDER_QUEUE_ITEMS_PER_JOB, which is calculated by hand. Firing means that
+    // number is now too high, and that the artist waited through dependency scanning for nothing.
+    if (template.parameterDefinitions.length > MAX_JOB_PARAMETERS) {
+        adcAlert(
+            "Error: The generated job template declares " + template.parameterDefinitions.length +
+            " parameters, more than the " + MAX_JOB_PARAMETERS + " an Open Job Description job template allows.\n\n" +
+            "Please select fewer render queue items and submit the rest as a separate job.", true
+        );
+        logger.error(
+            "Job template declared " + template.parameterDefinitions.length + " parameterDefinitions for " +
+            renderQueueItems.length + " render queue items, which exceeds the Open Job Description limit of " +
+            MAX_JOB_PARAMETERS + ". The selection was within MAX_RENDER_QUEUE_ITEMS_PER_JOB (" +
+            MAX_RENDER_QUEUE_ITEMS_PER_JOB + "), so that value is too high for the parameters this template " +
+            "now declares and needs recalculating.", submitBundleFile
+        );
+        return;
     }
 
     // Writes out final bundle files

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -180,16 +180,18 @@ function generateStepTemplateFragment(bundlePath, isImageSeq, renderQueueItemInd
     }
 
     stepTemplateObject.steps[0].name = generateParameterName(renderQueueItemIndex, compName, "");
+    const renderQueueIndexToken = "{{Param." + generateParameterName(renderQueueItemIndex, compName, "RenderQueueIndex") + "}}";
+    const outputFileNameToken = "{{Param." + generateParameterName(renderQueueItemIndex, compName, "OutputFileName") + "}}";
     // Replace any parameter names in onRun script
     const scriptArgs = stepTemplateObject.steps[0].script.actions.onRun.args;
     const replacedArgs = []
     for (var i = 0; i < scriptArgs.length; i++) {
-        // Substitute the inlined values first so that the parameter renaming below does not see them
-        var scriptArg = scriptArgs[i]
-            .replace("{{Param.RenderQueueIndex}}", renderQueueItemIndex.toString())
-            .replace("{{Param.OutputFileName}}", outputFileName);
+        // Rename first, so the regex never sees the output file name, which may contain "Param."
         // JobParams
-        replacedArgs.push(scriptArg.replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_"));
+        var scriptArg = scriptArgs[i].replace(paramPatternRegex, "Param." + generateParameterName(renderQueueItemIndex, compName, "") + "_");
+        // split/join keeps a $ in the output file name literal
+        scriptArg = scriptArg.split(renderQueueIndexToken).join(renderQueueItemIndex.toString());
+        replacedArgs.push(scriptArg.split(outputFileNameToken).join(outputFileName));
     }
     stepTemplateObject.steps[0].script.actions.onRun.args = replacedArgs;
     stepTemplateObject.steps[0].script.actions.onRun["timeout"] = taskTimeoutSeconds;
@@ -572,12 +574,12 @@ function SubmitSelection(selection, selectionSettings) {
         logger.debug("sanitizedOutputFileName is " + sanitizedOutputFileName, submitBundleFile);
 
         // The file name is written into the step's command rather than passed as a parameter, so it
-        // ends up inside an Open Job Description format string. "{{" there would be read as the start
-        // of a parameter reference instead of as part of the file name.
-        if (sanitizedOutputFileName.indexOf("{{") !== -1) {
+        // ends up inside an Open Job Description format string. "{{" or "}}" there would be read as
+        // parameter reference delimiters instead of as part of the file name.
+        if (sanitizedOutputFileName.indexOf("{{") !== -1 || sanitizedOutputFileName.indexOf("}}") !== -1) {
             adcAlert(
-                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\", which is not " +
-                "supported.\n\nPlease rename the output file in the render queue and try again.", true
+                "Error: The output file name for " + renderQueueItem.comp.name + " contains \"{{\" or \"}}\", which " +
+                "is not supported.\n\nPlease rename the output file in the render queue and try again.", true
             );
             return;
         }

--- a/src/ui/SubmitterUI.jsx
+++ b/src/ui/SubmitterUI.jsx
@@ -51,54 +51,62 @@ function buildUI(thisObj) {
     const controlsPanel = controlsGroup.add("panel", undefined, "");
     controlsPanel.alignment = ['fill', 'top'];
 
-    // Container with settings to modify comp-specific settings
-    const perCompSettingsGroup = controlsPanel.add("panel", undefined, "Render Queue Item Settings");
-    perCompSettingsGroup.orientation = "column";
-    perCompSettingsGroup.alignment = ['fill', 'top'];
-    perCompSettingsGroup.alignChildren = ['left', 'top'];
+    // These settings apply to the whole submission, not to individual render queue items. Not named
+    // "Render Settings" because After Effects already uses that for a per-item concept.
+    const jobRenderOptionsPanel = controlsPanel.add("panel", undefined, "Job Render Options");
+    jobRenderOptionsPanel.orientation = "column";
+    jobRenderOptionsPanel.alignment = ['fill', 'top'];
+    jobRenderOptionsPanel.alignChildren = ['left', 'top'];
 
     // Setting up frame per task GUI
-    const framesPerTaskGroup = perCompSettingsGroup.add("group", undefined, "");
+    const framesPerTaskGroup = jobRenderOptionsPanel.add("group", undefined, "");
     framesPerTaskGroup.orientation = "row";
     framesPerTaskGroup.alignment = ['fill', 'top'];
     framesPerTaskGroup.alignChildren = ['left', 'center'];
 
-    const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task");
+    // Always enabled, because this is a project level setting rather than a per composition one.
+    // The label says which outputs it affects so video-only artists do not expect an effect.
+    const framesPerTaskLabel = framesPerTaskGroup.add("statictext", undefined, "Frames per task (img seq only)");
     framesPerTaskLabel.alignment = ['left', 'center'];
-    framesPerTaskLabel.helpTip = "The number of frames per task. Only affects image sequence output.";
+    framesPerTaskLabel.helpTip = "The number of frames per task, applied to every image sequence in the submission. Has no effect on video output.";
 
     const framesPerTaskTextBox = framesPerTaskGroup.add("edittext", undefined, "");
     framesPerTaskTextBox.alignment = ['fill', 'top'];
     framesPerTaskTextBox.helpTip = framesPerTaskLabel.helpTip;
+    framesPerTaskTextBox.text = uiSettingsState.framesPerTask();
 
     function onFramesPerTaskChanged() {
-        if (list.selection == null) {
-            return;
+        // Frames per task is submitted as the ChunkSize job parameter, which the job template
+        // declares with a minimum of 1, and is used as the stride of the step's frame range.
+        // Strip non-digits so a stray minus sign or trailing text can't reach the template, then
+        // floor the result so an explicit "0" can't produce an invalid range such as "1-100:0".
+        const minFramesPerTask = 1;
+        const maxFramesPerTask = 9999;
+        framesPerTaskTextBox.text = framesPerTaskTextBox.text.replace(/[^0-9]/g, "");
+        var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
+        if (isNaN(newFramesPerTaskValue)) {
+            newFramesPerTaskValue = uiSettingsState.framesPerTask();
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            var newFramesPerTaskValue = parseInt(framesPerTaskTextBox.text);
-            if (isNaN(newFramesPerTaskValue)) {
-                newFramesPerTaskValue = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).framesPerTask();
-            }
-            if (newFramesPerTaskValue > 9999) {
-                newFramesPerTaskValue = 9999;
-            }
-            framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setFramesPerTask(newFramesPerTaskValue);
+        if (newFramesPerTaskValue < minFramesPerTask) {
+            newFramesPerTaskValue = minFramesPerTask;
         }
+        if (newFramesPerTaskValue > maxFramesPerTask) {
+            newFramesPerTaskValue = maxFramesPerTask;
+        }
+        framesPerTaskTextBox.text = newFramesPerTaskValue.toString();
+        uiSettingsState.setFramesPerTask(newFramesPerTaskValue);
     }
     framesPerTaskTextBox.onChange = onFramesPerTaskChanged;
 
     // Multi-frame rendering (MFR) GUI
-    const mfrGroup = perCompSettingsGroup.add("group", undefined, "");
+    const mfrGroup = jobRenderOptionsPanel.add("group", undefined, "");
     mfrGroup.orientation = "column";
     mfrGroup.alignment = ['fill', 'top'];
     mfrGroup.alignChildren = ['left', 'center'];
     mfrGroup.margins = 5;
 
     const mfrCheckBox = mfrGroup.add("checkbox", undefined, "Enable Multi-Frame Rendering");
-    mfrCheckBox.value = DEFAULT_MULTI_FRAME_RENDERING;
+    mfrCheckBox.value = uiSettingsState.multiFrameRendering();
 
     const maxCpuUsagePercentageGroup = mfrGroup.add("group", undefined, "");
     maxCpuUsagePercentageGroup.orientation = "row";
@@ -112,82 +120,68 @@ function buildUI(thisObj) {
     const maxCpuUsagePercentageTextBox = maxCpuUsagePercentageGroup.add("edittext", undefined, "N/A");
     maxCpuUsagePercentageTextBox.alignment = ['fill', 'top'];
     maxCpuUsagePercentageTextBox.helpTip = maxCpuUsagePercentageLabel.helpTip;
-    maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
-    maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageTextBox.enabled ? DEFAULT_MAX_CPU_USAGE_PERCENTAGE : "N/A";
+
+    // Max CPU usage is only meaningful while MFR is on, so the control follows the checkbox. This
+    // only reads the stored percentage, so toggling MFR off and back on does not disturb it.
+    function refreshMaxCpuUsagePercentageControl() {
+        maxCpuUsagePercentageTextBox.enabled = mfrCheckBox.value;
+        maxCpuUsagePercentageTextBox.text = mfrCheckBox.value ?
+            uiSettingsState.maxCpuUsagePercentage().toString() :
+            "N/A";
+    }
+    refreshMaxCpuUsagePercentageControl();
 
     function onMaxCpuUsagePercentageChanged() {
+        // The job template declares MaxCpuUsagePercentage with a minimum of 1, so reject 0 along
+        // with non-numeric and out-of-range input rather than persisting a value the template rejects.
+        const minMaxCpuUsagePercentage = 1;
         const maxCpuUsagePercentageValue = Math.abs(parseInt(maxCpuUsagePercentageTextBox.text));
-        if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue > 100) {
+        if (isNaN(maxCpuUsagePercentageValue) || maxCpuUsagePercentageValue < minMaxCpuUsagePercentage || maxCpuUsagePercentageValue > 100) {
             maxCpuUsagePercentageTextBox.text = DEFAULT_MAX_CPU_USAGE_PERCENTAGE;
         } else {
             // Need to reassign in case input string is a number followed my random characters
             // since parseInt parses the first number it finds in a provided string.
             maxCpuUsagePercentageTextBox.text = maxCpuUsagePercentageValue;
         }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
-        }
+        uiSettingsState.setMaxCpuUsagePercentage(parseInt(maxCpuUsagePercentageTextBox.text));
     }
     maxCpuUsagePercentageTextBox.onChange = onMaxCpuUsagePercentageChanged;
 
     // Disable max CPU percentage textbox when multi frame rendering is disabled
     function onMfrCheckBoxClicked() {
-        const isMfrChecked = mfrCheckBox.value;
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            var RQIID = dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex);
-            if (!isMfrChecked) {
-                maxCpuUsagePercentageTextBox.text = "N/A";
-                uiSettingsState.get(RQIID).setMultiFrameRendering(false);
-            } else {
-                maxCpuUsagePercentageTextBox.text = uiSettingsState.get(RQIID).maxCpuUsagePercentage();
-                uiSettingsState.get(RQIID).setMultiFrameRendering(true);
-            }
-        }
-        maxCpuUsagePercentageTextBox.enabled = isMfrChecked;
+        uiSettingsState.setMultiFrameRendering(mfrCheckBox.value);
+        refreshMaxCpuUsagePercentageControl();
     }
     mfrCheckBox.onClick = onMfrCheckBoxClicked;
 
     // Ignore Missing Dependencies GUI
-    const ignoreMissingDepsGroup = perCompSettingsGroup.add("group", undefined, "");
+    const ignoreMissingDepsGroup = jobRenderOptionsPanel.add("group", undefined, "");
     ignoreMissingDepsGroup.orientation = "column";
     ignoreMissingDepsGroup.alignment = ['fill', 'top'];
     ignoreMissingDepsGroup.alignChildren = ['left', 'center'];
 
     const ignoreMissingDepsCheckBox = ignoreMissingDepsGroup.add("checkbox", undefined, "Ignore Missing Dependencies");
     ignoreMissingDepsGroup.orientation = "column";
+    ignoreMissingDepsCheckBox.value = uiSettingsState.ignoreMissingDependencies();
 
     // Ignore Missing Dependencies Checkbox
     function onIgnoreMissingDepsCheckBoxClicked() {
-        if (list.selection == null) {
-            return;
-        }
-        const selectionItem = dcUtil.getSelection(list);
-        if (selectionItem) {
-            uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex)).setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
-        }
+        uiSettingsState.setIgnoreMissingDependencies(ignoreMissingDepsCheckBox.value);
     }
     ignoreMissingDepsCheckBox.onClick = onIgnoreMissingDepsCheckBoxClicked;
 
-    function isRenderQueueItemImageOutput(renderQueueItem) {
-        if (renderQueueItem.numOutputModules === 1) {
-            const outputModule = renderQueueItem.outputModule(1).file;
-            if (outputModule != null) {
-                const outputFileNameNoRegex = getFileNameNoRegex(outputModule.name);
-                const extension = getFileExtension(outputFileNameNoRegex);
-                return dcUtil.isImage(extension);
-            }
-        }
-        return false;
+    // Re-reads the render options from the project, which is needed because they go stale when a
+    // different project is opened. Reading a setting the project never stored seeds it with its
+    // default, which marks the project dirty.
+    function refreshRenderSettingControls() {
+        framesPerTaskTextBox.text = uiSettingsState.framesPerTask();
+        mfrCheckBox.value = uiSettingsState.multiFrameRendering();
+        ignoreMissingDepsCheckBox.value = uiSettingsState.ignoreMissingDependencies();
+        refreshMaxCpuUsagePercentageControl();
     }
 
-    const globalSettingsGroup = controlsPanel.add("panel", undefined, "Global Job Settings");
-    globalSettingsGroup.orientation = "column";
-    globalSettingsGroup.alignment = ['fill', 'top'];
-    globalSettingsGroup.alignChildren = ['left', 'top'];
     // Add Timeouts settings group
-    const timeoutsPanel = globalSettingsGroup.add("panel", undefined, "Timeouts");
+    const timeoutsPanel = controlsPanel.add("panel", undefined, "Timeouts");
     timeoutsPanel.orientation = "column";
     timeoutsPanel.alignment = ['fill', 'top'];
     timeoutsPanel.alignChildren = ['left', 'center'];
@@ -284,15 +278,13 @@ function buildUI(thisObj) {
     const submitButton = controlsGroup.add("button", undefined, "Submit");
     submitButton.onClick = function () {
         if (getPythonExecutable()) {
-            if (list.selection === null) {
-                return;
-            }
+            // The button is deliberately always enabled; SubmitSelection reports what is wrong, so
+            // an unexpected UI state cannot leave the artist with a button that does nothing.
             SubmitSelection(list.selection, uiSettingsState);
             list.selection = null;
         }
     }
     submitButton.alignment = 'right';
-    submitButton.enabled = false;
 
     function updateList() {
         const bounds = list == null ? undefined : list.bounds;
@@ -306,10 +298,11 @@ function buildUI(thisObj) {
         newList.preferredSize.height = 200;
         newList.preferredSize.width = 500;
 
-        // Disable all controls if the render queue is empty
-        // This forces the user to click "refresh" when a new project is opened and populate the list
-        controlsGroup.enabled = app.project.renderQueue.numItems > 0;
-        // Also populate timeout settings because the values could be stale if a new project has been opened since the last refresh
+        // The settings apply to the job rather than to individual render queue items, and they
+        // persist across submissions, so they stay editable even while the render queue is empty.
+        // Repopulate them here because they are stored in the project and a different project may
+        // have been opened since the last refresh.
+        refreshRenderSettingControls();
         taskRunDaysInput.text = uiSettingsState.taskRunDays();
         taskRunHoursInput.text = uiSettingsState.taskRunHours();
         taskRunMinutesInput.text = uiSettingsState.taskRunMinutes();
@@ -325,8 +318,6 @@ function buildUI(thisObj) {
             var item = newList.add('item', i.toString());
             item.renderQueueIndex = i;
             item.compId = rqi.comp.id;
-            // Create a default entry for each comp as needed.
-            uiSettingsState.get(i);
             item.subItems[0].text = rqi.comp.name;
 
             // Calculate frame range using the utility function
@@ -345,68 +336,16 @@ function buildUI(thisObj) {
             }
         }
 
-        dcUtil.deleteUnusedMetadata(uiSettingsState.rqiXmpPath);
-
         if (list != null) {
             listGroup.remove(list);
         }
         list = newList;
 
-        function onSelectionChange() {
-            const selection = list.selection;
-            perCompSettingsGroup.enabled = false;
-
-            framesPerTaskTextBox.text = "";
-            mfrCheckBox.value = false;
-            maxCpuUsagePercentageTextBox.text = "";
-            ignoreMissingDepsCheckBox.value = false;
-
-            if (selection === null) {
-                submitButton.enabled = false;
-            } else {
-                submitButton.enabled = true;
-            }
-
-            if (selection === null || selection.length !== 1) {
-                return;
-            }
-            const selectionItem = selection[0];
-            perCompSettingsGroup.enabled = true;
-            logger.warning("Selected Comp is: " + app.project.renderQueue.item(selectionItem.renderQueueIndex).comp.name);
-
-            const settings = uiSettingsState.get(dcUtil.getRenderQueueItemID(selectionItem.renderQueueIndex));
-            if (settings === undefined) {
-                logger.warning("Could not find settings for : " + selectionItem.compId);
-                return;
-            }
-
-            const imageOutput = isRenderQueueItemImageOutput(app.project.renderQueue.item(selectionItem.renderQueueIndex));
-            if (imageOutput) {
-                framesPerTaskTextBox.text = settings.framesPerTask();
-                framesPerTaskTextBox.enabled = true;
-                framesPerTaskTextBox.onChange();
-            } else {
-                framesPerTaskTextBox.text = "Selection is not image sequence";
-                framesPerTaskTextBox.enabled = false;
-            }
-            maxCpuUsagePercentageTextBox.text = settings.maxCpuUsagePercentage();
-            maxCpuUsagePercentageTextBox.onChange();
-            mfrCheckBox.value = settings.multiFrameRendering();
-            mfrCheckBox.onClick();
-            ignoreMissingDepsCheckBox.value = settings.ignoreMissingDependencies();
-            ignoreMissingDepsCheckBox.onClick();
-        }
-        list.onChange = onSelectionChange;
+        // No onChange handler needed: nothing in the panel depends on which items are selected.
         list.selection = null;
-        onSelectionChange();
     }
 
     updateList();
-    if (list.selection != null && list.selection.length === 1) {
-        const selectionItem = list.selection[0];
-        const renderQueueItem = app.project.renderQueue.item(selectionItem.renderQueueIndex);
-        framesPerTaskTextBox.enabled = isRenderQueueItemImageOutput(renderQueueItem);
-    }
     refreshButton.onClick = function () {
         updateList();
     }

--- a/src/utils/CompositionSettings.jsx
+++ b/src/utils/CompositionSettings.jsx
@@ -1,13 +1,11 @@
 function UiSettingsState() {
     /**
-     * Container that stores all of the configurable properties in the submitter UI
+     * Container that stores all of the configurable properties in the submitter UI.
+     * Every setting here applies to the job as a whole rather than to an individual
+     * render queue item.
      */
 
-    // Contains UiSettingsStore objects that store comp-specific settings
-    this.settings = {}
-
     this.xmpPath = dcUtil.composeXMPPath(DEADLINECLOUD_SETTINGS_ROOT, "UiSettingsState");
-    this.rqiXmpPath = dcUtil.composeXMPPath(this.xmpPath, "rqiSpecificSettings");
 
     // () -> bool
     this.taskRunTimeoutEnabled = function() {
@@ -42,55 +40,35 @@ function UiSettingsState() {
         dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_TASK_RUN_TIMEOUT_MINUTES), value);
     }
 
-}
-
-function UiSettingsStore(xmpPathPrefix, name) {
-    /**
-     * Stores comp-specific settings for the comp with given name.
-     */
-    this.name = name;
-    this.xmpPathPrefix = dcUtil.composeXMPPath(xmpPathPrefix, name);
-
     this.framesPerTask = function () {
-        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_FRAMESPERTASK), DEFAULT_FRAMESPERTASK);
     }
     this.setFramesPerTask = function (value) {
-        logger.warning("(" + this.name + ") Setting framesPerTask to " + value);
-        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_FRAMESPERTASK), value);
+        logger.warning("Setting framesPerTask to " + value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_FRAMESPERTASK), value);
     }
 
     this.multiFrameRendering = function () {
-        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MULTI_FRAME_RENDERING), DEFAULT_MULTI_FRAME_RENDERING);
     }
     this.setMultiFrameRendering = function (value) {
-        logger.warning("(" + this.name + ") Setting multiFrameRendering to " + value);
-        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
+        logger.warning("Setting multiFrameRendering to " + value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MULTI_FRAME_RENDERING), value);
     }
 
     this.maxCpuUsagePercentage = function () {
-        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
-
+        return dcUtil.getNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), DEFAULT_MAX_CPU_USAGE_PERCENTAGE);
     }
     this.setMaxCpuUsagePercentage = function (value) {
-        logger.warning("(" + this.name + ") Setting maxCpuUsagePercentage to " + value);
-        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
+        logger.warning("Setting maxCpuUsagePercentage to " + value);
+        dcUtil.saveNumberMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_MAX_CPU_USAGE_PERCENTAGE), value);
     }
 
     this.ignoreMissingDependencies = function () {
-        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
+        return dcUtil.getBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), DEFAULT_IGNORE_MISSING_DEPENDENCIES);
     }
     this.setIgnoreMissingDependencies = function (value) {
-        logger.warning("(" + this.name + ") Setting ignoreMissingDependencies to " + value)
-        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPathPrefix, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
+        logger.warning("Setting ignoreMissingDependencies to " + value);
+        dcUtil.saveBoolMetadata(dcUtil.composeXMPPath(this.xmpPath, DEADLINECLOUD_IGNORE_MISSING_DEPENDENCIES), value);
     }
-}
-
-UiSettingsState.prototype.get = function (RQIID) {
-    /**
-     * Gets UISettingsStore associated with given RQIID, or creates a new default one if it doesn't exit
-     */
-    if (!this.settings[RQIID]) {
-        this.settings[RQIID] = new UiSettingsStore(this.rqiXmpPath, RQIID);
-    }
-    return this.settings[RQIID]
 }

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -20,9 +20,6 @@ if (typeof SUPPORTED_VERSIONS === "undefined") {
 if (typeof DEADLINECLOUD_SETTINGS_ROOT === "undefined") {
     const DEADLINECLOUD_SETTINGS_ROOT = "xmp:DeadlineCloudSubmitter";
 }
-if (typeof DEADLINECLOUD_SEPARATEFRAMESINTOTASKS === "undefined") {
-    const DEADLINECLOUD_SEPARATEFRAMESINTOTASKS = "separateFramesIntoTasks";
-}
 if (typeof DEADLINECLOUD_FRAMESPERTASK === "undefined") {
     const DEADLINECLOUD_FRAMESPERTASK = "framePerTask";
 }
@@ -70,6 +67,28 @@ if (typeof DEFAULT_MAX_CPU_USAGE_PERCENTAGE === "undefined") {
 }
 if (typeof DEFAULT_IGNORE_MISSING_DEPENDENCIES === "undefined") {
     const DEFAULT_IGNORE_MISSING_DEPENDENCIES = false;
+}
+// The most parameter definitions the Open Job Description specification allows a job template to
+// declare. The service checks this against the job template's parameters merged with those of the
+// queue's environments, so the two share this budget.
+if (typeof MAX_JOB_PARAMETERS === "undefined") {
+    const MAX_JOB_PARAMETERS = 50;
+}
+// The most render queue items this submitter puts into a single job, calculated from
+// MAX_JOB_PARAMETERS because the template grows by a fixed number of parameters per item:
+//   7 per job: the JobParams names in SubmitBundle.jsx. ChunkSize is only declared when the
+//     submission contains an image sequence; counting it always keeps this one number valid for any
+//     mix of output types, at the cost of one item for video only submissions.
+//   2 per item: OutputDir and Frames. The render queue index and output file name are written into
+//     the step's command instead, see generateStepTemplateFragment.
+// The remaining budget belongs to the queue's environments, and the submitter cannot know which
+// queue the artist will pick. 15 items leaves 50 - 7 - (2 * 15) = 13 parameters for them, where the
+// Conda queue environments the Deadline Cloud console creates need 1 to 2. Submitting to a queue
+// whose environments declare more than that reserve fails in CreateJob rather than here.
+// Recalculate if either count changes. README.md and docs/user_guide/using-submitter.md also state
+// this limit.
+if (typeof MAX_RENDER_QUEUE_ITEMS_PER_JOB === "undefined") {
+    const MAX_RENDER_QUEUE_ITEMS_PER_JOB = 15;
 }
 
 var FootageTypes = {
@@ -605,8 +624,8 @@ function __generateUtil() {
 
     /**
      * Extracts frame number, prefix, and suffix for single frame in image sequence.
-     * @param {string} fileName 
-     * @returns Object containing prefix, name, and suffix 
+     * @param {string} fileName
+     * @returns Object containing prefix, name, and suffix
      */
     function getImageSequenceInformation(fileName) {
         var regex = /^(.*?)(\d*)(\D*)$/;
@@ -1038,52 +1057,21 @@ function __generateUtil() {
         return true;
     }
 
-    function getSelection(list) {
-        if (list.selection.length >= 1) {
-            return list.selection[0];
+    /**
+     * Reports whether the given render queue item renders to an image sequence.
+     * Items with no output module, or more than one, are not treated as image sequences.
+     * @param {Object} renderQueueItem
+     * @returns {boolean}
+     */
+    function isRenderQueueItemImageOutput(renderQueueItem) {
+        if (renderQueueItem == null || renderQueueItem.numOutputModules !== 1) {
+            return false;
         }
-    }
-
-    function getRenderQueueItemID(renderQueueIndex) {
-        /** Calculates an ID for the Render Queue Item with the given index in the render queue
-         * Not guaranteed to be unique if render queue items are reordered
-         */
-        return "_" + renderQueueIndex.toString() + "_" + app.project.renderQueue.item(renderQueueIndex).comp.id;
-    }
-
-    function getXMPPathLeaf(path) {
-        // The backslash is needed for this regex, so we need to skip SonarQube scan
-        const regex = /xmp:([^\/]+)$/;
-        return regex.exec(path)[1];
-    }
-
-    function deleteUnusedMetadata(renderMetadataRoot) {
-        var metadata = new XMPMeta(app.project.xmpPacket);
-        var paths = []
-        var iterator = metadata.iterator(XMPConst.ITERATOR_JUST_CHILDREN, XMPConst.NS_XMP, renderMetadataRoot);
-        var property;
-        while (property = iterator.next()) {
-            paths.push(property.path);
+        const outputModule = renderQueueItem.outputModule(1).file;
+        if (outputModule == null) {
+            return false;
         }
-        var ids = []
-        for (var i = 1; i <= app.project.renderQueue.numItems; i++) {
-            ids.push(getRenderQueueItemID(i));
-        }
-        for (var i = 0; i < paths.length; i++) {
-            var presentInArray = false;
-            var currentPath = paths[i];
-            for (var j = 0; j < ids.length; j++) {
-                var renderQueueID = ids[j];
-                if (getXMPPathLeaf(currentPath) === renderQueueID) {
-                    presentInArray = true;
-                    break;
-                }
-            }
-            if (!presentInArray) {
-                metadata.deleteProperty(XMPConst.NS_XMP, currentPath);
-            }
-        }
-        app.project.xmpPacket = metadata.serialize();
+        return isImage(getFileExtension(getFileNameNoRegex(outputModule.name)));
     }
 
     return {
@@ -1128,13 +1116,11 @@ function __generateUtil() {
         "getTempFolder": getTempFolder,
         "calculateFrameRange": calculateFrameRange,
         "validateTimeoutValues": validateTimeoutValues,
-        "getSelection": getSelection,
-        "getRenderQueueItemID": getRenderQueueItemID,
+        "isRenderQueueItemImageOutput": isRenderQueueItemImageOutput,
         "composeXMPPath": composeXMPPath,
         "saveToMetadata": saveToMetadata,
         "loadFromMetadata": loadFromMetadata,
         "metadataKeyExists": metadataKeyExists,
-        "deleteUnusedMetadata": deleteUnusedMetadata,
         "determineFootageType": determineFootageType,
         "getFilePathsFromFootageItem": getFilePathsFromFootageItem,
         "isVideo": isVideo,


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-after-effects/issues/315

### What was the problem/requirement? (What/Why)

The generated job template declared 8 parameters for every render queue item. The Open Job Description specification allows a job template at most 50 parameter definitions, shared with the parameters declared by the queue's environments, so a job could hold only 5 compositions.

### What was the solution? (How)

Cut the parameters a composition costs from 8 to 2, which fits 15 compositions in a job:

- Frames per task, multi-frame rendering, max CPU usage and ignore missing dependencies are declared once per job instead of once per render queue item. `ChunkSize` is only declared when the submission contains an image sequence.
- The render queue index and output file name are written into each step's command rather than being parameters. The index cannot change without invalidating the rest of that step's values, and the file name was already `HIDDEN`.
- Output directory and frame range stay per composition parameters: path mapping only applies to `PATH` parameters, and re-rendering a subrange is a real use case.

The submitter refuses an oversized selection before saving the project or scanning dependencies, and checks the assembled template as a backstop in case parameters are ever added in the future that invalidate the 15 comp limit.

### What is the impact of this change?

15 compositions per job instead of 5. Frames per task and multi-frame rendering are now editable with several compositions selected, and each composition shows 2 controls in the Deadline submitter instead of 4. Options that earlier versions stored per composition return to their defaults.

Smaller changes: the panel is renamed "Job Render Options" because After Effects already uses "Render Settings" for a per item concept, frames per task is labelled "(img seq only)" instead of being disabled, Submit validates on click rather than being enabled and disabled, and `image_template.json` / `video_template.json` were brought in sync with what the submitter emits.

### How was this change tested?

`hatch run test` and `hatch run lint-check` pass, and `dist/DeadlineCloudSubmitter.jsx` was regenerated and syntax checked.

On macOS with After Effects 26 and 25:
- A 10 composition job mixing image sequences and video declares 27 parameters, down from 47, and rendered successfully.
- A 15 composition job declares 37 parameters over 15 steps, leaving 13 of the 50 for the queue's environments.
- Selecting 16 compositions is refused immediately, before the save prompt and the dependency scan.
- Checked in the exported bundles that the index and file name appear as literals in each step's command, that image steps chunk by `ChunkSize` while video steps have no `parameterSpace`, and that output directory and frame range remain parameters.

Did the same test on Windows AE 25 and 26 and 24, it worked.

#### If you modified source files, did you run the Python script to update the files under the dist folder?

Yes.

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

Not modified.

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

No files were added to or removed from `dist/`.

### Was this change documented?

Yes. The README and `docs/user_guide/using-submitter.md` state the 15 item limit and describe the settings as job wide, and a troubleshooting entry was added for the error raised when a queue's environments push the merged parameter count over 50.

### Is this a breaking change?

Yes. Render options stored per composition are no longer read and return to their defaults, so artists who relied on different values per composition need to submit those compositions as separate jobs. The render queue index and output file name are no longer job parameters and cannot be changed in the Deadline submitter.

### Photos

#### Error case
<img width="334" height="533" alt="Screenshot 2026-08-03 at 11 33 16 AM" src="https://github.com/user-attachments/assets/7c5b3255-a1ab-4fcd-9c77-084d91d60106" />

#### Happy case
<img width="1512" height="947" alt="Screenshot 2026-08-03 at 11 34 00 AM" src="https://github.com/user-attachments/assets/9b2fff70-d89c-4f66-8623-36565587f204" />

Once the OpenJD limitation on parameter definitions goes up to 200 we can update the blocked from 15 to 60 compositions
---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._