### PR TITLE
fix: avoid Terminal cold-start race on macOS submission

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -2109,6 +2109,29 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 }
 
 /**
+ * Launches the Deadline Cloud GUI submitter on macOS without using Terminal.
+ *
+ * After Effects inherits a minimal launchd PATH from Finder that does not
+ * include the deadline CLI. Routing through Terminal.app to source the user's
+ * shell profile created a race: on a cold start the shell may not be ready
+ * before `do script` fires, silently dropping the command.
+ *
+ * Instead, system python3 (/usr/bin/python3) — which is always on the launchd
+ * PATH — runs launch_deadline.py, which locates the deadline binary by its
+ * well-known installer path and launches gui-submit as a detached process.
+ *
+ * @param {String} bundlePath         path to the job bundle directory
+ * @param {String} pythonExecutable   python3 executable found by getPythonExecutable()
+ **/
+function launchDeadlineGUI(bundlePath, pythonExecutable) {
+    const launcherScript = scriptFolder +
+        "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/launch_deadline.py";
+    const cmd = pythonExecutable + " \"" + launcherScript + "\" \"" + bundlePath + "\"";
+    logger.debug("Launching Deadline GUI via Python launcher: " + cmd, submitBundleFile);
+    system.callSystem(cmd);
+}
+
+/**
  * Submit the selected render queue item
  **/
 function SubmitSelection(selection, selectionSettings) {
@@ -2139,6 +2162,7 @@ function SubmitSelection(selection, selectionSettings) {
         "scripts/font_manager.py",
         "scripts/call_aerender.py",
         "scripts/create_output_directory.py",
+        "scripts/launch_deadline.py",
         "template.json",
         "image_template.json",
         "video_template.json",
@@ -2573,20 +2597,14 @@ function SubmitSelection(selection, selectionSettings) {
             output = logFile.read();
             logFile.close();
         }
+        if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
+            adcAlert(
+                "ERROR:" + output, true
+            );
+            logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
+        }
     } else {
-        // Execute the command using a bash in the interactive mode so it loads the bash profile to set
-        // the PATH correctly.
-        const shellPath = $.getenv("SHELL") || "/bin/bash";
-        cmd =
-            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
-        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
-    }
-    if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
-        adcAlert(
-            "ERROR:" + output, true
-        );
-        logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
+        launchDeadlineGUI(bundle.fsName, getPythonExecutable());
     }
 }
 

