### PR TITLE
feat: OpenJD progress and failure reporting for After Effects renders

### DIFF
--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
@@ -2,15 +2,71 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """
-Script that uses aerender cmd to render composition. When it is an image output,
-the script will have extra arguments: chunk-size and index passed in.
+Script that uses the aerender cmd to render a composition and emits OpenJD task
+status (progress + status message) so it surfaces in Deadline Cloud Monitor.
+
+Progress reporting contract
+---------------------------
+The openjd-sessions runtime on the worker scans this process's stdout for lines
+that START with one of its reserved prefixes and parses the rest:
+
+    openjd_progress: <float 0-100>     -> task progress percentage
+    openjd_status: <string>            -> task status message
+    openjd_fail: <string>              -> records a failure message
+
+No job-template configuration is required; this is a runtime convention. Any
+other stdout line is passed through untouched and ignored by the runtime.
+
+Progress estimation
+--------------------
+aerender's frame numbering under "-v ERRORS_AND_PROGRESS" is version- and
+MFR-dependent (a "(N)" token may be absolute or chunk-relative), so we do NOT
+derive a percentage from the frame index. Instead we count the number of
+DISTINCT frames aerender reports finishing and divide by the number of frames
+this task was asked to render. This is monotonic, never negative, and correct
+regardless of the numbering scheme.
+
+Junction path mapping (Windows)
+-------------------------------
+Windows caps paths at 260 characters, which long After Effects project and
+output paths can exceed. When a queue environment creates a junction for each
+asset root and points DEADLINE_JUNCTIONS at a file compatible with the OpenJD
+pathmapping-1.0 format, this script reroutes the project and output paths
+through those junctions to stay under the limit. When DEADLINE_JUNCTIONS is
+unset the paths render as given; when it is set but the file it names cannot be
+read as pathmapping-1.0, the task fails (emitting openjd_fail) instead of
+quietly rendering the original long paths.
 """
 
 import argparse
 import json
+import locale
+import os
+import re
 import subprocess
 import sys
-import os
+import unicodedata
+
+
+def _one_line(message):
+    """Flatten whitespace/newlines to single spaces: an embedded newline in an
+    untrusted value could otherwise forge a second openjd_* control line."""
+    return " ".join(str(message).split())
+
+
+def emit_progress(progress_int):
+    """Emit an OpenJD progress update (integer percent, 0-100)."""
+    print(f"openjd_progress: {int(progress_int)}", flush=True)
+
+
+def emit_status(message):
+    """Emit an OpenJD status message."""
+    print(f"openjd_status: {_one_line(message)}", flush=True)
+
+
+def emit_fail(message):
+    """Emit an OpenJD failure message (does not itself fail the task)."""
+    print(f"openjd_fail: {_one_line(message)}", flush=True)
 
 
 # Names a pathmapping-1.0 compatible file mapping each assetroot directory to its junction.
@@ -30,8 +86,8 @@ def load_junction_rules(rules_path):
         # pathmapping-1.0 allows the empty object when there are no rules.
         if document == {}:
             print(
-                f"[{JUNCTIONS_ENV_VAR}] Warning: the path mapping file {rules_path} is "
-                "empty. Rendering with the original long paths.",
+                f"[{JUNCTIONS_ENV_VAR}] Warning: the path mapping file {_one_line(rules_path)} "
+                "is empty. Rendering with the original long paths.",
                 file=sys.stderr,
                 flush=True,
             )
@@ -41,7 +97,9 @@ def load_junction_rules(rules_path):
         for rule in document["path_mapping_rules"]:
             source_path = rule["source_path"]
             destination_path = rule["destination_path"]
