### PR TITLE
fix: stop classifying gif as an image sequence

### DIFF
--- a/dist/DeadlineCloudSubmitter.jsx
+++ b/dist/DeadlineCloudSubmitter.jsx
@@ -604,7 +604,7 @@ function __generateUtil() {
     }
 
     function isImage(extension) {
-        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "gif", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
+        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
         return frameExtensions.indexOf(extension) >= 0;
     }
 

--- a/src/utils/Utils.jsx
+++ b/src/utils/Utils.jsx
@@ -600,7 +600,7 @@ function __generateUtil() {
     }
 
     function isImage(extension) {
-        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "gif", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
+        const frameExtensions = ["ai", "eps", "ps", "pdf", "psd", "bmp", "rle", "dlb", "tif", "crw", "nef", "raf", "orf", "mrw", "dcr", "mos", "raw", "pef", "srf", "dng", "x3f", "cr2", "erf", "sr2", "mfw", "mef", "arw", "cin", "dpx", "rla", "rpf", "img", "ei", "eps", "iff", "tdi", "jpg", "jpe", "heif", "ma", "exr", "sxr", "mxr", "pcx", "png", "hdr", "rgbe", "xyze", "sgi", "bw", "rgb", "pic", "tga", "vda", "icb", "vst", "tif", "jpeg"];
         return frameExtensions.indexOf(extension) >= 0;
     }
 

--- a/test/unit/test_output_extension_classification.py
+++ b/test/unit/test_output_extension_classification.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Regression guard: "gif" must not be in isImage()'s frameExtensions. If it is, a
+.gif render-queue output is treated as an image sequence and chunked across tasks
+that all overwrite the one file, silently losing frames."""
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).parent.parent.parent / "src" / "utils" / "Utils.jsx"
+_DIST = Path(__file__).parent.parent.parent / "dist" / "DeadlineCloudSubmitter.jsx"
+
+
+def _frame_extensions(path):
+    source = path.read_text(encoding="utf-8")
+    match = re.search(r"const frameExtensions = \[(.*?)\];", source, re.S)
+    assert match, f"could not find frameExtensions array in {path.name}"
+    # ExtendScript allows either quote style; accept both so a single-quoted
+    # re-add of "gif" can't slip past this guard.
+    return re.findall(r"""['"]([^'"]+)['"]""", match.group(1))
+
+
+def test_gif_is_not_an_image_extension():
+    assert "gif" not in _frame_extensions(_SRC)
+
+
+def test_src_and_dist_frame_extensions_agree():
+    assert _frame_extensions(_SRC) == _frame_extensions(_DIST)


### PR DESCRIPTION
## Summary
`"gif"` was listed as a frame-sequence extension in `isImage()` (`frameExtensions`). An Animated GIF is a **single file**, not a numbered sequence, so this misclassified GIF in the two places `isImage()` is consulted. Remove `"gif"` from `frameExtensions`; it stays in `videoExtensions`.

## The bug
`isImage()` drives two decisions, and gif was wrong for both:

**1. Output chunking** — `isRenderQueueItemImageOutput()` → `isImage(outputExtension)`. An image-sequence output is split across `ceil(frames / framesPerTask)` parallel tasks, each writing its own numbered files (`frame_00010.png`, …), which is safe because tasks write different files. A `.gif` output was treated the same way, so N tasks all wrote the **one** `output.gif` — last writer wins, every other task’s frames are lost, and the job still reports success (silent data loss).

**2. Footage attachment** — `determineFootageType()` → `getFilePathsFromFootageItem()`. An animated `.gif` used as footage was routed to the image-sequence branch, where `getImageSequenceInformation("banner.gif")` finds no frame digits (`parseInt` → `NaN`), every frame comparison is false, and the file is **silently dropped from job attachments** → missing footage on the worker.

## The fix
Remove `"gif"` from `frameExtensions`. A GIF is a single-file animation and remains in `videoExtensions`. Now a `.gif` output renders in one task, and an animated-GIF footage item is classified as video and attached as a single file.

**Trade-off:** a numbered sequence of individual `.gif` **still** files used as footage would now attach only the first frame. Accepted — real image sequences are png/exr/tif/dpx; telling an animated GIF apart from a GIF still-sequence needs sequence detection beyond the extension, which is out of scope here.

## Testing
- **Unit tests (regression guards, passing):** `"gif"` is absent from `frameExtensions`, and `src` and the generated `dist` bundle agree (so the bundle cannot drift from source).
- **Manual validation scope:** enumerating AE’s render-queue output modules showed there is **no Animated GIF module** — AE rewrites a forced `.gif` output to `.mp4` — so a `.gif` *output* is not producible on current AE. The output-chunking half is therefore a **defensive** guard (covers `.gif` output paths carried in a project), while the reachable, behavior-affecting change is the **footage classification**, verified by tracing both `isImage()` call sites.