--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/launch_deadline.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/launch_deadline.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+macOS launcher for the Deadline Cloud GUI submitter.
+
+The submitter's ExtendScript runs inside After Effects, which is launched from
+the Dock or Finder and therefore inherits a minimal launchd PATH that does not
+include the deadline CLI. This script is called by the submitter via
+system.callSystem() using the system python3 (/usr/bin/python3 or
+/usr/local/bin/python3), which IS on the launchd PATH.
+
+It finds the deadline binary by its well-known installer path rather than by
+PATH lookup, then launches gui-submit as a detached process. This avoids the
+Terminal cold-start race entirely: no Terminal window is opened, no interactive
+shell needs to initialize, and there is no timing dependency.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def find_deadline_binary():
+    """
+    Locate the deadline executable without relying on PATH.
+
+    The Deadline Cloud installer places a self-contained PyInstaller binary at
+    ~/DeadlineCloudSubmitter/DeadlineClient/deadline. This is checked first.
+    Falls back to shutil.which() for pip-installed or developer setups where
+    deadline may be on the system PATH.
+    """
+    user_install = os.path.join(
+        os.path.expanduser("~"),
+        "DeadlineCloudSubmitter",
+        "DeadlineClient",
+        "deadline",
+    )
+    if os.path.isfile(user_install) and os.access(user_install, os.X_OK):
+        return user_install
+
+    return shutil.which("deadline")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: launch_deadline.py <bundle_path>", file=sys.stderr)
+        sys.exit(1)
+
+    bundle_path = sys.argv[1]
+    deadline = find_deadline_binary()
+
+    if not deadline:
+        print(
+            "Error: Could not find the deadline executable.\n"
+            "Ensure the Deadline Cloud submitter is installed at "
+            "~/DeadlineCloudSubmitter/DeadlineClient/deadline, "
+            "or that 'deadline' is on your PATH.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Double-fork so the deadline GUI process is fully detached from the
+    # python3 process that system.callSystem() is waiting on. Without this,
+    # AE blocks until deadline exits because the child inherits the same
+    # process group. The first fork lets python3 exit immediately; the
+    # grandchild (deadline) is re-parented to launchd and runs independently.
+    pid = os.fork()
+    if pid == 0:
+        # Child: start a new session to detach from AE's process group,
+        # then exec deadline. os.setsid() is the key call — it prevents
+        # the grandchild from receiving signals sent to AE's process group.
+        os.setsid()
+        subprocess.Popen(
+            [
+                deadline,
+                "bundle",
+                "gui-submit",
+                bundle_path,
+                "--output",
+                "json",
+                "--install-gui",
+                "--submitter-info",
+                "submitter_name=After Effects",
+            ]
+        )
+        os._exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/launch_deadline.py
+++ b/src/scripts/launch_deadline.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+macOS launcher for the Deadline Cloud GUI submitter.
+
+The submitter's ExtendScript runs inside After Effects, which is launched from
+the Dock or Finder and therefore inherits a minimal launchd PATH that does not
+include the deadline CLI. This script is called by the submitter via
+system.callSystem() using the system python3 (/usr/bin/python3 or
+/usr/local/bin/python3), which IS on the launchd PATH.
+
+It finds the deadline binary by its well-known installer path rather than by
+PATH lookup, then launches gui-submit as a detached process. This avoids the
+Terminal cold-start race entirely: no Terminal window is opened, no interactive
+shell needs to initialize, and there is no timing dependency.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def find_deadline_binary():
+    """
+    Locate the deadline executable without relying on PATH.
+
+    The Deadline Cloud installer places a self-contained PyInstaller binary at
+    ~/DeadlineCloudSubmitter/DeadlineClient/deadline. This is checked first.
+    Falls back to shutil.which() for pip-installed or developer setups where
+    deadline may be on the system PATH.
+    """
+    user_install = os.path.join(
+        os.path.expanduser("~"),
+        "DeadlineCloudSubmitter",
+        "DeadlineClient",
+        "deadline",
+    )
+    if os.path.isfile(user_install) and os.access(user_install, os.X_OK):
+        return user_install
+
+    return shutil.which("deadline")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: launch_deadline.py <bundle_path>", file=sys.stderr)
+        sys.exit(1)
+
+    bundle_path = sys.argv[1]
+    deadline = find_deadline_binary()
+
+    if not deadline:
+        print(
+            "Error: Could not find the deadline executable.\n"
+            "Ensure the Deadline Cloud submitter is installed at "
+            "~/DeadlineCloudSubmitter/DeadlineClient/deadline, "
+            "or that 'deadline' is on your PATH.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Double-fork so the deadline GUI process is fully detached from the
+    # python3 process that system.callSystem() is waiting on. Without this,
+    # AE blocks until deadline exits because the child inherits the same
+    # process group. The first fork lets python3 exit immediately; the
+    # grandchild (deadline) is re-parented to launchd and runs independently.
+    pid = os.fork()
+    if pid == 0:
+        # Child: start a new session to detach from AE's process group,
+        # then exec deadline. os.setsid() is the key call — it prevents
+        # the grandchild from receiving signals sent to AE's process group.
+        os.setsid()
+        subprocess.Popen(
+            [
+                deadline,
+                "bundle",
+                "gui-submit",
+                bundle_path,
+                "--output",
+                "json",
+                "--install-gui",
+                "--submitter-info",
+                "submitter_name=After Effects",
+            ]
+        )
+        os._exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/submission/SubmitBundle.jsx
+++ b/src/submission/SubmitBundle.jsx
@@ -219,6 +219,29 @@ function generateJobEnvironmentFragment(bundlePath, outputFoldersStr) {
 }
 
 /**
+ * Launches the Deadline Cloud GUI submitter on macOS without using Terminal.
+ *
+ * After Effects inherits a minimal launchd PATH from Finder that does not
+ * include the deadline CLI. Routing through Terminal.app to source the user's
+ * shell profile created a race: on a cold start the shell may not be ready
+ * before `do script` fires, silently dropping the command.
+ *
+ * Instead, system python3 (/usr/bin/python3) — which is always on the launchd
+ * PATH — runs launch_deadline.py, which locates the deadline binary by its
+ * well-known installer path and launches gui-submit as a detached process.
+ *
+ * @param {String} bundlePath         path to the job bundle directory
+ * @param {String} pythonExecutable   python3 executable found by getPythonExecutable()
+ **/
+function launchDeadlineGUI(bundlePath, pythonExecutable) {
+    const launcherScript = scriptFolder +
+        "/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/launch_deadline.py";
+    const cmd = pythonExecutable + " \"" + launcherScript + "\" \"" + bundlePath + "\"";
+    logger.debug("Launching Deadline GUI via Python launcher: " + cmd, submitBundleFile);
+    system.callSystem(cmd);
+}
+
+/**
  * Submit the selected render queue item
  **/
 function SubmitSelection(selection, selectionSettings) {
@@ -249,6 +272,7 @@ function SubmitSelection(selection, selectionSettings) {
         "scripts/font_manager.py",
         "scripts/call_aerender.py",
         "scripts/create_output_directory.py",
+        "scripts/launch_deadline.py",
         "template.json",
         "image_template.json",
         "video_template.json",
@@ -683,19 +707,13 @@ function SubmitSelection(selection, selectionSettings) {
             output = logFile.read();
             logFile.close();
         }
+        if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
+            adcAlert(
+                "ERROR:" + output, true
+            );
+            logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
+        }
     } else {
-        // Execute the command using a bash in the interactive mode so it loads the bash profile to set
-        // the PATH correctly.
-        const shellPath = $.getenv("SHELL") || "/bin/bash";
-        cmd =
-            'deadline bundle gui-submit \\\"' + bundle.fsName + '\\\" --output json --install-gui --submitter-name=\\\\\\\"After Effects\\\\\\\"';
-        submitScriptContents = shellPath + " -i -c \\\"" + cmd + "\\\" && exit";
-        output = system.callSystem('osascript -e \'tell application "Terminal"\' -e \'do script "' + submitScriptContents + '\"\'' + ' -e \'end tell\' > /dev/null');
-    }
-    if (output.indexOf("\nERROR CODE: ", 0) >= 0) {
-        adcAlert(
-            "ERROR:" + output, true
-        );
-        logger.error("Error when launching Deadline GUI submitter: " + output, "Utils.jsx");
+        launchDeadlineGUI(bundle.fsName, getPythonExecutable());
     }
 }


### PR DESCRIPTION
## Problem

Fixes #305.

The submitter launched the Deadline GUI by injecting a command into Terminal.app via AppleScript `do script`. This had two problems:

1. **Silent drop on cold start.** Terminal takes several seconds to launch its login shell. A `do script` sent before the shell is ready is silently dropped — the window opens blank and no GUI appears. The `busy` property fires when the shell *process* has started, not when it is interactive. With a slow-loading shell config (e.g. fish with plugins) this gap can be several seconds.

2. **After Effects UI blocks.** `system.callSystem` is synchronous. Any delay during deadline startup blocked the entire AE application.

## Fix

Replace Terminal entirely on macOS with a Python script, `launch_deadline.py`.

- `/usr/bin/python3` is always on the minimal launchd PATH that After Effects inherits from Finder — no shell profile sourcing needed
- `launch_deadline.py` finds the `deadline` binary by its well-known installer path (`~/DeadlineCloudSubmitter/DeadlineClient/deadline`) and **double-forks** before launching `gui-submit`
- The fork calls `os.setsid()` to start a new session, detaching the deadline process from After Effects' process group. `python3` exits immediately after the fork, so `system.callSystem` returns in ~64ms regardless of what deadline does afterward
- Falls back to `shutil.which("deadline")` for pip-installed setups

The Windows branch is unchanged. Its `ERROR CODE` error check is preserved inside the Windows branch.

## Changes

- `src/scripts/launch_deadline.py` — new Python launcher (mirrored to `dist/…/scripts/`)
- `src/submission/SubmitBundle.jsx` — macOS `else` branch replaced with `launchDeadlineGUI()`; Terminal/osascript machinery removed
- `launch_deadline.py` added to the required-files check

## Notes on automated review comments

**Comment on `singleQuoteForShell` / path injection:** Not applicable — that construction was removed by this PR. The bundle path is passed as a Python `sys.argv` argument via `subprocess.Popen` with no shell involved.

**Comment on `--submitter-info` vs `--submitter-name`:** `--submitter-info submitter_name=After Effects` is the correct current syntax. The CLI marks `--submitter-name` as deprecated in favour of `--submitter-info`.

**Comment on `ERROR CODE` check removed:** Fixed — the check is now scoped inside the Windows branch where `output` is populated.

## Testing

- Bug reproduced: cold Terminal + slow fish login shell drops 5/5 without a wait and 1/5 with the previous `busy`-wait approach
- Fix passes 5/5 cold-start trials; GUI confirmed launching and making real AWS API calls
- AE UI confirmed non-blocking: `system.callSystem` returns in ~64ms
- 7/7 unit tests pass
- Bundle regenerated via `jsxbundler.py`