-            if not isinstance(source_path, str) or not isinstance(destination_path, str):
+            if not isinstance(source_path, str) or not isinstance(
+                destination_path, str
+            ):
                 raise TypeError(
                     "source_path and destination_path have to be strings, got "
                     f"{source_path!r} and {destination_path!r}"
@@ -68,18 +126,13 @@ def filter_invalid_junctions(rules):
             valid.append((assetroot, junction))
         else:
             print(
-                f"[{JUNCTIONS_ENV_VAR}] Warning: ignoring the rule for {assetroot} because "
-                f"its junction {junction} does not exist.",
+                f"[{JUNCTIONS_ENV_VAR}] Warning: ignoring the rule for {_one_line(assetroot)} "
+                f"because its junction {_one_line(junction)} does not exist.",
                 file=sys.stderr,
                 flush=True,
             )
 
     return valid
-
-
-def _to_windows_path(path):
-    """Square up separators so paths compare the way the Windows filesystem does."""
-    return path.replace("/", "\\")
 
 
 def apply_junction_rules(path, rules):
@@ -88,105 +141,123 @@ def apply_junction_rules(path, rules):
     Paths outside every assetroot, such as shared storage, are returned
     unchanged.
     """
-    windows_path = _to_windows_path(path)
-    # Only ever compared, never sliced. Lower casing can change a string's
-    # length, so slicing by the length of a lower cased root would cut the
-    # wrong number of characters off the path.
-    normalized = windows_path.rstrip("\\").lower()
+    # Match per segment (NFC + case-fold) so an NFD/NFC or case difference still
+    # matches, but rebuild the remainder from the ORIGINAL segments: NTFS stores
+    # names verbatim, so an NFD name below the root must reach aerender unchanged.
+    segments = path.replace("/", "\\").rstrip("\\").split("\\")
 
-    for assetroot, junction in rules:
-        root = _to_windows_path(assetroot).rstrip("\\")
-        if normalized == root.lower() or normalized.startswith(root.lower() + "\\"):
-            return junction.rstrip("\\/") + windows_path[len(root):]
+    def _fold(segment):
+        return unicodedata.normalize("NFC", segment).lower()
+
+    path_keys = [_fold(s) for s in segments]
+
+    # Most-specific root first: with overlapping roots (C:\a and C:\a\b) the
+    # deepest matching junction must win regardless of the rules file's order.
+    def _depth(rule):
+        return len(rule[0].replace("/", "\\").rstrip("\\").split("\\"))
+
+    for assetroot, junction in sorted(rules, key=_depth, reverse=True):
+        root_segments = assetroot.replace("/", "\\").rstrip("\\").split("\\")
+        n = len(root_segments)
+        if path_keys[:n] == [_fold(s) for s in root_segments]:
+            remainder = segments[n:]
+            # rstrip("\\/"): a junction with a trailing slash must not leave a
+            # doubled separator when we re-join the (original) remainder.
+            suffix = "\\" + "\\".join(remainder) if remainder else ""
+            return junction.rstrip("\\/") + suffix
 
     return path
 
 
-def main():
-    parser = argparse.ArgumentParser(description="After Effects Render Script")
-    parser.add_argument("project", type=str, help="Project file path")
-    parser.add_argument("rqindex", type=int, help="Render queue index")
-    parser.add_argument("outputpath", type=str, default="", help="Output path")
-    parser.add_argument(
-        "frames",
-        type=str,
-        default="0-100",
-        help="The range of frames, the format is startFrame-endFrame",
-    )
-    parser.add_argument("--chunk-size", type=int, help="The number of frames per task")
-    parser.add_argument("--index", type=int, help="The starting frame of the chunk")
-    parser.add_argument(
-        "--multi-frame-rendering",
-        type=str,
-        default="OFF",
-        help="Multi-frame render (MFR)",
-    )
-    parser.add_argument(
-        "--max-cpu-usage-percentage",
-        type=int,
-        default=90,
-        help="Specifies the desired maximum CPU percentage power to use during rendering. Value is ignored if MFR is OFF",
-    )
-    parser.add_argument("--ignore-missing-dependencies", type=str, default="OFF", help="Missing dependencies checking")
-
-    args = parser.parse_args()
-    print(f"Args: {args}", flush=True)
-
-    # Send the paths through the junctions to stay under the Windows 260 char
-    # path limit. Something else, such as a queue environment, has to create the
-    # junctions and set the environment variable. See
-    # https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/README.md#short-path-mapping-junctions
+def apply_junctions(args):
+    """Reroute args.project / args.outputpath through the DEADLINE_JUNCTIONS
+    junctions so aerender gets paths under the Windows 260-char limit. No-ops off
+    Windows or when the var is unset; raises JunctionPathmapFormatException (fail
+    closed) when the file can't be read as pathmapping-1.0. Producer setup:
+    https://github.com/aws-deadline/deadline-cloud-samples/blob/mainline/queue_environments/README.md#short-path-mapping-junctions
+    """
     junctions_file = os.environ.get(JUNCTIONS_ENV_VAR)
-    if sys.platform == "win32" and junctions_file:
-        print(
-            f"[{JUNCTIONS_ENV_VAR}] Detected junction path mapping file {JUNCTIONS_ENV_VAR}={junctions_file}.",
-            flush=True,
-        )
-        junction_rules = filter_invalid_junctions(load_junction_rules(junctions_file))
-        args.project = apply_junction_rules(args.project, junction_rules)
-        # A multi output module comp arrives as a comma separated list of paths.
-        args.outputpath = ",".join(
-            apply_junction_rules(output, junction_rules)
-            for output in args.outputpath.split(",")
-        )
-        print(
-            f"[{JUNCTIONS_ENV_VAR}] Path mapped Project: {args.project}",
-            flush=True,
-        )
-        print(
-            f"[{JUNCTIONS_ENV_VAR}] Path mapped Output: {args.outputpath}",
-            flush=True,
-        )
+    if sys.platform != "win32" or not junctions_file:
+        return
 
-    # Determine if second parameter is a Python script or a range
-    range_value = args.frames
-    range_list = range_value.split("-")
-    start_frame, end_frame = int(range_list[0]), int(range_list[1])
+    print(
+        f"[{JUNCTIONS_ENV_VAR}] Detected junction path mapping file "
+        f"{JUNCTIONS_ENV_VAR}={_one_line(junctions_file)}.",
+        flush=True,
+    )
+    junction_rules = filter_invalid_junctions(load_junction_rules(junctions_file))
+    args.project = apply_junction_rules(args.project, junction_rules)
+    # A multi-output-module comp arrives as a comma-separated list of paths;
+    # map each element individually so every one gets shortened (mapping the
+    # joined string as a whole would only rewrite the first path's prefix).
+    args.outputpath = ",".join(
+        apply_junction_rules(output, junction_rules)
+        for output in args.outputpath.split(",")
+    )
+    print(
+        f"[{JUNCTIONS_ENV_VAR}] Path mapped Project: {_one_line(args.project)}",
+        flush=True,
+    )
+    print(
+        f"[{JUNCTIONS_ENV_VAR}] Path mapped Output: {_one_line(args.outputpath)}",
+        flush=True,
+    )
 
-    if args.chunk_size is not None and args.index is not None:
-        try:
-            # if there is only 1 frame in the chunk
-            if args.chunk_size == 1:
-                start_frame = args.index
-                end_frame = args.index
-            else:
-                chunk_start = args.index
-                chunk_end = min(
-                    args.index + args.chunk_size - 1,
-                    end_frame,
-                )
-                start_frame = chunk_start
-                end_frame = chunk_end
-            print(f"Start frame: {start_frame}, End frame: {end_frame}", flush=True)
-        except Exception as e:
-            print(
-                f"Failed to get the valid start frame and end frame for the chunk: {str(e)}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-    else:
-        print("No chunk_size and index passed in, this is not an image output.")
 
+# Per-frame progress line, e.g. "PROGRESS:  0:00:00:00 (1): 0 Seconds"; used only
+# to COUNT frames. The leading timecode is required so header lines that also
+# carry a "(N)" -- "Duration: ... (49)", "Frame Rate: 24.00 (comp)" -- aren't counted.
+PROGRESS_FRAME_PATTERN = re.compile(
+    r"PROGRESS:\s+\d+:\d+:\d+:\d+\s+\((\d+)\)", re.IGNORECASE
+)
+
+# Low-false-positive markers for real AE/aerender failures; a match fails the task
+# even on exit 0. Anchored to AE-/aerender-prefixed phrasings so benign lines with
+# "error" (footage names, "0 errors") don't trip. A bare "Unable to ..." is a
+# common NON-fatal AE warning, so it's not matched here; fatal cases are
+# AE-prefixed or exit non-zero. Aggressive scan: AE_STRICT_ERROR_SCAN=1.
+STRONG_ERROR_PATTERNS = [
+    re.compile(r"After Effects error:", re.IGNORECASE),
+    # IGNORECASE covers every case spelling of this prefix (one entry suffices); it
+    # does NOT make "aerender " optional, so a bare "ERROR:" is caught only by exit code.
+    re.compile(r"aerender ERROR:", re.IGNORECASE),
+]
+
+# Broad "any line containing 'error'" scan. Off by default (aerender prints benign
+# "error" lines); AE_STRICT_ERROR_SCAN=1 restores the original fail-on-any behavior.
+BARE_ERROR_PATTERN = re.compile(r"error", re.IGNORECASE)
+
+
+def parse_frame_range(frames):
+    """Parse "start-end" into (start, end). Raises ValueError on bad input."""
+    parts = frames.split("-")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid frame range {frames!r}; expected 'start-end'")
+    start_frame, end_frame = int(parts[0]), int(parts[1])
+    if end_frame < start_frame:
+        raise ValueError(
+            f"Invalid frame range {frames!r}; end ({end_frame}) < start ({start_frame})"
+        )
+    return start_frame, end_frame
+
+
+def resolve_chunk(start_frame, end_frame, chunk_size, index):
+    """Narrow (start, end) to the chunk this task owns, if chunking is used."""
+    if chunk_size is None or index is None:
+        return start_frame, end_frame
+    if not (start_frame <= index <= end_frame):
+        raise ValueError(
+            f"Chunk index {index} is outside the frame range {start_frame}-{end_frame}"
+        )
+    if chunk_size == 1:
+        return index, index
+    chunk_start = index
+    chunk_end = min(index + chunk_size - 1, end_frame)
+    return chunk_start, chunk_end
+
+
+def build_render_args(args, start_frame, end_frame):
+    """Assemble the aerender argument list."""
     render_args = [
         "-project",
         f'"{args.project}"',
@@ -208,87 +279,277 @@ def main():
     ]
     if args.ignore_missing_dependencies == "ON":
         render_args.append("-continueOnMissingFootage")
-
     if "," not in args.outputpath:
         render_args.extend(["-output", f'"{args.outputpath}"'])
+    return render_args
 
+
+def is_strong_error(line):
+    return any(p.search(line) for p in STRONG_ERROR_PATTERNS)
+
+
+# How long to wait for the aerender child to exit before giving up, so a wedged
+# process can't hang cleanup indefinitely (the OpenJD session would then have to
+# force-terminate this script, losing the rest of the cleanup).
+_REAP_TIMEOUT_SECONDS = 30
+
+
+def reap_process(process):
+    """Best-effort terminate the aerender child and its tree, bounded so it can't
+    hang. On Windows aerender.exe is a launcher that spawns AfterFX.exe as a
+    SEPARATE process, so kill() would orphan AfterFX (holding a render slot / AE
+    license); taskkill /T reaps the whole tree. POSIX kill() suffices.
+    """
+    if sys.platform == "win32":
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=_REAP_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            process.kill()  # fall back to reaping at least the direct child
+    else:
+        process.kill()
+    try:
+        process.wait(timeout=_REAP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="After Effects Render Script with Progress"
+    )
+    parser.add_argument("project", type=str, help="Project file path")
+    parser.add_argument("rqindex", type=int, help="Render queue index")
+    parser.add_argument("outputpath", type=str, default="", help="Output path")
+    parser.add_argument(
+        "frames",
+        type=str,
+        default="0-100",
+        help="The range of frames, the format is startFrame-endFrame",
+    )
+    parser.add_argument("--chunk-size", type=int, help="The number of frames per task")
+    parser.add_argument("--index", type=int, help="The starting frame of the chunk")
+    parser.add_argument(
+        "--multi-frame-rendering",
+        type=str,
+        default="OFF",
+        help="Multi-frame render (MFR)",
+    )
+    parser.add_argument(
+        "--max-cpu-usage-percentage",
+        type=int,
+        default=90,
+        help="Maximum CPU percentage to use during rendering. Ignored if MFR is OFF",
+    )
+    parser.add_argument(
+        "--ignore-missing-dependencies",
+        type=str,
+        default="OFF",
+        help="Missing dependencies checking",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv):
+    """Run a render. Returns a process exit code (0 = success)."""
+    args = parse_args(argv)
+    print(f"Args: {args}", flush=True)
+
+    strict_error_scan = os.getenv("AE_STRICT_ERROR_SCAN", "").strip() in (
+        "1",
+        "true",
+        "TRUE",
+    )
+
+    # Reroute the project/output paths through the junctions before we build the
+    # aerender command. Fail closed: an unreadable/malformed junctions file fails
+    # the task rather than silently rendering the original (too long) paths.
+    try:
+        apply_junctions(args)
+    except JunctionPathmapFormatException as e:
+        emit_fail(f"Invalid {JUNCTIONS_ENV_VAR} file: {e}")
+        print(f"[ERROR] {_one_line(e)}", file=sys.stderr, flush=True)
+        return 1
+
+    try:
+        start_frame, end_frame = parse_frame_range(args.frames)
+    except ValueError as e:
+        emit_fail(f"Could not parse frame range: {e}")
+        print(f"[ERROR] {_one_line(e)}", file=sys.stderr, flush=True)
+        return 1
+
+    try:
+        start_frame, end_frame = resolve_chunk(
+            start_frame, end_frame, args.chunk_size, args.index
+        )
+        print(f"Start frame: {start_frame}, End frame: {end_frame}", flush=True)
+    except Exception as e:  # noqa: BLE001 - surface any chunk math failure clearly
+        emit_fail(f"Could not resolve chunk frame range: {e}")
+        print(f"[ERROR] {_one_line(e)}", file=sys.stderr, flush=True)
+        return 1
+
+    # Number of frames this task is responsible for (inclusive range).
+    total_frames = max(1, end_frame - start_frame + 1)
+
+    render_args = build_render_args(args, start_frame, end_frame)
     aerender_exe = os.getenv("AERENDER_EXECUTABLE", "aerender.exe")
 
     print(
-        f"[DEBUG] Starting aerender process with command: {aerender_exe} {' '.join(render_args)}",
+        "[DEBUG] Starting aerender process with command: "
+        f"{_one_line(aerender_exe + ' ' + ' '.join(render_args))}",
         flush=True,
     )
+    emit_status(f"Rendering frames {start_frame}-{end_frame}")
+    emit_progress(0)
 
-    error_found = False
+    frames_seen = set()
+    last_reported_progress = 0
+    strong_error_line = None
+    process = None
 
     try:
+        print(
+            f"[DEBUG] Starting render frames {start_frame} to {end_frame}", flush=True
+        )
+
         process = subprocess.Popen(
             [aerender_exe] + render_args,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+            stderr=subprocess.STDOUT,
+            # Decode with the OS code page, not hard-coded utf-8: aerender is a
+            # native binary that writes the platform (ANSI) encoding, so utf-8
+            # would mojibake non-ASCII paths. errors="replace" keeps a stray byte
+            # from raising and aborting a healthy render.
+            encoding=locale.getpreferredencoding(False),
+            errors="replace",
             bufsize=1,
         )
-        stdout, stderr = process.communicate()
 
-        print(
-            f"[DEBUG] Process finished with return code: {process.returncode}",
-            flush=True,
-        )
+        for line in iter(process.stdout.readline, ""):
+            line = line.rstrip("\n")
 
-        # Process stdout line by line
-        for line in stdout.splitlines():
+            # --- error detection ---------------------------------------------
+            if is_strong_error(line):
+                # Real, well-formed AE/aerender error. Remember the first one so
+                # we can report it, and fail the task regardless of exit code.
+                if strong_error_line is None:
+                    strong_error_line = line
+                print(f"[ERROR DETECTED] {line}", file=sys.stderr, flush=True)
+            elif strict_error_scan and BARE_ERROR_PATTERN.search(line):
+                # Opt-in aggressive behavior: any "error" substring fails.
+                if strong_error_line is None:
+                    strong_error_line = line
+                print(f"[ERROR DETECTED strict] {line}", file=sys.stderr, flush=True)
+
+            # --- progress counting -------------------------------------------
+            match = PROGRESS_FRAME_PATTERN.search(line)
+            if match:
+                frames_seen.add(match.group(1))
+                completed = min(len(frames_seen), total_frames)
+                progress_int = int((completed / total_frames) * 100.0)
+                if progress_int > last_reported_progress:
+                    emit_status(f"Rendered {completed} of {total_frames} frames")
+                    emit_progress(progress_int)
+                    last_reported_progress = progress_int
+                # Echo the frame line too: its per-frame timing is the main stall
+                # signal, and on >100-frame chunks most lines don't bump progress.
+                print(f"[STDOUT] {line}", flush=True)
+                continue
+
+            # Non-progress, non-error line: pass through for logs.
             print(f"[STDOUT] {line}", flush=True)
 
-            # Check for errors in stdout (case insensitive)
-            line_lower = line.lower()
-            if "error" in line_lower:
-                print(
-                    f"[ERROR DETECTED] in stdout: {line}", file=sys.stderr, flush=True
-                )
-                error_found = True
+        process.stdout.close()
+        returncode = process.wait()
 
-        # Process stderr line by line
-        for line in stderr.splitlines():
-            print(f"[STDERR] {line}", file=sys.stderr, flush=True)
+        print(f"[DEBUG] Process finished with return code: {returncode}", flush=True)
 
-            # Only consider stderr as error if it contains "error" (case insensitive)
-            if line.strip():
-                line_lower = line.lower()
-                if "error" in line_lower:
-                    print(
-                        f"[ERROR DETECTED] in stderr: {line}", file=sys.stderr, flush=True
-                    )
-                    error_found = True
-
-        # If process returned non-zero code, that's also an error
-        if process.returncode != 0:
-            print(
-                f"[ERROR] Process returned non-zero exit code: {process.returncode}",
-                file=sys.stderr,
-                flush=True,
-            )
-            error_found = True
-
-        # Exit with error if any errors were found
-        if error_found:
-            print("[DEBUG] Errors were detected, exiting with code 1", flush=True)
-            sys.exit(1)
-
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - any launch/stream failure is a task failure
+        emit_fail(f"Exception during aerender execution: {e}")
         print(
-            f"[ERROR] Exception during aerender execution: {str(e)}",
+            f"[ERROR] Exception during aerender execution: {_one_line(e)}",
             file=sys.stderr,
             flush=True,
         )
-        sys.exit(1)
+        return 1
+    finally:
+        # Reap the child/tree on EVERY exit path -- return, except, and a
+        # propagating BaseException (cancellation: KeyboardInterrupt / signal) --
+        # so no orphan holds an AE license/slot. Skipped once it has exited.
+        if process is not None and process.poll() is None:
+            reap_process(process)
 
-    # Exit with the same code as aerender
+    # --- final verdict ---------------------------------------------------
+    # Exit code is authoritative; a strong error line fails even on exit 0.
+    if returncode != 0:
+        reason = (
+            strong_error_line
+            if strong_error_line is not None
+            else f"aerender exited with code {returncode}"
+        )
+        emit_fail(reason)
+        print(f"[ERROR] {reason}", file=sys.stderr, flush=True)
+        # Collapse to 1, not the raw code: main() does sys.exit(code & 0xFF), so a
+        # non-zero multiple of 256 would exit 0 and mark a failed render successful.
+        return 1
+
+    if strong_error_line is not None:
+        emit_fail(f"aerender reported an error: {strong_error_line}")
+        print(
+            f"[ERROR] aerender exited 0 but reported an error: {strong_error_line}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    if not frames_seen:
+        # No per-frame progress was seen. Common for single-movie output; not an
+        # error on its own, but worth flagging in the log.
+        print(
+            "[WARN] No per-frame PROGRESS lines were parsed; "
+            "reporting 100% based on successful exit code.",
+            flush=True,
+        )
+    elif len(frames_seen) < total_frames:
+        # Exit 0 with fewer frames than asked: -continueOnMissingFootage lets
+        # aerender skip frames and still exit 0; warn so the shortfall is visible.
+        print(
+            f"[WARN] aerender exited 0 but reported only {len(frames_seen)} of "
+            f"{total_frames} frames; output may be incomplete.",
+            flush=True,
+        )
+
+    # Emit the terminal 100% only if the per-frame loop didn't already reach it,
+    # so a fully-counted render doesn't double-report 100.
+    if last_reported_progress < 100:
+        emit_status(f"Rendered {total_frames} of {total_frames} frames")
+        emit_progress(100)
     print(
-        f"[DEBUG] No errors detected, exiting with process return code: {process.returncode}",
+        f"[DEBUG] No errors detected, exiting with return code: {returncode}",
         flush=True,
     )
-    sys.exit(process.returncode)
+    # returncode is guaranteed 0 on this path; return it explicitly so the exit
+    # status can't be affected by the & 0xFF truncation noted above.
+    return 0
+
+
+def _ensure_utf8_output():
+    """Force stdout/stderr to UTF-8 (lenient) so a non-ASCII path/log line can't
+    raise UnicodeEncodeError mid-stream and fail an otherwise-successful render."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+def main():
+    _ensure_utf8_output()
+    sys.exit(run(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,3 +7,11 @@ ruff == 0.16.*
 twine == 6.*
 types-pyyaml == 6.*
 fonttools == 4.*
+# Used only by test/unit/test_call_aerender.py's OpenJD contract test, which
+# drives the worker's ActionMonitoringFilter. The private
+# openjd.sessions._action_filter API (ActionMonitoringFilter /
+# ActionMessageKind) was verified present in 0.11.0 and the contract test
+# passes against it. Pinned to a minor because that filter lives in the private
+# openjd.sessions._action_filter module (see the note in that test) and could
+# move across minor releases.
+openjd-sessions == 0.11.*

--- a/test/unit/fake_aerender.py
+++ b/test/unit/fake_aerender.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Test stub that mimics Adobe's `aerender` CLI output for call_aerender.py tests.
+
+It reads -s/-e from argv and env vars to decide what to emit, then replays
+canned stdout lines shaped like real "-v ERRORS_AND_PROGRESS" output.
+
+Env controls:
+    FAKE_AE_MODE   seq (default) | mfr | movie | strong_error | benign_error | partial | bad_bytes
+    FAKE_AE_EXIT   integer exit code to return (default "0")
+"""
+
+import os
+import sys
+
+
+def parse_range(argv):
+    start = end = None
+    for i, a in enumerate(argv):
+        if a == "-s" and i + 1 < len(argv):
+            start = int(argv[i + 1])
+        elif a == "-e" and i + 1 < len(argv):
+            end = int(argv[i + 1])
+    if start is None or end is None:
+        start, end = 0, 0
+    return start, end
+
+
+def frame_line(frame_index):
+    # Mimic: "PROGRESS:  0:00:00:00 (1): 0 Seconds"
+    return f"PROGRESS:  0:00:00:{frame_index:02d} ({frame_index}): 0 Seconds"
+
+
+def main():
+    argv = sys.argv[1:]
+    start, end = parse_range(argv)
+    mode = os.getenv("FAKE_AE_MODE", "seq")
+    exit_code = int(os.getenv("FAKE_AE_EXIT", "0"))
+
+    print("aerender version 26.0", flush=True)
+    print(
+        f"PROGRESS: Rendering 0:00:00:00 to 0:00:00:{max(0, end - start):02d}",
+        flush=True,
+    )
+
+    # Real -v ERRORS_AND_PROGRESS output carries header lines that ALSO have a
+    # parenthesised integer but are NOT frames. A frame-count regex must ignore
+    # these; emitting them here pins call_aerender.PROGRESS_FRAME_PATTERN so it
+    # can't miscount them (which would inflate progress past the frame count).
+    print(f"PROGRESS:  Duration: 0:00:02:00 ({max(1, end - start + 1)})", flush=True)
+    print("PROGRESS:  Frame Rate: 24.00 (comp)", flush=True)
+
+    frames = list(range(start, end + 1))
+
+    if mode == "movie":
+        # Single movie output: aerender may not print per-frame PROGRESS lines.
+        print("PROGRESS: Rendering movie...", flush=True)
+    elif mode == "mfr":
+        # Multi-frame rendering: frames complete out of order.
+        order = frames[1::2] + frames[0::2]
+        for f in order:
+            print(frame_line(f), flush=True)
+    elif mode == "partial":
+        # Render stops partway through.
+        for f in frames[: max(1, len(frames) // 2)]:
+            print(frame_line(f), flush=True)
+    elif mode == "strong_error":
+        for f in frames[: max(1, len(frames) // 2)]:
+            print(frame_line(f), flush=True)
+        # Well-formed AE error line.
+        print("After Effects error: Unable to open project file.", flush=True)
+    elif mode == "benign_error":
+        # Lines that contain "error" but are NOT failures.
+        print("Loading footage: error_analysis_final.mov", flush=True)
+        for f in frames:
+            print(frame_line(f), flush=True)
+        print("Render finished with 0 errors.", flush=True)
+    elif mode == "bad_bytes":
+        # Emit the normal frame lines but interleave a raw, undecodable byte
+        # sequence directly on stdout. Strict UTF-8 decoding would raise
+        # UnicodeDecodeError in the parent's readline(); errors="replace" must
+        # let the healthy render continue and still reach 100%.
+        for f in frames:
+            print(frame_line(f), flush=True)
+            sys.stdout.flush()
+            sys.stdout.buffer.write(b"\xff\xfe garbage\n")
+            sys.stdout.buffer.flush()
+    else:  # "seq"
+        for f in frames:
+            print(frame_line(f), flush=True)
+
+    print("PROGRESS: Total Time Elapsed: 1 Second", flush=True)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/test_call_aerender.py
+++ b/test/unit/test_call_aerender.py
@@ -1,0 +1,748 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the hardened call_aerender.py progress-reporting script.
+
+Layers:
+  * pure-function unit tests (frame range / chunk / render args / error match)
+  * end-to-end run() tests driving a fake aerender stub via AERENDER_EXECUTABLE
+  * an openjd-sessions CONTRACT test that feeds the emitted stdout back through
+    the real ActionMonitoringFilter to prove PROGRESS/STATUS/FAIL callbacks fire
+    exactly as Deadline Cloud's worker would parse them.
+"""
+
+import importlib.util
+import json
+import locale
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# --- import the script under test (it lives under the JobTemplate scripts dir) ---
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "dist"
+    / "DeadlineCloudSubmitter_Assets"
+    / "JobTemplate"
+    / "scripts"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "call_aerender", _SCRIPTS_DIR / "call_aerender.py"
+)
+call_aerender = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(call_aerender)
+
+_FAKE_AERENDER = str(Path(__file__).resolve().parent / "fake_aerender.py")
+
+
+# ----------------------------------------------------------------------------
+# Pure-function unit tests
+# ----------------------------------------------------------------------------
+class TestFrameRange:
+    def test_basic(self):
+        assert call_aerender.parse_frame_range("0-100") == (0, 100)
+
+    def test_single(self):
+        assert call_aerender.parse_frame_range("5-5") == (5, 5)
+
+    @pytest.mark.parametrize("bad", ["100", "0-", "-", "a-b", "10-5", "0-1-2"])
+    def test_invalid(self, bad):
+        with pytest.raises(ValueError):
+            call_aerender.parse_frame_range(bad)
+
+
+class TestResolveChunk:
+    def test_no_chunk_passthrough(self):
+        assert call_aerender.resolve_chunk(0, 100, None, None) == (0, 100)
+
+    def test_chunk_size_one(self):
+        assert call_aerender.resolve_chunk(0, 100, 1, 42) == (42, 42)
+
+    def test_chunk_clamped_to_end(self):
+        # index 98, chunk 10 -> would be 98..107 but end is 100
+        assert call_aerender.resolve_chunk(0, 100, 10, 98) == (98, 100)
+
+    def test_chunk_interior(self):
+        assert call_aerender.resolve_chunk(0, 100, 10, 20) == (20, 29)
+
+    def test_index_above_end_raises(self):
+        # index 150 is past end 100 -> would yield end < start; must fail loud.
+        with pytest.raises(ValueError):
+            call_aerender.resolve_chunk(0, 100, 1, 150)
+
+    def test_index_below_start_raises(self):
+        # index 10 is below start 50 -> out of range; must fail loud.
+        with pytest.raises(ValueError):
+            call_aerender.resolve_chunk(50, 100, 10, 10)
+
+
+class TestStrongError:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "After Effects error: Unable to open project file.",
+            "aerender ERROR: something went wrong",
+            "After Effects error: Unable to render frame 5",
+        ],
+    )
+    def test_matches_real_errors(self, line):
+        assert call_aerender.is_strong_error(line) is True
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Loading footage: error_analysis_final.mov",
+            "Render finished with 0 errors.",
+            "PROGRESS:  0:00:00:00 (1): 0 Seconds",
+            # A bare "Unable to ..." line is a common NON-fatal AE warning (e.g.
+            # a missing font/plug-in) and must no longer fail the task; genuinely
+            # fatal cases arrive AE-prefixed ("After Effects error: ...").
+            "Unable to load font: Helvetica",
+        ],
+    )
+    def test_ignores_benign_lines(self, line):
+        assert call_aerender.is_strong_error(line) is False
+
+    def test_no_duplicate_case_variant_patterns(self):
+        # IGNORECASE makes "aerender ERROR:" and "aerender Error:" identical, so
+        # only the AE-prefix and one aerender-prefix entry should remain.
+        assert len(call_aerender.STRONG_ERROR_PATTERNS) == 2
+        # Both case spellings still match (proving the dedupe kept coverage).
+        assert call_aerender.is_strong_error("aerender ERROR: boom") is True
+        assert call_aerender.is_strong_error("aerender Error: boom") is True
+
+
+class TestProgressFramePattern:
+    """The frame-count regex must match per-frame timecode lines only, never the
+    header lines that also carry a parenthesised integer (which would inflate
+    progress)."""
+
+    @pytest.mark.parametrize(
+        "line,frame",
+        [
+            ("PROGRESS:  0:00:00:00 (1): 0 Seconds", "1"),
+            ("PROGRESS:  0:00:00:09 (10): 2 Seconds", "10"),
+        ],
+    )
+    def test_matches_frame_lines(self, line, frame):
+        m = call_aerender.PROGRESS_FRAME_PATTERN.search(line)
+        assert m is not None and m.group(1) == frame
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "PROGRESS:  Duration: 0:00:02:00 (49)",
+            "PROGRESS:  Frame Rate: 24.00 (comp)",
+            "PROGRESS: Rendering 0:00:00:00 to 0:00:00:09",
+        ],
+    )
+    def test_ignores_header_lines(self, line):
+        assert call_aerender.PROGRESS_FRAME_PATTERN.search(line) is None
+
+
+class TestApplyJunctionRules:
+    RULES = [("C:\\assetroot", "J:\\j")]
+
+    def test_maps_path_under_root(self):
+        assert (
+            call_aerender.apply_junction_rules("C:\\assetroot\\a\\out.png", self.RULES)
+            == "J:\\j\\a\\out.png"
+        )
+
+    def test_passthrough_outside_every_root(self):
+        assert (
+            call_aerender.apply_junction_rules("D:\\other\\x.png", self.RULES)
+            == "D:\\other\\x.png"
+        )
+
+    def test_forward_slash_junction_has_no_doubled_separator(self):
+        # A junction written with a trailing "/" must not leave a doubled
+        # separator when the remainder is re-joined.
+        rules = [("C:\\assetroot", "J:/j/")]
+        assert (
+            call_aerender.apply_junction_rules("C:\\assetroot\\a.png", rules)
+            == "J:/j\\a.png"
+        )
+
+    def test_slice_uses_unlowered_root_length(self):
+        # "İ" (U+0130) lower-cases to two code points, so slicing by the length
+        # of the lower-cased root would drop characters. The remainder must be
+        # sliced by the un-lowered root's length.
+        rules = [("C:\\\u0130", "J:\\j")]
+        assert (
+            call_aerender.apply_junction_rules("C:\\\u0130\\out.png", rules)
+            == "J:\\j\\out.png"
+        )
+
+    def test_nfd_path_matches_nfc_root(self):
+        # A macOS-authored NFD path ("cafe" + combining acute U+0301) must match
+        # an NFC assetroot ("café" U+00E9). NFC-normalizing both the path and the
+        # root keeps the slice offset correct even though the two forms differ in
+        # code-point count.
+        rules = [("C:\\caf\u00e9", "J:\\j")]
+        assert (
+            call_aerender.apply_junction_rules("C:\\cafe\u0301\\out.png", rules)
+            == "J:\\j\\out.png"
+        )
+
+    def test_most_specific_root_wins(self):
+        # With overlapping roots the deepest junction must win regardless of the
+        # rules file's order (here the least-specific rule is listed first).
+        rules = [("C:\\a", "J:\\ja"), ("C:\\a\\b", "J:\\jb")]
+        assert (
+            call_aerender.apply_junction_rules("C:\\a\\b\\x.png", rules)
+            == "J:\\jb\\x.png"
+        )
+
+    def test_nfd_remainder_below_root_is_preserved(self):
+        # An NFD directory name BELOW the assetroot must reach aerender with its
+        # original code points. Windows/NTFS does not normalize file names, so
+        # rewriting the remainder to NFC would name a file that doesn't exist.
+        rules = [("C:\\assetroot", "J:\\j")]
+        nfd = "cafe\u0301"  # "cafe" + combining acute accent (decomposed)
+        result = call_aerender.apply_junction_rules(
+            f"C:\\assetroot\\{nfd}\\out.png", rules
+        )
+        assert result == f"J:\\j\\{nfd}\\out.png"
+        assert "\u0301" in result  # still decomposed, not collapsed to U+00E9
+
+    def test_prefix_segment_is_not_a_partial_match(self):
+        # "C:\asset" must not match a path under "C:\assetroot" -- segment
+        # comparison, not string prefix, prevents the false hit.
+        rules = [("C:\\asset", "J:\\j")]
+        assert (
+            call_aerender.apply_junction_rules("C:\\assetroot\\x.png", rules)
+            == "C:\\assetroot\\x.png"
+        )
+
+
+def test_apply_junctions_maps_each_output_in_comma_list(monkeypatch, tmp_path):
+    """A multi-output-module comp arrives as a comma-separated list; every
+    element must be routed through its junction, not just the first."""
+    junction = tmp_path / "j1"
+    junction.mkdir()
+    rules_file = tmp_path / "rules.json"
+    rules_file.write_text(
+        json.dumps(
+            {
+                "path_mapping_rules": [
+                    {"source_path": "C:\\assetroot", "destination_path": str(junction)}
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+    monkeypatch.setenv(call_aerender.JUNCTIONS_ENV_VAR, str(rules_file))
+
+    class _Args:
+        project = "C:\\assetroot\\proj.aep"
+        outputpath = "C:\\assetroot\\a\\o1.png,C:\\assetroot\\b\\o2.png"
+
+    args = _Args()
+    call_aerender.apply_junctions(args)
+
+    mapped = args.outputpath.split(",")
+    assert len(mapped) == 2
+    # Both elements were shortened through the junction (the bug left the 2nd
+    # element with its original long assetroot prefix).
+    assert all(p.startswith(str(junction)) for p in mapped), mapped
+
+
+# ----------------------------------------------------------------------------
+# End-to-end run() tests using the fake aerender stub
+# ----------------------------------------------------------------------------
+def _parse_openjd(stdout):
+    """Extract (progress[], status[], fail[]) from emitted stdout."""
+    progress, status, fail = [], [], []
+    for line in stdout.splitlines():
+        if line.startswith("openjd_progress: "):
+            progress.append(float(line[len("openjd_progress: ") :]))
+        elif line.startswith("openjd_status: "):
+            status.append(line[len("openjd_status: ") :])
+        elif line.startswith("openjd_fail: "):
+            fail.append(line[len("openjd_fail: ") :])
+    return progress, status, fail
+
+
+@pytest.fixture
+def run_render(monkeypatch, capsys):
+    """Run call_aerender.run() against the fake aerender, return (rc, progress, status, fail)."""
+
+    def _invoke(
+        frames="0-9", chunk_size=None, index=None, mode="seq", exit_code=0, env=None
+    ):
+        monkeypatch.setenv("FAKE_AE_MODE", mode)
+        monkeypatch.setenv("FAKE_AE_EXIT", str(exit_code))
+        # aerender executable = current python; make the fake script the first arg
+        # by monkeypatching build_render_args to prepend it.
+        monkeypatch.setenv("AERENDER_EXECUTABLE", sys.executable)
+        orig = call_aerender.build_render_args
+
+        def patched(args, s, e):
+            return [_FAKE_AERENDER] + orig(args, s, e)
+
+        monkeypatch.setattr(call_aerender, "build_render_args", patched)
+        for k, v in (env or {}).items():
+            monkeypatch.setenv(k, v)
+
+        argv = ["proj.aep", "0", "/out/frame_[####].png", frames]
+        if chunk_size is not None:
+            argv += ["--chunk-size", str(chunk_size)]
+        if index is not None:
+            argv += ["--index", str(index)]
+        rc = call_aerender.run(argv)
+        out = capsys.readouterr().out
+        progress, status, fail = _parse_openjd(out)
+        return rc, progress, status, fail, out
+
+    return _invoke
+
+
+class TestEndToEnd:
+    def test_happy_path_monotonic_to_100(self, run_render):
+        rc, progress, status, fail, _ = run_render(frames="0-9", mode="seq")
+        assert rc == 0
+        assert fail == []
+        assert progress == sorted(progress)  # monotonic non-decreasing
+        assert progress[0] == 0
+        assert progress[-1] == 100
+        assert all(0.0 <= p <= 100.0 for p in progress)
+
+    def test_progress_denoised_no_duplicates_below_100(self, run_render):
+        rc, progress, status, fail, _ = run_render(frames="0-9", mode="seq")
+        # each intermediate integer percent should be emitted at most once
+        assert len(progress) == len(set(progress))
+
+    def test_mfr_out_of_order_still_monotonic(self, run_render):
+        rc, progress, status, fail, _ = run_render(frames="0-9", mode="mfr")
+        assert rc == 0
+        assert progress == sorted(progress)
+        assert progress[-1] == 100
+
+    def test_movie_mode_no_frames_reports_100_on_success(self, run_render):
+        rc, progress, status, fail, out = run_render(frames="0-9", mode="movie")
+        assert rc == 0
+        assert progress[-1] == 100
+        assert "No per-frame PROGRESS lines" in out
+
+    def test_nonzero_exit_fails_and_no_false_100(self, run_render):
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="partial", exit_code=1
+        )
+        assert rc == 1
+        assert 100 not in progress  # never claim done on failure
+        assert fail  # a failure reason was emitted
+
+    def test_strong_error_fails_even_on_exit_0(self, run_render):
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="strong_error", exit_code=0
+        )
+        assert rc == 1
+        assert 100 not in progress
+        assert any("error" in f.lower() for f in fail)
+
+    def test_benign_error_lines_do_not_fail(self, run_render):
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="benign_error", exit_code=0
+        )
+        assert rc == 0
+        assert fail == []
+        assert progress[-1] == 100
+
+    def test_strict_scan_opt_in_fails_on_benign(self, run_render):
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9",
+            mode="benign_error",
+            exit_code=0,
+            env={"AE_STRICT_ERROR_SCAN": "1"},
+        )
+        assert rc == 1  # aggressive mode trips on "error" substring
+
+    def test_chunk_size_one_single_frame(self, run_render):
+        rc, progress, status, fail, _ = run_render(
+            frames="0-100", chunk_size=1, index=50, mode="seq"
+        )
+        assert rc == 0
+        assert progress[-1] == 100
+        assert "Rendered 1 of 1 frames" in status[-1]
+
+    def test_bad_frame_range_fails_cleanly(self, run_render):
+        rc, progress, status, fail, _ = run_render(frames="notarange", mode="seq")
+        assert rc == 1
+        assert fail
+
+    def test_undecodable_bytes_do_not_fail_render(self, run_render):
+        # A single non-UTF-8 byte in aerender's stdout must not kill an otherwise
+        # healthy render: errors="replace" keeps the stream readable so we still
+        # count every frame and reach 100%.
+        rc, progress, status, fail, _ = run_render(frames="0-9", mode="bad_bytes")
+        assert rc == 0
+        assert fail == []
+        assert progress[-1] == 100
+
+    def test_frame_lines_are_echoed_to_log(self, run_render):
+        # Per-frame PROGRESS lines must still reach the log (prefixed "[STDOUT] ")
+        # in addition to being counted -- their timing is the signal for
+        # diagnosing a slow/stalled render, and on long chunks most frame lines
+        # don't bump the percent, so without the echo the log goes silent.
+        rc, progress, status, fail, out = run_render(frames="0-9", mode="seq")
+        assert rc == 0
+        echoed_frames = [
+            ln
+            for ln in out.splitlines()
+            if ln.startswith("[STDOUT] PROGRESS:") and "Seconds" in ln
+        ]
+        assert len(echoed_frames) == 10  # every frame line echoed, none swallowed
+
+    def test_nonzero_exit_collapses_to_one(self, run_render):
+        # run() must return exactly 1 for any non-zero aerender exit, not the raw
+        # code: main() does sys.exit(run(...)) and sys.exit truncates to code &
+        # 0xFF, so a raw code that is a multiple of 256 would exit 0 on POSIX.
+        # Using 42 (not 1) proves the collapse rather than a pass-through.
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="seq", exit_code=42
+        )
+        assert rc == 1
+        assert fail
+
+    def test_under_render_exit_zero_warns(self, run_render):
+        # aerender can exit 0 having rendered fewer frames than asked (e.g.
+        # -continueOnMissingFootage). The task still succeeds by exit code, but
+        # the shortfall must be surfaced in the log rather than hidden behind 100%.
+        rc, progress, status, fail, out = run_render(
+            frames="0-9", mode="partial", exit_code=0
+        )
+        assert rc == 0
+        assert fail == []
+        assert progress[-1] == 100
+        assert "reported only 5 of 10 frames" in out
+
+
+# ----------------------------------------------------------------------------
+# openjd-sessions CONTRACT test: prove the worker would parse what we emit
+# ----------------------------------------------------------------------------
+class TestOpenJDContract:
+    def _drive_filter(self, emitted_stdout):
+        """Feed each emitted line through the real ActionMonitoringFilter."""
+        # ActionMonitoringFilter / ActionMessageKind live in the PRIVATE
+        # openjd.sessions._action_filter module -- not part of the package's
+        # public API, so a patch release could rename or move them. We pin
+        # openjd-sessions to a minor in requirements-testing.txt to keep that
+        # coupling diagnosable, and skip (rather than error at collection) if the
+        # dependency isn't installed at all.
+        pytest.importorskip("openjd.sessions")
+        from openjd.sessions._action_filter import (
+            ActionMonitoringFilter,
+            ActionMessageKind,
+        )
+
+        session_id = "session-test"
+        events = []
+
+        def callback(kind, value, cancel):
+            events.append((kind, value, cancel))
+
+        filt = ActionMonitoringFilter(session_id=session_id, callback=callback)
+
+        logger = logging.getLogger("call_aerender_contract_test")
+        for line in emitted_stdout.splitlines():
+            record = logging.LogRecord(
+                name=logger.name,
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg=line,
+                args=(),
+                exc_info=None,
+            )
+            record.session_id = session_id
+            filt.filter(record)
+        return events, ActionMessageKind
+
+    def test_progress_and_status_callbacks_fire(self, run_render):
+        _, _, _, _, out = run_render(frames="0-9", mode="seq")
+        events, Kind = self._drive_filter(out)
+
+        progress_events = [v for (k, v, _c) in events if k == Kind.PROGRESS]
+        status_events = [v for (k, v, _c) in events if k == Kind.STATUS]
+
+        assert progress_events, "worker parsed no PROGRESS updates"
+        assert status_events, "worker parsed no STATUS updates"
+        # openjd hands progress back as floats in [0, 100], monotonic here.
+        assert all(isinstance(p, float) for p in progress_events)
+        assert all(0.0 <= p <= 100.0 for p in progress_events)
+        assert progress_events == sorted(progress_events)
+        assert progress_events[-1] == 100.0
+
+    def test_failure_emits_fail_callback(self, run_render):
+        _, _, _, _, out = run_render(frames="0-9", mode="strong_error", exit_code=0)
+        events, Kind = self._drive_filter(out)
+        fail_events = [v for (k, v, _c) in events if k == Kind.FAIL]
+        assert fail_events, "worker parsed no FAIL message on a failing render"
+
+
+class TestEnsureUtf8Output:
+    def test_reconfigures_when_supported(self, monkeypatch):
+        seen = []
+
+        class _Stream:
+            def reconfigure(self, **kw):
+                seen.append(kw)
+
+        monkeypatch.setattr(call_aerender.sys, "stdout", _Stream())
+        monkeypatch.setattr(call_aerender.sys, "stderr", _Stream())
+        call_aerender._ensure_utf8_output()
+        assert seen == [
+            {"encoding": "utf-8", "errors": "replace"},
+            {"encoding": "utf-8", "errors": "replace"},
+        ]
+
+    def test_noop_when_reconfigure_absent(self, monkeypatch):
+        # A stream without reconfigure() (e.g. pytest capture) must not raise.
+        monkeypatch.setattr(call_aerender.sys, "stdout", object())
+        monkeypatch.setattr(call_aerender.sys, "stderr", object())
+        call_aerender._ensure_utf8_output()
+
+
+class TestControlChannelSanitization:
+    """A value carrying an embedded newline must never inject a second line into
+    the OpenJD control channel (the runtime dispatches on any line starting with
+    a reserved prefix)."""
+
+    def test_emit_fail_collapses_newlines(self, capsys):
+        call_aerender.emit_fail("boom\nopenjd_progress: 100")
+        out = capsys.readouterr().out.splitlines()
+        assert out == [
+            "openjd_fail: boom openjd_progress: 100"
+        ]  # one line, no forged progress
+        assert not any(ln.startswith("openjd_progress:") for ln in out)
+
+    def test_emit_status_collapses_crlf_and_env_injection(self, capsys):
+        call_aerender.emit_status("stage\r\nopenjd_env: FOO=bar")
+        out = capsys.readouterr().out.splitlines()
+        assert len(out) == 1
+        assert not any(ln.startswith("openjd_env:") for ln in out)
+
+    def test_emit_progress_coerces_int(self, capsys):
+        call_aerender.emit_progress(42)
+        assert capsys.readouterr().out.strip() == "openjd_progress: 42"
+
+
+class _FakeProc:
+    def __init__(self, wait_exc=None):
+        self.pid = 4321
+        self.killed = False
+        self.wait_timeout = "unset"
+        self._wait_exc = wait_exc
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self, timeout=None):
+        self.wait_timeout = timeout
+        if self._wait_exc is not None:
+            raise self._wait_exc
+        return 0
+
+
+class TestReapProcess:
+    def test_posix_kills_child_with_bounded_wait(self, monkeypatch):
+        monkeypatch.setattr(call_aerender.sys, "platform", "linux")
+        proc = _FakeProc()
+        call_aerender.reap_process(proc)
+        assert proc.killed is True
+        assert proc.wait_timeout == call_aerender._REAP_TIMEOUT_SECONDS
+
+    def test_windows_kills_whole_tree_via_taskkill(self, monkeypatch):
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return None
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", fake_run)
+        proc = _FakeProc()
+        call_aerender.reap_process(proc)
+        assert len(calls) == 1
+        cmd, kwargs = calls[0]
+        # /T reaps the tree (aerender.exe -> AfterFX.exe); PID targets our child.
+        assert cmd[0] == "taskkill" and "/T" in cmd and str(proc.pid) in cmd
+        assert kwargs.get("timeout") == call_aerender._REAP_TIMEOUT_SECONDS
+        assert proc.killed is False  # taskkill handled it; no fallback kill
+        assert proc.wait_timeout == call_aerender._REAP_TIMEOUT_SECONDS
+
+    def test_windows_falls_back_to_kill_when_taskkill_unavailable(self, monkeypatch):
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+
+        def boom(cmd, **kwargs):
+            raise FileNotFoundError("taskkill missing")
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", boom)
+        proc = _FakeProc()
+        call_aerender.reap_process(proc)
+        assert proc.killed is True  # fell back to reaping the direct child
+
+    def test_bounded_wait_swallows_timeout(self, monkeypatch):
+        # A wedged child that never exits must not hang cleanup.
+        monkeypatch.setattr(call_aerender.sys, "platform", "linux")
+        wedged = _FakeProc(
+            wait_exc=call_aerender.subprocess.TimeoutExpired(cmd="aerender", timeout=30)
+        )
+        call_aerender.reap_process(wedged)  # must not raise
+
+
+class TestSubprocessDecoding:
+    def test_pipe_uses_locale_encoding_not_hardcoded_utf8(self, monkeypatch):
+        # aerender is a native binary that writes the OS code page; the pipe must
+        # be decoded with the locale-preferred encoding, not a hard-coded utf-8
+        # (which would mojibake non-ASCII paths on a Windows worker).
+        captured = {}
+        real_popen = call_aerender.subprocess.Popen
+
+        def spy(cmd, **kwargs):
+            captured.update(kwargs)
+            return real_popen(cmd, **kwargs)
+
+        monkeypatch.setattr(call_aerender.subprocess, "Popen", spy)
+        monkeypatch.setenv("AERENDER_EXECUTABLE", sys.executable)
+        monkeypatch.setenv("FAKE_AE_MODE", "seq")
+        monkeypatch.setenv("FAKE_AE_EXIT", "0")
+        orig = call_aerender.build_render_args
+        monkeypatch.setattr(
+            call_aerender,
+            "build_render_args",
+            lambda a, s, e: [_FAKE_AERENDER] + orig(a, s, e),
+        )
+
+        call_aerender.run(["p.aep", "0", "/out/f_[####].png", "0-2"])
+
+        assert captured.get("errors") == "replace"
+        assert captured.get("encoding") == locale.getpreferredencoding(False)
+        assert (
+            captured.get("encoding") != "utf-8"
+            or locale.getpreferredencoding(False) == "utf-8"
+        )  # only equal to utf-8 if that's genuinely the locale default
+
+
+class TestLoadJunctionRules:
+    def test_empty_object_returns_no_rules(self, tmp_path):
+        # pathmapping-1.0 permits {} to mean "no rules"; that must parse to an
+        # empty list (render with the original paths), not raise.
+        f = tmp_path / "rules.json"
+        f.write_text("{}")
+        assert call_aerender.load_junction_rules(str(f)) == []
+
+    def test_malformed_file_raises_format_exception(self, tmp_path):
+        # Anything that is not a readable pathmapping-1.0 document must surface as
+        # JunctionPathmapFormatException so run() can fail the task closed.
+        f = tmp_path / "rules.json"
+        f.write_text("not json {[")
+        with pytest.raises(call_aerender.JunctionPathmapFormatException):
+            call_aerender.load_junction_rules(str(f))
+
+
+class TestFilterInvalidJunctions:
+    def test_missing_junction_is_dropped(self, tmp_path, capsys):
+        # A stale rules file may name a junction that no longer exists; that rule
+        # must be dropped rather than rewriting a path to a missing directory.
+        present = tmp_path / "present"
+        present.mkdir()
+        rules = [
+            ("C:\\a", str(present)),
+            ("C:\\b", str(tmp_path / "gone")),
+        ]
+        assert call_aerender.filter_invalid_junctions(rules) == [
+            ("C:\\a", str(present))
+        ]
+        assert "does not exist" in capsys.readouterr().err
+
+
+class TestRunFailClosedJunctions:
+    def test_malformed_junctions_file_fails_task(
+        self, run_render, monkeypatch, tmp_path
+    ):
+        # A malformed DEADLINE_JUNCTIONS must fail the task (rc 1 + openjd_fail),
+        # NOT silently fall back to rendering the original long paths.
+        bad = tmp_path / "rules.json"
+        bad.write_text("not json {[")
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+
+        rc, progress, status, fail, out = run_render(
+            env={call_aerender.JUNCTIONS_ENV_VAR: str(bad)}
+        )
+
+        assert rc == 1
+        assert fail and any(call_aerender.JUNCTIONS_ENV_VAR in f for f in fail)
+
+
+class TestRunReapsOnException:
+    def test_stream_failure_reaps_running_process(self, monkeypatch):
+        # If the stream loop raises after the child launched, run()'s finally must
+        # still reap the (poll() is None => still running) process so no orphan
+        # aerender/AfterFX survives to hold a license/render slot.
+        class _Stdout:
+            def readline(self):
+                raise RuntimeError("pipe failed mid-render")
+
+            def close(self):
+                pass
+
+        class _StreamBoom:
+            pid = 999
+            stdout = _Stdout()
+
+            def poll(self):
+                return None  # still running -> finally must reap it
+
+            def wait(self, timeout=None):
+                return 0
+
+        launched = _StreamBoom()
+        monkeypatch.setattr(call_aerender.subprocess, "Popen", lambda *a, **k: launched)
+        reaped = []
+        monkeypatch.setattr(call_aerender, "reap_process", lambda p: reaped.append(p))
+        monkeypatch.setenv("AERENDER_EXECUTABLE", "aerender.exe")
+
+        rc = call_aerender.run(["p.aep", "0", "/out/f_[####].png", "0-2"])
+
+        assert rc == 1
+        assert reaped == [launched]
+
+
+class TestDiagnosticPrintsAreSanitized:
+    def test_path_mapped_lines_cannot_forge_control_line(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        # apply_junctions echoes the mapped project/output to stdout (the control
+        # channel). A newline in a mapped path must not forge a reserved-prefix
+        # line (e.g. an attacker-controlled rules-file destination).
+        junction = tmp_path / "j"
+        junction.mkdir()
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(
+            json.dumps(
+                {
+                    "path_mapping_rules": [
+                        {
+                            "source_path": "C:\\assetroot",
+                            "destination_path": str(junction),
+                        }
+                    ]
+                }
+            )
+        )
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setenv(call_aerender.JUNCTIONS_ENV_VAR, str(rules_file))
+
+        class _Args:
+            project = "C:\\assetroot\\proj.aep\nopenjd_fail: forged"
+            outputpath = "C:\\assetroot\\o.png"
+
+        args = _Args()
+        call_aerender.apply_junctions(args)
+
+        out = capsys.readouterr().out.splitlines()
+        assert not any(ln.startswith("openjd_fail:") for ln in out)


### PR DESCRIPTION
## What

Adds OpenJD progress and failure reporting to the After Effects render script
(`call_aerender.py`).

While `aerender` runs, the script now emits the reserved OpenJD stdout lines so
per-task progress, status, and failures surface in Deadline Cloud Monitor instead of a
job only flipping from 0% to 100% at the end:

- `openjd_progress: <0-100>` — count-based (distinct frames seen / frames owned by the
  task), **monotonic**, and independent of whether `aerender` prints absolute or
  chunk-relative frame numbers.
- `openjd_status: <message>` — human-readable render status (e.g. `Rendered 57 of 150 frames`).
- `openjd_fail: <message>` — emitted on failure so the reason reaches the monitor.

## Why

Previously a render task reported no intermediate progress, and some failure modes were
easy to miss. This makes long renders observable and makes failures explicit.

## Notable behavior changes

- **Exit code is authoritative.** Anchored strong-error patterns still fail the task
  even if `aerender` lies with exit 0. The old bare `"error"` substring scan (which
  false-positived on benign lines like footage filenames containing "error") is
  downgraded to a non-fatal warning; opt back into the strict scan with
  `AE_STRICT_ERROR_SCAN=1`.
- **Control-channel sanitization.** OpenJD dispatches on any stdout line that *starts*
  with a reserved prefix, so untrusted content (footage names, `aerender` errors) could
  otherwise forge a control line — e.g. a failure reason of `"boom\nopenjd_progress: 100"`
  spoofing a progress callback. All emitted status/fail messages are collapsed to a
  single line at the choke point, and non-control `aerender` output is passed through
  behind a `[STDOUT] ` prefix so it can never be mistaken for a control line.
- **Orphan process reaping.** On Windows `aerender.exe` is a thin launcher that spawns
  `AfterFX.exe` as a separate process; a bare `kill()` would leave `AfterFX.exe` holding
  a render slot / license that a retried task collides with. Cleanup now tree-kills via
  `taskkill /T`, bounded by a timeout so a wedged process can't hang cleanup. (POSIX
  uses `kill()`.)
