### PR TITLE
ci: pin gitpython < 3.1.60 to unblock release

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,6 @@
 python-semantic-release == 10.6.*
+# GitPython 3.1.60's ReDoS-hardening removed Actor.name_email_regex, which
+# python-semantic-release 10.6.1 still references (crashes the release "Bump"
+# job with: type object 'Actor' has no attribute 'name_email_regex'). Pin below
+# 3.1.60 until a PSR release stops using the removed attribute, then drop this.
+gitpython < 3.1.60


### PR DESCRIPTION
## What

Pin `gitpython < 3.1.60` in `requirements-release.txt`.

## Why

The release **Version Bump / Bump** job started failing at the `NextSemver` step ([run 32899515608](https://github.com/aws-deadline/deadline-cloud-for-after-effects/actions/runs/32899515608/job/97969807937)) with:

```
type object 'Actor' has no attribute 'name_email_regex'
```

GitPython **3.1.60** (released 2026-08-25, a ReDoS-hardening security release) removed the `Actor.name_email_regex` attribute that **python-semantic-release 10.6.1** (our pinned `10.6.*`, and currently the latest) still references. `requirements-release.txt` pinned only `python-semantic-release` and let GitPython float, so CI pulled the new 3.1.60 and `semantic-release version` crashes before computing a version. This blocks releases regardless of what is being released.

Verified the boundary:

| gitpython | `Actor.name_email_regex` | PSR 10.6.1 |
|---|---|---|
| 3.1.59 | present | works |
| 3.1.60 | removed | crashes (above error) |

## Fix / follow-up

Pin below 3.1.60 to unblock releases. Tradeoff: forgoes 3.1.60's three advisories (3.1.59's fixes are retained). Once a python-semantic-release build ships that no longer uses the removed attribute, drop the pin.