### PR TITLE
feat: add HEVC/GPU remediation hint to "Could not read from source" failures

### DIFF
--- a/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
+++ b/dist/DeadlineCloudSubmitter_Assets/JobTemplate/scripts/call_aerender.py
@@ -227,6 +227,119 @@ STRONG_ERROR_PATTERNS = [
 # "error" lines); AE_STRICT_ERROR_SCAN=1 restores the original fail-on-any behavior.
 BARE_ERROR_PATTERN = re.compile(r"error", re.IGNORECASE)
 
+# Fails the task even on exit 0: AE can log this bare (no STRONG_ERROR prefix) and
+# still exit 0, which would otherwise ship black frames as success. Also drives the hint.
+# Too loose to fail on alone -- pair it with is_source_read_failure().
+COULD_NOT_READ_SOURCE_PATTERN = re.compile(r"could not read from source", re.IGNORECASE)
+
+# AE stamps a genuine decode failure with its error-code suffix, e.g. "( 86 :: 2 )".
+AE_ERROR_CODE_PATTERN = re.compile(r"\(\s*\d+\s*::\s*\d+\s*\)")
+
+# Cap the GPU probe so a missing/wedged nvidia-smi can't stall failure reporting.
+_GPU_PROBE_TIMEOUT_SECONDS = 5
+
+
+def _resolve_nvidia_smi():
+    """Windows-only path to nvidia-smi.exe under the OS system dir, or None."""
+    # System dir via the OS, never PATH/%SystemRoot%/cwd -- all job-controllable.
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        buffer = ctypes.create_unicode_buffer(260)  # MAX_PATH
+        length = ctypes.windll.kernel32.GetSystemDirectoryW(buffer, len(buffer))
+        # 0 means failure; >= buffer size means truncation (buffer left unfilled).
+        if not length or length >= len(buffer):
+            return None
+        candidate = os.path.join(buffer.value, "nvidia-smi.exe")
+        return candidate if os.path.isfile(candidate) else None
+    except Exception:  # noqa: BLE001 - any resolution failure means "no GPU"
+        # Keeps decode_failure_hint total: it runs before emit_fail and outside the
+        # render try/finally, so a raising probe would swallow the openjd_fail line.
+        return None
+
+
+def worker_has_nvidia_gpu():
+    # Necessary, not sufficient, for HEVC decode: AE can also use an Intel iGPU, so
+    # callers word the hint loosely. Any probe failure counts as "no NVIDIA GPU".
+    nvidia_smi = _resolve_nvidia_smi()
+    if not nvidia_smi:
+        return False
+    try:
+        result = subprocess.run(
+            [nvidia_smi, "-L"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_GPU_PROBE_TIMEOUT_SECONDS,
+            check=False,
+            # Run from the resolved (system) dir, never the session cwd: Windows'
+            # new-process DLL search order includes the current directory, and a job
+            # drops attachments into the session cwd, so a delay-loaded dependency
+            # nvidia-smi.exe needs but System32 lacks could otherwise load job content.
+            cwd=os.path.dirname(nvidia_smi),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and b"GPU" in (result.stdout or b"")
+
+
+def decode_failure_hint(saw_read_source_error):
+    if not saw_read_source_error:
+        return ""
+    # A bad path is the common cause, so source-path advice always leads; the HEVC/GPU
+    # clause is Windows-only and probes for a GPU only when it might apply.
+    hint = (
+        "aerender could not read a source clip. First confirm every source file "
+        "exists and its path resolves on this worker."
+    )
+    if sys.platform == "win32" and not worker_has_nvidia_gpu():
+        hint += (
+            " If the sources are fine, a likely cause is a codec that needs a GPU "
+            "hardware decoder -- e.g. HEVC/H.265 -- since no NVIDIA GPU was detected "
+            "on this worker; render on a GPU-enabled fleet or transcode the "
+            "source(s) to H.264 before submitting."
+        )
+    return hint
+
+
+def _source_read_hint_anchored(reported_line, read_source_line):
+    hint = decode_failure_hint(bool(read_source_line))
+    # When an unrelated error is the headline, prefix the source-read line so the advice
+    # stays tied to what justifies it (else the message reads as self-contradictory).
+    if hint and read_source_line and read_source_line != reported_line:
+        hint = f"Also saw: {read_source_line} {hint}"
+    return hint
+
+
+def build_failure_message(returncode, strong_error_line, read_source_line):
+    """The (openjd_fail, log) message pair for a failed render, or None on success.
+
+    Lines are "" when unseen. On exit 0 a strong error or a source-read line still fails
+    -- the bare source-read spelling would otherwise ship black frames as success.
+    """
+    # Report the most specific evidence: a strong error, else the source-read line.
+    reported_line = strong_error_line or read_source_line
+    if returncode == 0 and not reported_line:
+        return None
+
+    hint = _source_read_hint_anchored(reported_line, read_source_line)
+    suffix = f" {hint}" if hint else ""
+
+    if returncode != 0:
+        # Keep the exit code alongside the line: 137/-1073741819 (worker killed AE)
+        # warrants a retry, not a resubmit, so it must not be replaced by the line.
+        if reported_line:
+            reason = f"{reported_line} (aerender exited with code {returncode}){suffix}"
+        else:
+            reason = f"aerender exited with code {returncode}{suffix}"
+        return reason, reason
+
+    return (
+        f"aerender reported an error: {reported_line}{suffix}",
+        f"aerender exited 0 but reported an error: {reported_line}{suffix}",
+    )
+
 
 def parse_frame_range(frames):
     """Parse "start-end" into (start, end). Raises ValueError on bad input."""
@@ -286,6 +399,16 @@ def build_render_args(args, start_frame, end_frame):
 
 def is_strong_error(line):
     return any(p.search(line) for p in STRONG_ERROR_PATTERNS)
+
+
+def is_source_read_failure(line):
+    # The bare phrase alone would fail a healthy render whose footage/output name merely
+    # contains it (aerender echoes user-controlled names verbatim -- see is_strong_error).
+    # Require AE's own signal too: a strong-error prefix or its error-code suffix, both of
+    # which every real decode failure carries.
+    return bool(COULD_NOT_READ_SOURCE_PATTERN.search(line)) and (
+        is_strong_error(line) or bool(AE_ERROR_CODE_PATTERN.search(line))
+    )
 
 
 def build_render_env(base_env=None):
@@ -429,7 +552,9 @@ def run(argv):
 
     frames_seen = set()
     last_reported_progress = 0
-    strong_error_line = None
+    # First matching line of each kind, or "" if unseen.
+    strong_error_line = ""
+    read_source_line = ""
     process = None
 
     try:
@@ -458,14 +583,17 @@ def run(argv):
             if is_strong_error(line):
                 # Real, well-formed AE/aerender error. Remember the first one so
                 # we can report it, and fail the task regardless of exit code.
-                if strong_error_line is None:
+                if not strong_error_line:
                     strong_error_line = line
                 print(f"[ERROR DETECTED] {line}", file=sys.stderr, flush=True)
             elif strict_error_scan and BARE_ERROR_PATTERN.search(line):
                 # Opt-in aggressive behavior: any "error" substring fails.
-                if strong_error_line is None:
+                if not strong_error_line:
                     strong_error_line = line
                 print(f"[ERROR DETECTED strict] {line}", file=sys.stderr, flush=True)
+
+            if not read_source_line and is_source_read_failure(line):
+                read_source_line = line
 
             # --- progress counting -------------------------------------------
             match = PROGRESS_FRAME_PATTERN.search(line)
@@ -506,26 +634,13 @@ def run(argv):
             reap_process(process)
 
     # --- final verdict ---------------------------------------------------
-    # Exit code is authoritative; a strong error line fails even on exit 0.
-    if returncode != 0:
-        reason = (
-            strong_error_line
-            if strong_error_line is not None
-            else f"aerender exited with code {returncode}"
-        )
-        emit_fail(reason)
-        print(f"[ERROR] {reason}", file=sys.stderr, flush=True)
-        # Collapse to 1, not the raw code: main() does sys.exit(code & 0xFF), so a
-        # non-zero multiple of 256 would exit 0 and mark a failed render successful.
-        return 1
-
-    if strong_error_line is not None:
-        emit_fail(f"aerender reported an error: {strong_error_line}")
-        print(
-            f"[ERROR] aerender exited 0 but reported an error: {strong_error_line}",
-            file=sys.stderr,
-            flush=True,
-        )
+    failure = build_failure_message(returncode, strong_error_line, read_source_line)
+    if failure is not None:
+        openjd_message, log_message = failure
+        emit_fail(openjd_message)
+        print(f"[ERROR] {log_message}", file=sys.stderr, flush=True)
+        # Collapse to 1: main() does sys.exit(code & 0xFF), so a multiple of 256 would
+        # exit 0 and mark a failed render successful.
         return 1
 
     if not frames_seen:

--- a/test/unit/fake_aerender.py
+++ b/test/unit/fake_aerender.py
@@ -8,7 +8,7 @@ It reads -s/-e from argv and env vars to decide what to emit, then replays
 canned stdout lines shaped like real "-v ERRORS_AND_PROGRESS" output.
 
 Env controls:
-    FAKE_AE_MODE   seq (default) | mfr | movie | strong_error | benign_error | partial | bad_bytes
+    FAKE_AE_MODE   seq (default) | mfr | movie | strong_error | read_source_error | bare_read_source_error | error_then_read_source | full_render_then_read_source | benign_source_read_name | benign_error | partial | bad_bytes
     FAKE_AE_EXIT   integer exit code to return (default "0")
 """
 
@@ -71,6 +71,50 @@ def main():
             print(frame_line(f), flush=True)
         # Well-formed AE error line.
         print("After Effects error: Unable to open project file.", flush=True)
+    elif mode == "read_source_error":
+        # The HEVC-on-CPU symptom: aerender prints the AE error and (as observed
+        # on real workers) still exits 0, so STRONG_ERROR_PATTERNS is what fails it.
+        print(
+            "aerender Error: After Effects error: Could not read from source. "
+            "Please check the settings and try again.",
+            flush=True,
+        )
+    elif mode == "bare_read_source_error":
+        # AE also logs the source-read failure BARE -- no "After Effects error:" or
+        # "aerender ERROR:" prefix -- and still exits 0. STRONG_ERROR_PATTERNS misses
+        # this spelling, so only COULD_NOT_READ_SOURCE_PATTERN can fail it.
+        print(
+            "Could not read from source. Please check the settings and try again. "
+            "( 86 :: 2 )",
+            flush=True,
+        )
+    elif mode == "error_then_read_source":
+        # An unrelated AE error appears BEFORE the source-read one, so the first
+        # captured error line is not the source-read line.
+        print("After Effects error: Unable to open project file.", flush=True)
+        print(
+            "aerender Error: After Effects error: Could not read from source. "
+            "Please check the settings and try again.",
+            flush=True,
+        )
+    elif mode == "full_render_then_read_source":
+        # AE renders EVERY frame (progress reaches 100%) and only THEN logs the bare
+        # source-read failure -- the "ships black frames as success" case. Exercises the
+        # real ordering: progress is emitted before the verdict, so 100% is reported and
+        # the task must still fail afterwards.
+        for f in frames:
+            print(frame_line(f), flush=True)
+        print(
+            "Could not read from source. Please check the settings and try again. "
+            "( 86 :: 2 )",
+            flush=True,
+        )
+    elif mode == "benign_source_read_name":
+        # A footage name that merely CONTAINS the phrase, with no AE prefix and no error
+        # code -- must NOT fail an otherwise healthy render.
+        print("Loading footage: could not read from source_FIX.mov", flush=True)
+        for f in frames:
+            print(frame_line(f), flush=True)
     elif mode == "benign_error":
         # Lines that contain "error" but are NOT failures.
         print("Loading footage: error_analysis_final.mov", flush=True)

--- a/test/unit/test_call_aerender.py
+++ b/test/unit/test_call_aerender.py
@@ -11,11 +11,13 @@ Layers:
     exactly as Deadline Cloud's worker would parse them.
 """
 
+import ctypes
 import importlib.util
 import json
 import locale
 import logging
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -112,6 +114,225 @@ class TestStrongError:
         # Both case spellings still match (proving the dedupe kept coverage).
         assert call_aerender.is_strong_error("aerender ERROR: boom") is True
         assert call_aerender.is_strong_error("aerender Error: boom") is True
+
+
+class TestWorkerHasNvidiaGpu:
+    def _fake_completed(self, returncode, stdout):
+        class _R:
+            pass
+
+        r = _R()
+        r.returncode = returncode
+        r.stdout = stdout
+        return r
+
+    def _resolves(self, monkeypatch):
+        """Pretend nvidia-smi resolves so the subprocess branch is reached."""
+        monkeypatch.setattr(
+            call_aerender,
+            "_resolve_nvidia_smi",
+            lambda: r"C:\Windows\System32\nvidia-smi.exe",
+        )
+
+    def test_true_when_nvidia_smi_lists_a_gpu(self, monkeypatch):
+        self._resolves(monkeypatch)
+        monkeypatch.setattr(
+            call_aerender.subprocess,
+            "run",
+            lambda *a, **k: self._fake_completed(0, b"GPU 0: Tesla T4 (UUID: GPU-x)\n"),
+        )
+        assert call_aerender.worker_has_nvidia_gpu() is True
+
+    def test_false_when_no_gpu_listed(self, monkeypatch):
+        self._resolves(monkeypatch)
+        monkeypatch.setattr(
+            call_aerender.subprocess,
+            "run",
+            lambda *a, **k: self._fake_completed(0, b""),
+        )
+        assert call_aerender.worker_has_nvidia_gpu() is False
+
+    def test_false_when_unresolved(self, monkeypatch):
+        # nvidia-smi not found -> "no GPU", and we must not run anything.
+        monkeypatch.setattr(call_aerender, "_resolve_nvidia_smi", lambda: None)
+
+        def boom(*a, **k):
+            raise AssertionError("nvidia-smi must not be launched when unresolved")
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", boom)
+        assert call_aerender.worker_has_nvidia_gpu() is False
+
+    def test_false_when_launch_fails(self, monkeypatch):
+        self._resolves(monkeypatch)
+
+        def boom(*a, **k):
+            raise FileNotFoundError("nvidia-smi vanished after resolution")
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", boom)
+        assert call_aerender.worker_has_nvidia_gpu() is False
+
+    def test_false_when_nvidia_smi_times_out(self, monkeypatch):
+        self._resolves(monkeypatch)
+
+        def timeout(*a, **k):
+            raise call_aerender.subprocess.TimeoutExpired(cmd="nvidia-smi", timeout=5)
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", timeout)
+        assert call_aerender.worker_has_nvidia_gpu() is False
+
+    def test_false_on_nonzero_exit(self, monkeypatch):
+        self._resolves(monkeypatch)
+        monkeypatch.setattr(
+            call_aerender.subprocess,
+            "run",
+            lambda *a, **k: self._fake_completed(9, b"some driver error"),
+        )
+        assert call_aerender.worker_has_nvidia_gpu() is False
+
+    def test_probe_runs_from_resolved_dir_not_session_cwd(self, monkeypatch, tmp_path):
+        # Windows' new-process DLL search order includes the current directory, and a
+        # job controls the session cwd, so the probe must launch from the resolved
+        # (system) dir -- never the cwd -- to avoid loading job-supplied DLLs. Build the
+        # path with os.path.join so dirname is meaningful under posix ntpath alike.
+        resolved = str(tmp_path / "nvidia-smi.exe")
+        monkeypatch.setattr(call_aerender, "_resolve_nvidia_smi", lambda: resolved)
+        captured = {}
+
+        def capture(*a, **k):
+            captured["cwd"] = k.get("cwd")
+            return self._fake_completed(0, b"GPU 0: Tesla T4\n")
+
+        monkeypatch.setattr(call_aerender.subprocess, "run", capture)
+        assert call_aerender.worker_has_nvidia_gpu() is True
+        assert captured["cwd"] == str(tmp_path)
+
+
+class TestResolveNvidiaSmi:
+    def test_none_off_windows(self, monkeypatch):
+        # The probe is Windows-only; every other platform resolves to nothing.
+        monkeypatch.setattr(call_aerender.sys, "platform", "darwin")
+        assert call_aerender._resolve_nvidia_smi() is None
+
+    def test_windows_uses_os_system_dir_not_cwd(self, monkeypatch, tmp_path):
+        # The system directory comes from the OS (GetSystemDirectoryW), never PATH,
+        # %SystemRoot%, or the cwd where job attachments land. A nvidia-smi.exe in the
+        # cwd must never be resolved; only the OS-reported system dir counts.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+
+        sysdir = tmp_path / "System32"
+        sysdir.mkdir()
+
+        def fake_get_system_directory(buf, _size):
+            buf.value = str(sysdir)
+            return len(str(sysdir))
+
+        fake_windll = types.SimpleNamespace(
+            kernel32=types.SimpleNamespace(
+                GetSystemDirectoryW=fake_get_system_directory
+            )
+        )
+        # ctypes.windll only exists on Windows, so inject it (raising=False).
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        session_cwd = tmp_path / "session"
+        session_cwd.mkdir()
+        (session_cwd / "nvidia-smi.exe").write_text("attacker")
+        monkeypatch.chdir(session_cwd)
+
+        # Absent from the system dir -> None, never the cwd copy.
+        assert call_aerender._resolve_nvidia_smi() is None
+
+        # Present in the system dir -> that absolute path.
+        real = sysdir / "nvidia-smi.exe"
+        real.write_text("driver tool")
+        assert call_aerender._resolve_nvidia_smi() == str(real)
+
+    def test_windows_returns_none_on_truncation(self, monkeypatch, tmp_path):
+        # GetSystemDirectoryW returns the *required* size (>= buffer) and leaves the
+        # buffer unfilled when the path is too long; that must be rejected, not treated
+        # as an empty (relative, cwd-resolved) path.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+
+        def truncating_get_system_directory(_buf, size):
+            return size + 1  # required length exceeds the buffer; buffer untouched
+
+        fake_windll = types.SimpleNamespace(
+            kernel32=types.SimpleNamespace(
+                GetSystemDirectoryW=truncating_get_system_directory
+            )
+        )
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        session_cwd = tmp_path / "session"
+        session_cwd.mkdir()
+        (session_cwd / "nvidia-smi.exe").write_text("attacker")
+        monkeypatch.chdir(session_cwd)
+
+        assert call_aerender._resolve_nvidia_smi() is None
+
+    def test_windows_returns_none_when_probe_raises(self, monkeypatch):
+        # A raising GetSystemDirectoryW (embedded/frozen interpreter, odd ctypes
+        # state) must resolve to None, not escape -- decode_failure_hint runs before
+        # emit_fail and outside the render try/finally, so a raise would swallow the
+        # openjd_fail line this feature exists to emit.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+
+        def raising_get_system_directory(_buf, _size):
+            raise OSError("boom")
+
+        fake_windll = types.SimpleNamespace(
+            kernel32=types.SimpleNamespace(
+                GetSystemDirectoryW=raising_get_system_directory
+            )
+        )
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        assert call_aerender._resolve_nvidia_smi() is None
+
+
+class TestDecodeFailureHint:
+    SOURCE_ADVICE = "confirm every source file"
+
+    def test_hint_on_windows_without_gpu(self, monkeypatch):
+        # Windows + no NVIDIA GPU: source-path advice AND the HEVC/GPU-fleet clause.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        hint = call_aerender.decode_failure_hint(True)
+        assert self.SOURCE_ADVICE in hint
+        assert "HEVC" in hint and "GPU-enabled fleet" in hint and "H.264" in hint
+
+    def test_source_advice_but_no_codec_clause_when_gpu_present(self, monkeypatch):
+        # GPU present but source still unreadable -> the HEVC-decode theory doesn't
+        # hold, so keep the universal source-path advice but drop the GPU-fleet clause.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: True)
+        hint = call_aerender.decode_failure_hint(True)
+        assert self.SOURCE_ADVICE in hint
+        assert "HEVC" not in hint
+
+    def test_no_hint_when_no_read_source_error(self, monkeypatch):
+        # No source-read failure was seen -> no hint, and no GPU probe.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        probed = []
+        monkeypatch.setattr(
+            call_aerender, "worker_has_nvidia_gpu", lambda: probed.append(True)
+        )
+        assert call_aerender.decode_failure_hint(False) == ""
+        assert probed == []  # short-circuited before the GPU probe
+
+    def test_source_advice_off_windows_without_probe(self, monkeypatch):
+        # macOS/Linux: the source-path advice still applies (a missing/unresolvable
+        # path is platform-independent), but the NVIDIA-decoder theory does not, so we
+        # emit no codec clause and never probe.
+        monkeypatch.setattr(call_aerender.sys, "platform", "darwin")
+        probed = []
+        monkeypatch.setattr(
+            call_aerender, "worker_has_nvidia_gpu", lambda: probed.append(True)
+        )
+        hint = call_aerender.decode_failure_hint(True)
+        assert self.SOURCE_ADVICE in hint
+        assert "HEVC" not in hint
+        assert probed == []
 
 
 class TestProgressFramePattern:
@@ -342,6 +563,128 @@ class TestEndToEnd:
         assert rc == 1
         assert 100 not in progress
         assert any("error" in f.lower() for f in fail)
+
+    def test_read_source_error_adds_gpu_hint_when_no_gpu(self, run_render, monkeypatch):
+        # "Could not read from source" on a GPU-less Windows worker must fail AND
+        # enrich the failure message with the HEVC/GPU-fleet remediation.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="read_source_error", exit_code=0
+        )
+        assert rc == 1
+        assert 100 not in progress
+        assert fail and any(
+            "HEVC" in f and "GPU-enabled fleet" in f for f in fail
+        ), fail
+
+    def test_read_source_error_gpu_present_keeps_source_advice_only(
+        self, run_render, monkeypatch
+    ):
+        # Same error on a GPU worker: still fails and still gets the universal
+        # source-path advice, but no misleading GPU-fleet/HEVC clause.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: True)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="read_source_error", exit_code=0
+        )
+        assert rc == 1
+        assert fail and any("confirm every source file" in f for f in fail), fail
+        assert not any("HEVC" in f for f in fail), fail
+
+    def test_hint_latches_when_read_source_error_not_first(
+        self, run_render, monkeypatch
+    ):
+        # An unrelated AE error precedes the source-read line. The hint must still
+        # attach, because detection latches on ANY matching line (not just the first
+        # captured error).
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="error_then_read_source", exit_code=0
+        )
+        assert rc == 1
+        assert fail and any("HEVC" in f for f in fail), fail
+        # The hint's advice must stay tied to the source-read line that justifies it,
+        # even though the reported error is the unrelated strong error preceding it.
+        assert any(
+            "Also saw" in f and "Could not read from source" in f for f in fail
+        ), fail
+
+    def test_hint_latches_when_read_source_error_not_first_nonzero_exit(
+        self, run_render, monkeypatch
+    ):
+        # Nonzero-exit twin of the case above: an unrelated strong error is the
+        # reported reason, but the source-read line still justifies the hint and must
+        # be surfaced -- and the exit code must be kept, not replaced by the log line.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="error_then_read_source", exit_code=1
+        )
+        assert rc == 1
+        assert fail and any("HEVC" in f for f in fail), fail
+        assert any(
+            "Also saw" in f and "Could not read from source" in f for f in fail
+        ), fail
+        assert any("exited with code 1" in f for f in fail), fail
+
+    def test_bare_read_source_error_fails_on_exit_0(self, run_render, monkeypatch):
+        # AE logs "Could not read from source" WITHOUT an AE-/aerender- prefix and
+        # exits 0. STRONG_ERROR_PATTERNS misses it, so only the source-read latch can
+        # fail it -- otherwise silent bad output (missing/black frames marked success).
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="bare_read_source_error", exit_code=0
+        )
+        assert rc == 1
+        assert fail and any(
+            "confirm every source file" in f and "HEVC" in f for f in fail
+        ), fail
+
+    def test_bare_read_source_error_nonzero_exit_uses_source_line(
+        self, run_render, monkeypatch
+    ):
+        # Nonzero exit + only the bare spelling (no strong-error prefix): the failure
+        # reason must be the actual source-read line (incl. its AE error code), not the
+        # generic "aerender exited with code N".
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="bare_read_source_error", exit_code=1
+        )
+        assert rc == 1
+        assert fail and any("Could not read from source" in f for f in fail), fail
+        # Keep the authoritative exit code alongside the source line (retry vs resubmit).
+        assert any("exited with code 1" in f for f in fail), fail
+
+    def test_full_render_then_read_source_still_fails(self, run_render, monkeypatch):
+        # AE renders every frame (progress reaches 100%) and only afterwards logs the bare
+        # source-read failure. Progress is emitted before the verdict is known, so 100% is
+        # reported -- but the task must still FAIL, which is what stops black frames from
+        # shipping as success. Pins the real ordering, not a stub that emits no frames.
+        monkeypatch.setattr(call_aerender.sys, "platform", "win32")
+        monkeypatch.setattr(call_aerender, "worker_has_nvidia_gpu", lambda: False)
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="full_render_then_read_source", exit_code=0
+        )
+        assert rc == 1
+        assert progress[-1] == 100  # 100% is reported...
+        assert fail and any(
+            "Could not read from source" in f for f in fail
+        ), fail  # ...yet the task fails
+
+    def test_benign_source_read_name_does_not_fail(self, run_render):
+        # A footage name literally containing "could not read from source" -- no AE prefix,
+        # no error code -- must not fail a healthy render (mirrors the benign_error test).
+        # The bare phrase alone is not enough to trip the verdict.
+        rc, progress, status, fail, _ = run_render(
+            frames="0-9", mode="benign_source_read_name", exit_code=0
+        )
+        assert rc == 0
+        assert fail == []
+        assert progress[-1] == 100
 
     def test_benign_error_lines_do_not_fail(self, run_render):
         rc, progress, status, fail, _ = run_render(


### PR DESCRIPTION
## What

When aerender reports **"Could not read from source"**, fail the task and append a remediation hint to the failure message. The error is generic, so the hint always leads with a source-path check (every platform): confirm each source file exists and its path resolves on the worker. On a **Windows** worker with **no NVIDIA GPU** it additionally appends a codec cause — a source may use a codec (e.g. HEVC/H.265) that needs a GPU hardware decoder, in which case run on a GPU-enabled fleet or transcode to H.264.

This closes a silent-bad-output gap: AE can log the source-read failure **bare** (no `After Effects error:` / `aerender ERROR:` prefix) and still exit 0, so it slipped past `STRONG_ERROR_PATTERNS` and the render was marked successful with missing/black frames. The source-read pattern is specific and low-false-positive, so it now drives the verdict (fail even on exit 0), not just the message.

Addresses the frequent "Could not read from source" reports whose underlying cause is HEVC footage on a CPU-only Windows fleet (After Effects has no software HEVC decoder there).

## How

- `decode_failure_hint(saw_read_source_error)` — when a source-read failure was seen, always returns the universal source-path advice; only on `win32` **and** when no NVIDIA GPU is detected does it append the HEVC/GPU-fleet clause (the only branch that probes for a GPU). Returns `""` when no source-read failure occurred.
- `worker_has_nvidia_gpu()` — probes `nvidia-smi -L` (5s timeout); any failure counts as "no GPU". Necessary-not-sufficient (Windows AE can also decode via Intel Quick Sync), so the hint is worded loosely.
- `_resolve_nvidia_smi()` — Windows-only. Resolves the system directory through the OS (`GetSystemDirectoryW`), never PATH / `%SystemRoot%` / cwd — all job-controllable, so any of them could run a `nvidia-smi.exe` dropped among a job's attachments. Rejects a zero or truncated result, and wraps the whole probe in `try/except → None` so any failure means "no GPU" — keeping `decode_failure_hint` total (it runs before `emit_fail` and outside the render `try/finally`, so a raising probe would otherwise swallow the `openjd_fail` line). Returns `None` off Windows.
- `saw_read_source_error` is latched in the read loop on **any** line matching the source-read pattern; the exit-0 failure branch keys on `strong_error_line is not None or saw_read_source_error`, using the first captured source-read line as the reason when no strong error preceded it. The latch also drives the hint, so it survives even when an earlier unrelated error is the first captured one.

## Testing

**Unit tests (`test/unit/test_call_aerender.py`) — 91 passed.**
- `TestWorkerHasNvidiaGpu` — GPU listed / none listed / unresolved (no subprocess launched) / launch fails / timeout / non-zero exit.
- `TestResolveNvidiaSmi` — off-Windows returns `None`; on Windows resolves under the OS-reported system dir and never the cwd copy (attacker `nvidia-smi.exe` planted in cwd is ignored); a truncated `GetSystemDirectoryW` result returns `None` (not a relative, cwd-resolved path); a raising `GetSystemDirectoryW` returns `None` (probe can't escape).
- `TestDecodeFailureHint` — Windows + no GPU → source advice **and** HEVC/GPU-fleet clause; GPU present → source advice only, no codec clause; no source-read error → `""` and no probe; off Windows → source advice only, no probe.
- End-to-end via fake-aerender modes: `read_source_error` (prefixed) → rc=1 + full hint on GPU-less Windows, rc=1 + source-advice-only with a GPU; `bare_read_source_error` (unprefixed, exit 0) → rc=1 + full hint, proving the bare spelling fails instead of shipping silent bad output; `error_then_read_source` → hint still attaches when the source-read line is not the first error.

**Sample `openjd_fail` messages** (from the fake aerender stub, which prints the AE error and exits 0 as real workers do):

Windows, no GPU — source advice + codec clause:
```
openjd_fail: aerender reported an error: aerender Error: After Effects error: Could not read from source. Please check the settings and try again. aerender could not read a source clip. First confirm every source file exists and its path resolves on this worker. If the sources are fine, a likely cause is a codec that needs a GPU hardware decoder -- e.g. HEVC/H.265 -- since no NVIDIA GPU was detected on this worker; render on a GPU-enabled fleet or transcode the source(s) to H.264 before submitting.
```

GPU present, or off Windows — source advice only:
```
openjd_fail: aerender reported an error: aerender Error: After Effects error: Could not read from source. Please check the settings and try again. aerender could not read a source clip. First confirm every source file exists and its path resolves on this worker.
```

This was validated end-to-end on real Windows fleets with the patched script: on a CPU-only fleet the HEVC render fails and the `openjd_fail` message carries the full hint (source-path advice **and** the codec/GPU-fleet clause, with `GetSystemDirectoryW`-based detection correctly reporting no NVIDIA GPU); on a T4 GPU fleet the same source succeeds with no hint emitted. An H.264 transcode succeeds on either.