- **Junction path mapping** is unchanged in behavior, but the block that lived inline
  in `main()` is extracted into `apply_junctions()` so the new `run()` orchestrator can
  call it and it can be unit-tested. Its one visible improvement: a malformed mapping
  file now surfaces as a clean `openjd_fail` message (still exits non-zero) rather than
  an uncaught traceback. (`_to_windows_path` was also renamed to `_normalize`.)
- **Refactor for testability.** `main()` is split into importable pure functions
  (`parse_args`, `parse_frame_range`, `resolve_chunk`, `build_render_args`,
  `is_strong_error`, `apply_junctions`, `reap_process`, `run`) while preserving output
  streaming and stderr merging.

## Testing

New unit suite (`test/unit/test_call_aerender.py`, `test/unit/fake_aerender.py`) —
**68 tests, all passing**. Coverage:

- Pure-function units: frame-range parsing, chunk resolution, strong-error matching,
  progress-frame pattern.
- End-to-end `run()` against a fake `aerender` stub: monotonic-to-100 progress,
  de-duplicated progress, out-of-order multi-frame rendering, movie-mode (no per-frame
  output) reporting 100 on success, non-zero exit failing without a false 100, strong
  error failing even on exit 0, benign "error" lines not failing, and bad frame range
  failing cleanly.
