### PR TITLE
fix: Solve multiple OpenMP lib crash issue for the aerender subprocess

### DIFF
--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
@@ -288,6 +288,26 @@ def is_strong_error(line):
     return any(p.search(line) for p in STRONG_ERROR_PATTERNS)
 
 
+def build_render_env(base_env=None):
+    """Set KMP_DUPLICATE_LIB_OK=TRUE so AE + duplicate-OpenMP plugins don't abort."""
+    env = dict(os.environ if base_env is None else base_env)
+    env.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+    # Always announce the effective value so a maintainer can confirm whether the
+    # OpenMP workaround was active on the task.
+    if env["KMP_DUPLICATE_LIB_OK"].strip().upper() == "TRUE":
+        print(
+            "[DEBUG] KMP_DUPLICATE_LIB_OK=TRUE (duplicate-OpenMP workaround active).",
+            flush=True,
+        )
+    else:
+        print(
+            f"[WARN] KMP_DUPLICATE_LIB_OK={env['KMP_DUPLICATE_LIB_OK']!r} (not TRUE); "
+            "render may fail if multiple OpenMP runtimes load.",
+            flush=True,
+        )
+    return env
+
+
 # How long to wait for the aerender child to exit before giving up, so a wedged
 # process can't hang cleanup indefinitely (the OpenJD session would then have to
 # force-terminate this script, losing the rest of the cleanup).
@@ -428,6 +448,7 @@ def run(argv):
             encoding=locale.getpreferredencoding(False),
             errors="replace",
             bufsize=1,
+            env=build_render_env(),
         )
 
         for line in iter(process.stdout.readline, ""):

--- a/test/unit/test_call_aerender.py
+++ b/test/unit/test_call_aerender.py
@@ -746,3 +746,53 @@ class TestDiagnosticPrintsAreSanitized:
 
         out = capsys.readouterr().out.splitlines()
         assert not any(ln.startswith("openjd_fail:") for ln in out)
+
+
+# ----------------------------------------------------------------------------
+# aerender launched with KMP_DUPLICATE_LIB_OK=TRUE
+# ----------------------------------------------------------------------------
+class TestRenderEnv:
+    def test_kmp_true_injected_when_absent(self):
+        assert (
+            call_aerender.build_render_env(base_env={})["KMP_DUPLICATE_LIB_OK"]
+            == "TRUE"
+        )
+
+    @pytest.mark.parametrize("value", ["FALSE", ""])
+    def test_operator_value_is_honored_not_forced(self, value):
+        env = call_aerender.build_render_env(base_env={"KMP_DUPLICATE_LIB_OK": value})
+        assert env["KMP_DUPLICATE_LIB_OK"] == value
+
+    def test_base_env_carried_through_and_not_mutated(self):
+        base = {"PATH": "/usr/bin"}
+        env = call_aerender.build_render_env(base_env=base)
+        assert env["PATH"] == "/usr/bin"
+        assert "KMP_DUPLICATE_LIB_OK" not in base
+
+    def test_aerender_child_receives_kmp_true(self, monkeypatch):
+        # Behavioral: spy on Popen and assert the env actually handed to the
+        # aerender child sets KMP_DUPLICATE_LIB_OK, rather than matching source text.
+        captured = {}
+        real_popen = call_aerender.subprocess.Popen
+
+        def spy(cmd, **kwargs):
+            captured.update(kwargs)
+            return real_popen(cmd, **kwargs)
+
+        monkeypatch.setattr(call_aerender.subprocess, "Popen", spy)
+        monkeypatch.delenv(
+            "KMP_DUPLICATE_LIB_OK", raising=False
+        )  # not preset -> fix must set it
+        monkeypatch.setenv("AERENDER_EXECUTABLE", sys.executable)
+        monkeypatch.setenv("FAKE_AE_MODE", "seq")
+        monkeypatch.setenv("FAKE_AE_EXIT", "0")
+        orig = call_aerender.build_render_args
+        monkeypatch.setattr(
+            call_aerender,
+            "build_render_args",
+            lambda a, s, e: [_FAKE_AERENDER] + orig(a, s, e),
+        )
+
+        call_aerender.run(["p.aep", "0", "/out/f_[####].png", "0-2"])
+
+        assert captured.get("env", {}).get("KMP_DUPLICATE_LIB_OK") == "TRUE"


### PR DESCRIPTION
## What
Launch `aerender` with `KMP_DUPLICATE_LIB_OK=TRUE` via a new `build_render_env()`, preserving any operator-set override.

## Why
After Effects and common plugins (Trapcode, Element 3D, …) each bundle their own Intel OpenMP runtime. Two copies loaded into one process abort with `OMP: Error #15: … libiomp5md already initialized`, killing the render. Deadline 10 set this variable in `InitializeProcess()`; the Deadline Cloud worker set it nowhere.

## Validation on a real Service-Managed-Fleet worker
Bundled AE's own `libiomp5md.dll` to recreate the duplicate-OpenMP condition on the worker:
- **stock** `call_aerender.py` → aerender child launched with `KMP_DUPLICATE_LIB_OK` unset → `OMP: Error #15`, exit 3 → task **FAILED**
- **this change** → child launched with `KMP_DUPLICATE_LIB_OK=TRUE` → survived, exit 0 → task **SUCCEEDED**

## Tests
Unit tests for `build_render_env()` (sets the variable, preserves an existing override, and that the Popen launch is wired to use it).

---