### PR TITLE
docs: document submission hooks (pre-GUI, pre/post-submission) for After Effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ If you want to submit the job from the export, rather than through the submitter
 then you can use the [Deadline Cloud application](https://github.com/aws-deadline/deadline-cloud) to submit that bundle to your farm.
 
 
+## Submission Hooks
+
+The After Effects submitter shells out to the `deadline` CLI (`deadline bundle gui-submit`, see `src/submission/SubmitBundle.jsx`), so it supports Deadline Cloud's **pre-GUI, pre-submission, and post-submission hooks** with no submitter-side code. Hooks are sourced from `DEADLINE_HOOKS_DIR` (enable with `deadline config set settings.allow_environment_hooks true`). See **[deadline-cloud `docs/submission-hooks.md`](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md)** for full documentation — `hooks.yaml` format, hook examples, the confirmation prompts, and troubleshooting.
+
+A few After Effects specifics the base doc doesn't cover:
+
+- **Use environment hooks (`DEADLINE_HOOKS_DIR`).** The submitter regenerates its job bundle on every submit (`generateBundle()` deletes and recreates the temp bundle dir), so a `hooks.yaml` hand-placed in the generated bundle is discarded before `deadline` reads it — point hooks at `DEADLINE_HOOKS_DIR` instead.
+- **Version floor:** the `deadline` on your `PATH` must meet this package's pin, **`deadline >= 0.60.3, < 0.61`** (`pyproject.toml`), for a pre-GUI hook to set `name`/`description`. Applying **`deadline:` job-property overrides** (e.g. `deadline:priority`) additionally requires **`deadline >= 0.60.4`** ([deadline-cloud#1322](https://github.com/aws-deadline/deadline-cloud/pull/1322)); on older clients they are silently ignored.
+- **Which parameters a hook may set:** the render options — `ChunkSize`, `MultiFrameRendering`, `MaxCpuUsagePercentage`, `IgnoreMissingDependencies` — are job-level and free-standing. `ProjectFile` is also job-level, but only safe to repoint at the *same* project content (a different `.aep` desyncs it from the open project's asset references and per-item parameters). Don't set the `HIDDEN` submitter internals `JobScriptDir`/`CondaPackages` (setting them breaks the render or silently changes the AE version), and don't target the per-render-queue-item names (`_<index>_<comp>_<param>`) — they're generated at submit time, change on reorder/rename, and unmatched names are silently dropped.
+- **Where to set `DEADLINE_HOOKS_DIR`:** on **Windows** the submitter runs `deadline` as a child of After Effects, so set it as a user/machine environment variable and relaunch After Effects; on **macOS** the submitter runs `deadline` in a Terminal.app interactive shell, so export it in your shell startup file (`~/.zshrc` / `~/.bashrc`).
+
+
 ## Troubleshooting
 
 ### Error: Couldn't find Python 3 or higher on your PATH. Please ensure that Python 3 or higher is installed correctly and added to your PATH.


### PR DESCRIPTION
Fixes: _N/A — documentation gap; no tracked GitHub issue._

### What was the problem/requirement? (What/Why)

The README had no documentation for Deadline Cloud submission hooks, so After Effects users had no guidance on enabling or using them.

### What was the solution? (How)

Docs-only: added a concise **"Submission Hooks"** section to `README.md` that references the base client's [`docs/submission-hooks.md`](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md) for full documentation (rather than duplicating it), and keeps only the After Effects specifics. Since the submitter shells out to `deadline bundle gui-submit`, it supports all three hook phases with no code change.

### What is the impact of this change?

Documentation only; no behavior change.

### How was this change tested?

Validated the documented flow end-to-end via a real After Effects GUI submit (all three hooks fired; created job confirmed `CREATE_COMPLETE`). Markdown links/anchors reviewed.

#### If you modified source files, did you run the Python script to update the files under the dist folder?
N/A — documentation only; no source or `dist/` changes.

#### If you modified the `/installer`, `/install_builder`, or `/scripts` logic, please run the integration tests and paste the results below

N/A — not modified.

#### If `installer/` was modified or a file was added/removed from `dist/`, then update the installer tests and post the test results below

N/A — not modified.

### Was this change documented?

Yes — this PR is the documentation (README). No code/docstrings changed. Version requirements are consistent with the `pyproject.toml` pin (`deadline >= 0.60.3`): `name`/`description` work at that floor; `deadline:` job-property overrides need `deadline >= 0.60.4` (the `gui-submit` path).

### Is this a breaking change?

No.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