- Junction handling: rule loading/validation, per-output mapping across comma lists,
  invalid-junction filtering, and fail-closed behavior on a malformed mapping file.
- Control-channel sanitization: status/fail messages and diagnostic prints cannot inject
  or forge reserved `openjd_` control lines.
- Process reaping: Windows tree-kill via `taskkill`, fallback to direct-child reaping,
  bounded wait that swallows a timeout, and reaping on the in-process exception path.
- Output encoding: UTF-8 stdout and subprocess decoding.
- OpenJD contract test: emitted stdout is fed through the real OpenJD sessions
  `ActionMonitoringFilter` to prove the PROGRESS/STATUS/FAIL callbacks actually fire.

```
$ pytest test/unit/test_call_aerender.py
...
68 passed in 1.64s
```

Also verified end-to-end on a real Deadline Cloud render on a Windows worker (180-frame
job, MFR off): the worker session log shows the emitted lines climbing 0→100 in lockstep
with the `aerender` frame count, and the task succeeded. Sample of the emitted
render-step output:

```
openjd_status: Rendering frames 0-179
openjd_progress: 0
openjd_status: Rendered 2 of 180 frames
openjd_progress: 1
openjd_status: Rendered 99 of 180 frames
openjd_progress: 55
...
openjd_status: Rendered 180 of 180 frames
openjd_progress: 100
```
